### PR TITLE
Rename hook errors to be more descriptive

### DIFF
--- a/contracts/BaseHook.sol
+++ b/contracts/BaseHook.sol
@@ -12,7 +12,14 @@ abstract contract BaseHook is IHooks {
     error NotSelf();
     error InvalidPool();
     error LockFailure();
-    error HookNotImplemented();
+    error BeforeInitializeHookNotImplemented();
+    error AfterInitializeHookNotImplemented();
+    error BeforeModifyPositionHookNotImplemented();
+    error AfterModifyPositionHookNotImplemented();
+    error BeforeSwapHookNotImplemented();
+    error AfterSwapHookNotImplemented();
+    error BeforeDonateHookNotImplemented();
+    error AfterDonateHookNotImplemented();
 
     /// @notice The address of the pool manager
     IPoolManager public immutable poolManager;
@@ -61,7 +68,7 @@ abstract contract BaseHook is IHooks {
     }
 
     function beforeInitialize(address, PoolKey calldata, uint160, bytes calldata) external virtual returns (bytes4) {
-        revert HookNotImplemented();
+        revert BeforeInitializeHookNotImplemented();
     }
 
     function afterInitialize(address, PoolKey calldata, uint160, int24, bytes calldata)
@@ -69,7 +76,7 @@ abstract contract BaseHook is IHooks {
         virtual
         returns (bytes4)
     {
-        revert HookNotImplemented();
+        revert AfterInitializeHookNotImplemented();
     }
 
     function beforeModifyPosition(address, PoolKey calldata, IPoolManager.ModifyPositionParams calldata, bytes calldata)
@@ -77,7 +84,7 @@ abstract contract BaseHook is IHooks {
         virtual
         returns (bytes4)
     {
-        revert HookNotImplemented();
+        revert BeforeModifyPositionHookNotImplemented();
     }
 
     function afterModifyPosition(
@@ -87,7 +94,7 @@ abstract contract BaseHook is IHooks {
         BalanceDelta,
         bytes calldata
     ) external virtual returns (bytes4) {
-        revert HookNotImplemented();
+        revert AfterModifyPositionHookNotImplemented();
     }
 
     function beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
@@ -95,7 +102,7 @@ abstract contract BaseHook is IHooks {
         virtual
         returns (bytes4)
     {
-        revert HookNotImplemented();
+        revert BeforeSwapHookNotImplemented();
     }
 
     function afterSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
@@ -103,7 +110,7 @@ abstract contract BaseHook is IHooks {
         virtual
         returns (bytes4)
     {
-        revert HookNotImplemented();
+        revert AfterSwapHookNotImplemented();
     }
 
     function beforeDonate(address, PoolKey calldata, uint256, uint256, bytes calldata)
@@ -111,7 +118,7 @@ abstract contract BaseHook is IHooks {
         virtual
         returns (bytes4)
     {
-        revert HookNotImplemented();
+        revert BeforeDonateHookNotImplemented();
     }
 
     function afterDonate(address, PoolKey calldata, uint256, uint256, bytes calldata)
@@ -119,6 +126,6 @@ abstract contract BaseHook is IHooks {
         virtual
         returns (bytes4)
     {
-        revert HookNotImplemented();
+        revert AfterDonateHookNotImplemented();
     }
 }


### PR DESCRIPTION
## Related Issue
Hi, I had a question but I'm wagering that this is easy in the interest of time/effort... so rather than creating a separate issue *and* PR, I'm including the question inline here alongside the PR.

I'm not wedded to the code so if it gets declined, no big deal.

Is there a compelling reason why `HookNotImplemented` is shared across the eight lifecycle events? I'm doing some light fuzzing work with @khegeman and having a single error made it a bit challenging to discover where our code was failing.

I found great use out of dedicated errors and I wanted to pass it along... but again, if this provides no value (or negative value), feel free to decline.

## Description of changes

This PR creates explicit errors for where execution of a hook is attempted despite it not being implemented.