### PR TITLE
Fix `v4-core` submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/marktoda/forge-gas-snapshot
 [submodule "lib/v4-core"]
 	path = lib/v4-core
-	url = git@github.com:Uniswap/v4-core.git
+	url = https://github.com/Uniswap/v4-core


### PR DESCRIPTION
## Related Issue
Fixes #25 

## Description of changes
Replace url in `.gitmodules` from `git@github.com:Uniswap/v4-core.git` to `https://github.com/Uniswap/v4-core`