### PR TITLE
Fix `TWAMM.claimTokens`

### DIFF
--- a/contracts/hooks/examples/TWAMM.sol
+++ b/contracts/hooks/examples/TWAMM.sol
@@ -332,13 +332,6 @@ contract TWAMM is BaseHook, ITWAMM {
         return twammStates[keccak256(abi.encode(key))];
     }
 
-    struct OrderParams {
-        address owner;
-        bool zeroForOne;
-        uint256 amountIn;
-        uint160 expiration;
-    }
-
     struct PoolParamsOnExecute {
         uint160 sqrtPriceX96;
         uint128 liquidity;

--- a/contracts/hooks/examples/TWAMM.sol
+++ b/contracts/hooks/examples/TWAMM.sol
@@ -298,6 +298,7 @@ contract TWAMM is BaseHook, ITWAMM {
         amountTransferred = tokensOwed[token][msg.sender];
         if (amountRequested != 0 && amountRequested < amountTransferred) amountTransferred = amountRequested;
         if (currentBalance < amountTransferred) amountTransferred = currentBalance; // to catch precision errors
+        tokensOwed[token][msg.sender] -= amountTransferred;
         IERC20Minimal(Currency.unwrap(token)).safeTransfer(to, amountTransferred);
     }
 

--- a/test/TWAMM.t.sol
+++ b/test/TWAMM.t.sol
@@ -392,6 +392,9 @@ contract TWAMMTest is Test, Deployers, GasSnapshot {
         twamm.claimTokens(poolKey.currency0, address(this), 0);
         twamm.claimTokens(poolKey.currency1, address(this), 0);
 
+        assertEq(twamm.tokensOwed(poolKey.currency0, address(this)), 0);
+        assertEq(twamm.tokensOwed(poolKey.currency1, address(this)), 0);
+
         uint256 balance0AfterTWAMM = TestERC20(Currency.unwrap(poolKey.currency0)).balanceOf(address(twamm));
         uint256 balance1AfterTWAMM = TestERC20(Currency.unwrap(poolKey.currency1)).balanceOf(address(twamm));
         uint256 balance0AfterThis = poolKey.currency0.balanceOfSelf();


### PR DESCRIPTION
## Description of changes
- fix missed accounting in `claimTokens`
- remove unused `TWAMM.OrderParams` struct, which seems duplicated with `ITWAMM.OrderKey`