### PR TITLE
Allow integrators to override `PositionManager.transferFrom`

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -358,7 +358,7 @@ contract PositionManager is
     }
 
     /// @dev overrides solmate transferFrom in case a notification to subscribers is needed
-    function transferFrom(address from, address to, uint256 id) public override {
+    function transferFrom(address from, address to, uint256 id) public virtual override {
         super.transferFrom(from, to, id);
         if (positionConfigs.hasSubscriber(id)) _notifyTransfer(id, from, to);
     }


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?

## Description of changes
This PR makes the `PositionManager.transferFrom` method `virtual` so that integrators
who are extending `PositionManger` can override its functionality more easily.