### PR TITLE
change the v4-core submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/marktoda/forge-gas-snapshot
 [submodule "lib/v4-core"]
 	path = lib/v4-core
-	url = git@github.com:Uniswap/v4-core.git
+	url = https://github.com/Uniswap/v4-core
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate


### PR DESCRIPTION
## Related Issue
On running
`forge install https://github.com/Uniswap/periphery-next `

using the [git@github.com:Uniswap/v4-core.git](git@github.com:Uniswap/v4-core.git) URL, there is a fatal error.

![image](https://github.com/Uniswap/v4-periphery/assets/115455855/ba7a69d0-d7b9-4c5e-a876-a3bed950d13b)
## Description of changes
The issue is resolved when the URL is changed to the [remote repository link ](https://github.com/Uniswap/v4-core)of the v4-core contracts
