### PR TITLE
Chore: update BaseHook.sol license

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,7 @@ contract CoolHook is BaseHook {
 
 ## License
 
-The license for Uniswap V4 Periphery is the GNU General Public License (GPL 2.0), see [LICENSE](https://github.com/Uniswap/periphery-next/blob/main/LICENSE).
+The primary license for Uniswap V4 Periphery is the GNU General Public License (GPL 2.0), see [LICENSE](https://github.com/Uniswap/periphery-next/blob/main/LICENSE). Minus the following exceptions:
+- [BaseHook.sol](/contracts/BaseHook.sol) has an MIT License
+
+This file states its license type.

--- a/contracts/BaseHook.sol
+++ b/contracts/BaseHook.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";


### PR DESCRIPTION
## Related Issue
`BaseHook.sol` will likely be a required import to any hook contracts or protocols that are built on top of v4. In talking to developers who are likely to build these types of contracts and protocols, the Uniswap Foundation has surfaced a common concern around the restrictions enforced by `BaseHook.sol`'s GPL license.

## Description of changes
This PR changes the SPDX License Identifier in `BaseHook.sol` to MIT. It also edits the **License** section of the README to note the new exceptions to the GPL that governs most of the repository.