### PR TITLE
Accept new params for hooks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/marktoda/forge-gas-snapshot
 [submodule "lib/v4-core"]
 	path = lib/v4-core
-	url = git@github.com:Uniswap/v4-core.git
+	url = https://github.com/uniswap/v4-core

--- a/contracts/BaseHook.sol
+++ b/contracts/BaseHook.sol
@@ -64,7 +64,11 @@ abstract contract BaseHook is IHooks {
         revert HookNotImplemented();
     }
 
-    function afterInitialize(address, PoolKey calldata, uint160, int24, bytes calldata) external virtual returns (bytes4) {
+    function afterInitialize(address, PoolKey calldata, uint160, int24, bytes calldata)
+        external
+        virtual
+        returns (bytes4)
+    {
         revert HookNotImplemented();
     }
 
@@ -76,11 +80,13 @@ abstract contract BaseHook is IHooks {
         revert HookNotImplemented();
     }
 
-    function afterModifyPosition(address, PoolKey calldata, IPoolManager.ModifyPositionParams calldata, BalanceDelta, bytes calldata)
-        external
-        virtual
-        returns (bytes4)
-    {
+    function afterModifyPosition(
+        address,
+        PoolKey calldata,
+        IPoolManager.ModifyPositionParams calldata,
+        BalanceDelta,
+        bytes calldata
+    ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
@@ -100,11 +106,19 @@ abstract contract BaseHook is IHooks {
         revert HookNotImplemented();
     }
 
-    function beforeDonate(address, PoolKey calldata, uint256, uint256, bytes calldata) external virtual returns (bytes4) {
+    function beforeDonate(address, PoolKey calldata, uint256, uint256, bytes calldata)
+        external
+        virtual
+        returns (bytes4)
+    {
         revert HookNotImplemented();
     }
 
-    function afterDonate(address, PoolKey calldata, uint256, uint256, bytes calldata) external virtual returns (bytes4) {
+    function afterDonate(address, PoolKey calldata, uint256, uint256, bytes calldata)
+        external
+        virtual
+        returns (bytes4)
+    {
         revert HookNotImplemented();
     }
 }

--- a/contracts/BaseHook.sol
+++ b/contracts/BaseHook.sol
@@ -60,15 +60,15 @@ abstract contract BaseHook is IHooks {
         }
     }
 
-    function beforeInitialize(address, PoolKey calldata, uint160) external virtual returns (bytes4) {
+    function beforeInitialize(address, PoolKey calldata, uint160, bytes calldata) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
-    function afterInitialize(address, PoolKey calldata, uint160, int24) external virtual returns (bytes4) {
+    function afterInitialize(address, PoolKey calldata, uint160, int24, bytes calldata) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
-    function beforeModifyPosition(address, PoolKey calldata, IPoolManager.ModifyPositionParams calldata)
+    function beforeModifyPosition(address, PoolKey calldata, IPoolManager.ModifyPositionParams calldata, bytes calldata)
         external
         virtual
         returns (bytes4)
@@ -76,7 +76,7 @@ abstract contract BaseHook is IHooks {
         revert HookNotImplemented();
     }
 
-    function afterModifyPosition(address, PoolKey calldata, IPoolManager.ModifyPositionParams calldata, BalanceDelta)
+    function afterModifyPosition(address, PoolKey calldata, IPoolManager.ModifyPositionParams calldata, BalanceDelta, bytes calldata)
         external
         virtual
         returns (bytes4)
@@ -84,7 +84,7 @@ abstract contract BaseHook is IHooks {
         revert HookNotImplemented();
     }
 
-    function beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata)
+    function beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
         external
         virtual
         returns (bytes4)
@@ -92,7 +92,7 @@ abstract contract BaseHook is IHooks {
         revert HookNotImplemented();
     }
 
-    function afterSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, BalanceDelta)
+    function afterSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
         external
         virtual
         returns (bytes4)
@@ -100,11 +100,11 @@ abstract contract BaseHook is IHooks {
         revert HookNotImplemented();
     }
 
-    function beforeDonate(address, PoolKey calldata, uint256, uint256) external virtual returns (bytes4) {
+    function beforeDonate(address, PoolKey calldata, uint256, uint256, bytes calldata) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
-    function afterDonate(address, PoolKey calldata, uint256, uint256) external virtual returns (bytes4) {
+    function afterDonate(address, PoolKey calldata, uint256, uint256, bytes calldata) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 }

--- a/contracts/hooks/examples/GeomeanOracle.sol
+++ b/contracts/hooks/examples/GeomeanOracle.sol
@@ -110,12 +110,12 @@ contract GeomeanOracle is BaseHook {
         );
     }
 
-    function beforeModifyPosition(address, PoolKey calldata key, IPoolManager.ModifyPositionParams calldata params, bytes calldata)
-        external
-        override
-        poolManagerOnly
-        returns (bytes4)
-    {
+    function beforeModifyPosition(
+        address,
+        PoolKey calldata key,
+        IPoolManager.ModifyPositionParams calldata params,
+        bytes calldata
+    ) external override poolManagerOnly returns (bytes4) {
         if (params.liquidityDelta < 0) revert OraclePoolMustLockLiquidity();
         int24 maxTickSpacing = poolManager.MAX_TICK_SPACING();
         if (

--- a/contracts/hooks/examples/GeomeanOracle.sol
+++ b/contracts/hooks/examples/GeomeanOracle.sol
@@ -73,7 +73,7 @@ contract GeomeanOracle is BaseHook {
         });
     }
 
-    function beforeInitialize(address, PoolKey calldata key, uint160)
+    function beforeInitialize(address, PoolKey calldata key, uint160, bytes calldata)
         external
         view
         override
@@ -87,7 +87,7 @@ contract GeomeanOracle is BaseHook {
         return GeomeanOracle.beforeInitialize.selector;
     }
 
-    function afterInitialize(address, PoolKey calldata key, uint160, int24)
+    function afterInitialize(address, PoolKey calldata key, uint160, int24, bytes calldata)
         external
         override
         poolManagerOnly
@@ -110,7 +110,7 @@ contract GeomeanOracle is BaseHook {
         );
     }
 
-    function beforeModifyPosition(address, PoolKey calldata key, IPoolManager.ModifyPositionParams calldata params)
+    function beforeModifyPosition(address, PoolKey calldata key, IPoolManager.ModifyPositionParams calldata params, bytes calldata)
         external
         override
         poolManagerOnly
@@ -126,7 +126,7 @@ contract GeomeanOracle is BaseHook {
         return GeomeanOracle.beforeModifyPosition.selector;
     }
 
-    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata)
+    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
         external
         override
         poolManagerOnly

--- a/contracts/hooks/examples/LimitOrder.sol
+++ b/contracts/hooks/examples/LimitOrder.sol
@@ -114,7 +114,7 @@ contract LimitOrder is BaseHook {
         return compressed * tickSpacing;
     }
 
-    function afterInitialize(address, PoolKey calldata key, uint160, int24 tick)
+    function afterInitialize(address, PoolKey calldata key, uint160, int24 tick, bytes calldata)
         external
         override
         poolManagerOnly
@@ -124,7 +124,7 @@ contract LimitOrder is BaseHook {
         return LimitOrder.afterInitialize.selector;
     }
 
-    function afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params, BalanceDelta)
+    function afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params, BalanceDelta, bytes calldata)
         external
         override
         poolManagerOnly
