### PR TITLE
use textarea for bug repros

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -20,7 +20,7 @@ body:
           description: Provide a clear and concise description of the desired fix.
       validations:
           required: true
-    - type: input
+    - type: textarea
       attributes:
           label: To Reproduce
           description: If you have written tests to showcase the bug, what can we run to reproduce the issue?


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?
The old bug submission template had a small space for adding any commands to reproduce the bug. This makes it a larger text area.

## Description of changes