@@ -193,7 +193,8 @@ contract LimitOrder is BaseHook {
                 tickLower: tickLower,
                 tickUpper: tickLower + key.tickSpacing,
                 liquidityDelta: liquidityDelta
-            })
+            }),
+            bytes("")
         );
 
         if (delta.amount0() < 0) poolManager.mint(key.currency0, address(this), amount0 = uint128(-delta.amount0()));
@@ -248,7 +249,8 @@ contract LimitOrder is BaseHook {
                 tickLower: tickLower,
                 tickUpper: tickLower + key.tickSpacing,
                 liquidityDelta: liquidityDelta
-            })
+            }),
+            bytes("")
         );
 
         if (delta.amount0() > 0) {
@@ -320,7 +322,7 @@ contract LimitOrder is BaseHook {
         // to prevent this, we allocate all fee revenue to remaining limit order placers, unless this is the last order.
         if (!removingAllLiquidity) {
             BalanceDelta deltaFee = poolManager.modifyPosition(
-                key, IPoolManager.ModifyPositionParams({tickLower: tickLower, tickUpper: tickUpper, liquidityDelta: 0})
+                key, IPoolManager.ModifyPositionParams({tickLower: tickLower, tickUpper: tickUpper, liquidityDelta: 0}), bytes("")
             );
 
             if (deltaFee.amount0() < 0) {
@@ -337,7 +339,8 @@ contract LimitOrder is BaseHook {
                 tickLower: tickLower,
                 tickUpper: tickUpper,
                 liquidityDelta: liquidityDelta
-            })
+            }),
+            bytes("")
         );
 
         if (delta.amount0() < 0) poolManager.take(key.currency0, to, amount0 = uint128(-delta.amount0()));

--- a/contracts/hooks/examples/TWAMM.sol
+++ b/contracts/hooks/examples/TWAMM.sol
@@ -83,12 +83,12 @@ contract TWAMM is BaseHook, ITWAMM {
         return BaseHook.beforeInitialize.selector;
     }
 
-    function beforeModifyPosition(address, PoolKey calldata key, IPoolManager.ModifyPositionParams calldata, bytes calldata)
-        external
-        override
-        poolManagerOnly
-        returns (bytes4)
-    {
+    function beforeModifyPosition(
+        address,
+        PoolKey calldata key,
+        IPoolManager.ModifyPositionParams calldata,
+        bytes calldata
+    ) external override poolManagerOnly returns (bytes4) {
         executeTWAMMOrders(key);
         return BaseHook.beforeModifyPosition.selector;
     }

--- a/contracts/hooks/examples/TWAMM.sol
+++ b/contracts/hooks/examples/TWAMM.sol
@@ -71,7 +71,7 @@ contract TWAMM is BaseHook, ITWAMM {
         });
     }
 
-    function beforeInitialize(address, PoolKey calldata key, uint160)
+    function beforeInitialize(address, PoolKey calldata key, uint160, bytes calldata)
         external
         virtual
         override
@@ -83,7 +83,7 @@ contract TWAMM is BaseHook, ITWAMM {
         return BaseHook.beforeInitialize.selector;
     }
 
-    function beforeModifyPosition(address, PoolKey calldata key, IPoolManager.ModifyPositionParams calldata)
+    function beforeModifyPosition(address, PoolKey calldata key, IPoolManager.ModifyPositionParams calldata, bytes calldata)
         external
         override
         poolManagerOnly
@@ -93,7 +93,7 @@ contract TWAMM is BaseHook, ITWAMM {
         return BaseHook.beforeModifyPosition.selector;
     }
 
-    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata)
+    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
         external
         override
         poolManagerOnly
@@ -304,7 +304,7 @@ contract TWAMM is BaseHook, ITWAMM {
         (PoolKey memory key, IPoolManager.SwapParams memory swapParams) =
             abi.decode(rawData, (PoolKey, IPoolManager.SwapParams));
 
-        BalanceDelta delta = poolManager.swap(key, swapParams);
+        BalanceDelta delta = poolManager.swap(key, swapParams, bytes(""));
 
         if (swapParams.zeroForOne) {
             if (delta.amount0() > 0) {

--- a/contracts/hooks/examples/VolatilityOracle.sol
+++ b/contracts/hooks/examples/VolatilityOracle.sol
@@ -15,7 +15,11 @@ contract VolatilityOracle is BaseHook, IDynamicFeeManager {
 
     uint32 deployTimestamp;
 
-    function getFee(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata) external view returns (uint24) {
+    function getFee(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
+        external
+        view
+        returns (uint24)
+    {
         uint24 startingFee = 3000;
         uint32 lapsed = _blockTimestamp() - deployTimestamp;
         return startingFee + (uint24(lapsed) * 100) / 60; // 100 bps a minute
@@ -43,7 +47,12 @@ contract VolatilityOracle is BaseHook, IDynamicFeeManager {
         });
     }
 
-    function beforeInitialize(address, PoolKey calldata key, uint160, bytes calldata) external pure override returns (bytes4) {
+    function beforeInitialize(address, PoolKey calldata key, uint160, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
         if (!key.fee.isDynamicFee()) revert MustUseDynamicFee();
         return VolatilityOracle.beforeInitialize.selector;
     }

--- a/contracts/hooks/examples/VolatilityOracle.sol
+++ b/contracts/hooks/examples/VolatilityOracle.sol
@@ -15,7 +15,7 @@ contract VolatilityOracle is BaseHook, IDynamicFeeManager {
 
     uint32 deployTimestamp;
 
-    function getFee(PoolKey calldata) external view returns (uint24) {
+    function getFee(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata) external view returns (uint24) {
         uint24 startingFee = 3000;
         uint32 lapsed = _blockTimestamp() - deployTimestamp;
         return startingFee + (uint24(lapsed) * 100) / 60; // 100 bps a minute
@@ -43,7 +43,7 @@ contract VolatilityOracle is BaseHook, IDynamicFeeManager {
         });
     }
 
-    function beforeInitialize(address, PoolKey calldata key, uint160) external pure override returns (bytes4) {
+    function beforeInitialize(address, PoolKey calldata key, uint160, bytes calldata) external pure override returns (bytes4) {
         if (!key.fee.isDynamicFee()) revert MustUseDynamicFee();
         return VolatilityOracle.beforeInitialize.selector;
     }

--- a/test/GeomeanOracle.t.sol
+++ b/test/GeomeanOracle.t.sol
@@ -69,14 +69,15 @@ contract TestGeomeanOracle is Test, Deployers {
     }
 
     function testBeforeInitializeAllowsPoolCreation() public {
-        manager.initialize(key, SQRT_RATIO_1_1);
+        manager.initialize(key, SQRT_RATIO_1_1, bytes(""));
     }
 
     function testBeforeInitializeRevertsIfFee() public {
         vm.expectRevert(GeomeanOracle.OnlyOneOraclePoolAllowed.selector);
         manager.initialize(
             PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 1, MAX_TICK_SPACING, geomeanOracle),
-            SQRT_RATIO_1_1
+            SQRT_RATIO_1_1,
+            bytes("")
         );
     }
 
@@ -84,12 +85,13 @@ contract TestGeomeanOracle is Test, Deployers {
         vm.expectRevert(GeomeanOracle.OnlyOneOraclePoolAllowed.selector);
         manager.initialize(
             PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 0, 60, geomeanOracle),
-            SQRT_RATIO_1_1
+            SQRT_RATIO_1_1,
+            bytes("")
         );
     }
 
     function testAfterInitializeState() public {
-        manager.initialize(key, SQRT_RATIO_2_1);
+        manager.initialize(key, SQRT_RATIO_2_1, bytes(""));
         GeomeanOracle.ObservationState memory observationState = geomeanOracle.getState(key);
         assertEq(observationState.index, 0);
         assertEq(observationState.cardinality, 1);
@@ -97,7 +99,7 @@ contract TestGeomeanOracle is Test, Deployers {
     }
 
     function testAfterInitializeObservation() public {
-        manager.initialize(key, SQRT_RATIO_2_1);
+        manager.initialize(key, SQRT_RATIO_2_1, bytes(""));
         Oracle.Observation memory observation = geomeanOracle.getObservation(key, 0);
         assertTrue(observation.initialized);
         assertEq(observation.blockTimestamp, 1);
@@ -106,7 +108,7 @@ contract TestGeomeanOracle is Test, Deployers {
     }
 
     function testAfterInitializeObserve0() public {
-        manager.initialize(key, SQRT_RATIO_2_1);
+        manager.initialize(key, SQRT_RATIO_2_1, bytes(""));
         uint32[] memory secondsAgo = new uint32[](1);
         secondsAgo[0] = 0;
         (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s) =
@@ -118,7 +120,7 @@ contract TestGeomeanOracle is Test, Deployers {
     }
 
     function testBeforeModifyPositionNoObservations() public {
-        manager.initialize(key, SQRT_RATIO_2_1);
+        manager.initialize(key, SQRT_RATIO_2_1, bytes(""));
         modifyPositionRouter.modifyPosition(
             key,
             IPoolManager.ModifyPositionParams(
@@ -139,7 +141,7 @@ contract TestGeomeanOracle is Test, Deployers {
     }
 
     function testBeforeModifyPositionObservation() public {
-        manager.initialize(key, SQRT_RATIO_2_1);
+        manager.initialize(key, SQRT_RATIO_2_1, bytes(""));
         geomeanOracle.setTime(3); // advance 2 seconds
         modifyPositionRouter.modifyPosition(
             key,
@@ -161,7 +163,7 @@ contract TestGeomeanOracle is Test, Deployers {
     }
 
     function testBeforeModifyPositionObservationAndCardinality() public {
-        manager.initialize(key, SQRT_RATIO_2_1);
+        manager.initialize(key, SQRT_RATIO_2_1, bytes(""));
         geomeanOracle.setTime(3); // advance 2 seconds
         geomeanOracle.increaseCardinalityNext(key, 2);
         GeomeanOracle.ObservationState memory observationState = geomeanOracle.getState(key);

--- a/test/LimitOrder.t.sol
+++ b/test/LimitOrder.t.sol
@@ -49,7 +49,7 @@ contract TestLimitOrder is Test, Deployers {
 
         key = PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, limitOrder);
         id = key.toId();
-        manager.initialize(key, SQRT_RATIO_1_1);
+        manager.initialize(key, SQRT_RATIO_1_1, bytes(""));
 
         swapRouter = new PoolSwapTest(manager);
 
@@ -66,7 +66,7 @@ contract TestLimitOrder is Test, Deployers {
     function testGetTickLowerLastWithDifferentPrice() public {
         PoolKey memory differentKey =
             PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 61, limitOrder);
-        manager.initialize(differentKey, SQRT_RATIO_10_1);
+        manager.initialize(differentKey, SQRT_RATIO_10_1, bytes(""));
         assertEq(limitOrder.getTickLowerLast(differentKey.toId()), 22997);
     }
 
@@ -159,8 +159,8 @@ contract TestLimitOrder is Test, Deployers {
             uint128 liquidityTotal
         ) = limitOrder.epochInfos(Epoch.wrap(1));
         assertFalse(filled);
-        assertTrue(CurrencyLibrary.equals(currency0, Currency.wrap(address(token0))));
-        assertTrue(CurrencyLibrary.equals(currency1, Currency.wrap(address(token1))));
+        assertTrue(currency0 == Currency.wrap(address(token0)));
+        assertTrue(currency1 == Currency.wrap(address(token1)));
         assertEq(token0Total, 0);
         assertEq(token1Total, 0);
         assertEq(liquidityTotal, liquidity * 2);

--- a/test/TWAMM.t.sol
+++ b/test/TWAMM.t.sol
@@ -20,6 +20,7 @@ import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/types/Curren
 import {TWAMM} from "../contracts/hooks/examples/TWAMM.sol";
 import {ITWAMM} from "../contracts/interfaces/ITWAMM.sol";
 import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
+import {MockERC20} from "@uniswap/v4-core/test/foundry-tests/utils/MockERC20.sol";
 
 contract TWAMMTest is Test, Deployers, GasSnapshot {
     using PoolIdLibrary for PoolKey;
@@ -79,7 +80,7 @@ contract TWAMMTest is Test, Deployers, GasSnapshot {
 
         poolKey = PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, twamm);
         poolId = poolKey.toId();
-        manager.initialize(poolKey, SQRT_RATIO_1_1);
+        manager.initialize(poolKey, SQRT_RATIO_1_1, bytes(""));
 
         token0.approve(address(modifyPositionRouter), 100 ether);
         token1.approve(address(modifyPositionRouter), 100 ether);
@@ -96,7 +97,7 @@ contract TWAMMTest is Test, Deployers, GasSnapshot {
         (PoolKey memory initKey, PoolId initId) = newPoolKeyWithTWAMM(twamm);
         assertEq(twamm.lastVirtualOrderTimestamp(initId), 0);
         vm.warp(10000);
-        manager.initialize(initKey, SQRT_RATIO_1_1);
+        manager.initialize(initKey, SQRT_RATIO_1_1, bytes(""));
         assertEq(twamm.lastVirtualOrderTimestamp(initId), 10000);
     }
 
@@ -410,7 +411,7 @@ contract TWAMMTest is Test, Deployers, GasSnapshot {
     }
 
     function newPoolKeyWithTWAMM(IHooks hooks) public returns (PoolKey memory, PoolId) {
-        TestERC20[] memory tokens = deployTokens(2, 2 ** 255);
+        MockERC20[] memory tokens = deployTokens(2, 2 ** 255);
         PoolKey memory key = PoolKey(Currency.wrap(address(tokens[0])), Currency.wrap(address(tokens[1])), 0, 60, hooks);
         return (key, key.toId());
     }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/Uniswap/v4-periphery/issues/51

## Description of changes
Updates hooks to accept new parameters added in v4-core. Also fixes other compilation errors:
- `CurrencyLibrary.equals` replaced with `==`
- `LimitOrder.afterSwap` stack too deep

Tests currently failing due to unrelated issues