### PR TITLE
:hammer: Fix unused imports and unnecessary using directives

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.8.24;
 
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
-import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
 import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
@@ -20,7 +19,7 @@ import {IPositionManager} from "./interfaces/IPositionManager.sol";
 import {Multicall_v4} from "./base/Multicall_v4.sol";
 import {PoolInitializer} from "./base/PoolInitializer.sol";
 import {DeltaResolver} from "./base/DeltaResolver.sol";
-import {PositionConfig, PositionConfigLibrary} from "./libraries/PositionConfig.sol";
+import {PositionConfig} from "./libraries/PositionConfig.sol";
 import {BaseActionsRouter} from "./base/BaseActionsRouter.sol";
 import {Actions} from "./libraries/Actions.sol";
 import {Notifier} from "./base/Notifier.sol";
@@ -28,7 +27,7 @@ import {CalldataDecoder} from "./libraries/CalldataDecoder.sol";
 import {INotifier} from "./interfaces/INotifier.sol";
 import {Permit2Forwarder} from "./base/Permit2Forwarder.sol";
 import {SlippageCheckLibrary} from "./libraries/SlippageCheck.sol";
-import {PositionConfigId, PositionConfigIdLibrary} from "./libraries/PositionConfigId.sol";
+import {PositionConfigId} from "./libraries/PositionConfigId.sol";
 
 //                                           444444444
 //                                444444444444      444444
@@ -108,16 +107,12 @@ contract PositionManager is
     Permit2Forwarder
 {
     using SafeTransferLib for *;
-    using CurrencyLibrary for Currency;
-    using PoolIdLibrary for PoolKey;
-    using PositionConfigLibrary for PositionConfig;
     using StateLibrary for IPoolManager;
     using TransientStateLibrary for IPoolManager;
     using SafeCast for uint256;
     using SafeCast for int256;
     using CalldataDecoder for bytes;
     using SlippageCheckLibrary for BalanceDelta;
-    using PositionConfigIdLibrary for PositionConfigId;
 
     /// @dev The ID of the next token that will be minted. Skips 0
     uint256 public nextTokenId = 1;

--- a/src/base/Notifier.sol
+++ b/src/base/Notifier.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {ISubscriber} from "../interfaces/ISubscriber.sol";
 import {PositionConfig} from "../libraries/PositionConfig.sol";
-import {PositionConfigId, PositionConfigIdLibrary} from "../libraries/PositionConfigId.sol";
+import {PositionConfigId} from "../libraries/PositionConfigId.sol";
 import {BipsLibrary} from "../libraries/BipsLibrary.sol";
 import {INotifier} from "../interfaces/INotifier.sol";
 import {CustomRevert} from "@uniswap/v4-core/src/libraries/CustomRevert.sol";
@@ -13,7 +13,6 @@ import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 abstract contract Notifier is INotifier {
     using BipsLibrary for uint256;
     using CustomRevert for bytes4;
-    using PositionConfigIdLibrary for PositionConfigId;
 
     error AlreadySubscribed(address subscriber);
 

--- a/src/lens/Quoter.sol
+++ b/src/lens/Quoter.sol
@@ -9,17 +9,14 @@ import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {IQuoter} from "../interfaces/IQuoter.sol";
 import {PoolTicksCounter} from "../libraries/PoolTicksCounter.sol";
-import {PathKey, PathKeyLib} from "../libraries/PathKey.sol";
+import {PathKey} from "../libraries/PathKey.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {SafeCallback} from "../base/SafeCallback.sol";
 
 contract Quoter is IQuoter, SafeCallback {
     using Hooks for IHooks;
-    using PoolIdLibrary for PoolKey;
-    using PathKeyLib for PathKey;
     using StateLibrary for IPoolManager;
 
     /// @dev cache used to check a safety condition in exact output swaps.
@@ -238,8 +235,8 @@ contract Quoter is IQuoter, SafeCallback {
             curAmountOut = i == pathLength ? params.exactAmount : cache.prevAmount;
             amountOutCached = curAmountOut;
 
-            (PoolKey memory poolKey, bool oneForZero) = PathKeyLib.getPoolAndSwapDirection(
-                params.path[i - 1], i == pathLength ? params.exactCurrency : cache.prevCurrency
+            (PoolKey memory poolKey, bool oneForZero) = params.path[i - 1].getPoolAndSwapDirection(
+                 i == pathLength ? params.exactCurrency : cache.prevCurrency
             );
 
             (, cache.tickBefore,,) = poolManager.getSlot0(poolKey.toId());

--- a/src/libraries/PathKey.sol
+++ b/src/libraries/PathKey.sol
@@ -13,6 +13,8 @@ struct PathKey {
     bytes hookData;
 }
 
+using PathKeyLib for PathKey global;
+
 library PathKeyLib {
     function getPoolAndSwapDirection(PathKey calldata params, Currency currencyIn)
         internal

--- a/src/libraries/PoolTicksCounter.sol
+++ b/src/libraries/PoolTicksCounter.sol
@@ -3,11 +3,9 @@ pragma solidity >=0.8.20;
 
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 
 library PoolTicksCounter {
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
 
     struct TickCache {

--- a/src/libraries/PositionConfig.sol
+++ b/src/libraries/PositionConfig.sol
@@ -10,6 +10,8 @@ struct PositionConfig {
     int24 tickUpper;
 }
 
+using PositionConfigLibrary for PositionConfig global; 
+
 /// @notice Library to calculate the PositionConfigId from the PositionConfig struct
 library PositionConfigLibrary {
     function toId(PositionConfig calldata config) internal pure returns (bytes32 id) {

--- a/src/libraries/PositionConfigId.sol
+++ b/src/libraries/PositionConfigId.sol
@@ -8,6 +8,8 @@ struct PositionConfigId {
     bytes32 id;
 }
 
+using PositionConfigIdLibrary for PositionConfigId global;
+
 library PositionConfigIdLibrary {
     bytes32 constant MASK_UPPER_BIT = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
     bytes32 constant DIRTY_UPPER_BIT = 0x8000000000000000000000000000000000000000000000000000000000000000;

--- a/test/Quoter.t.sol
+++ b/test/Quoter.t.sol
@@ -13,7 +13,7 @@ import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
 import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {PoolModifyLiquidityTest} from "@uniswap/v4-core/src/test/PoolModifyLiquidityTest.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
@@ -25,7 +25,6 @@ import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 
 contract QuoterTest is Test, Deployers {
     using SafeCast for *;
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
 
     // Min tick for full range with tick spacing of 60

--- a/test/StateViewTest.t.sol
+++ b/test/StateViewTest.t.sol
@@ -11,7 +11,7 @@ import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {CurrencyLibrary, Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {Pool} from "@uniswap/v4-core/src/libraries/Pool.sol";
 import {TickBitmap} from "@uniswap/v4-core/src/libraries/TickBitmap.sol";
@@ -25,7 +25,6 @@ import {StateView} from "../src/lens/StateView.sol";
 /// This test was taken from StateLibrary.t.sol in v4-core and adapted to use the StateView contract instead.
 contract StateViewTest is Test, Deployers, Fuzzers, GasSnapshot {
     using FixedPointMathLib for uint256;
-    using PoolIdLibrary for PoolKey;
 
     PoolId poolId;
 

--- a/test/position-managers/Execute.t.sol
+++ b/test/position-managers/Execute.t.sol
@@ -6,7 +6,7 @@ import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
@@ -30,7 +30,6 @@ import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
 contract ExecuteTest is Test, PosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
     using CurrencyLibrary for Currency;
-    using PoolIdLibrary for PoolKey;
     using Planner for Plan;
     using StateLibrary for IPoolManager;
 

--- a/test/position-managers/FeeCollection.t.sol
+++ b/test/position-managers/FeeCollection.t.sol
@@ -6,7 +6,7 @@ import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";

--- a/test/position-managers/IncreaseLiquidity.t.sol
+++ b/test/position-managers/IncreaseLiquidity.t.sol
@@ -6,7 +6,7 @@ import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
@@ -33,7 +33,6 @@ import {ActionConstants} from "../../src/libraries/ActionConstants.sol";
 contract IncreaseLiquidityTest is Test, PosmTestSetup, Fuzzers {
     using FixedPointMathLib for uint256;
     using CurrencyLibrary for Currency;
-    using PoolIdLibrary for PoolKey;
     using Planner for Plan;
     using FeeMath for IPositionManager;
     using StateLibrary for IPoolManager;

--- a/test/position-managers/NativeToken.t.sol
+++ b/test/position-managers/NativeToken.t.sol
@@ -7,7 +7,7 @@ import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta, toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
@@ -39,7 +39,6 @@ contract PositionManagerTest is Test, PosmTestSetup, LiquidityFuzzers {
     using CurrencyLibrary for Currency;
     using PositionConfigLibrary for PositionConfig;
     using Planner for Plan;
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
     using SafeCast for *;
 

--- a/test/position-managers/Permit.t.sol
+++ b/test/position-managers/Permit.t.sol
@@ -6,7 +6,7 @@ import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
@@ -25,7 +25,6 @@ import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
 contract PermitTest is Test, PosmTestSetup {
     using FixedPointMathLib for uint256;
     using CurrencyLibrary for Currency;
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
 
     PoolId poolId;

--- a/test/position-managers/PositionManager.gas.t.sol
+++ b/test/position-managers/PositionManager.gas.t.sol
@@ -7,7 +7,7 @@ import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
@@ -28,7 +28,6 @@ import {ActionConstants} from "../../src/libraries/ActionConstants.sol";
 contract PosMGasTest is Test, PosmTestSetup, GasSnapshot {
     using FixedPointMathLib for uint256;
     using CurrencyLibrary for Currency;
-    using PoolIdLibrary for PoolKey;
     using Planner for Plan;
 
     PoolId poolId;

--- a/test/position-managers/PositionManager.modifyLiquidities.t.sol
+++ b/test/position-managers/PositionManager.modifyLiquidities.t.sol
@@ -7,7 +7,7 @@ import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
@@ -26,7 +26,6 @@ import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
 
 contract PositionManagerModifyLiquiditiesTest is Test, PosmTestSetup, LiquidityFuzzers {
     using StateLibrary for IPoolManager;
-    using PoolIdLibrary for PoolKey;
 
     PoolId poolId;
     address alice;

--- a/test/position-managers/PositionManager.multicall.t.sol
+++ b/test/position-managers/PositionManager.multicall.t.sol
@@ -6,7 +6,7 @@ import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
@@ -34,10 +34,8 @@ import {IERC721Permit_v4} from "../../src/interfaces/IERC721Permit_v4.sol";
 contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
     using CurrencyLibrary for Currency;
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
     using Planner for Plan;
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
 
     PoolId poolId;

--- a/test/position-managers/PositionManager.notifier.t.sol
+++ b/test/position-managers/PositionManager.notifier.t.sol
@@ -7,7 +7,6 @@ import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
-import {PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
 import {MockSubscriber} from "../mocks/MockSubscriber.sol";
@@ -21,7 +20,6 @@ import {MockReturnDataSubscriber, MockRevertSubscriber} from "../mocks/MockBadSu
 import {BalanceDelta, toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 
 contract PositionManagerNotifierTest is Test, PosmTestSetup, GasSnapshot {
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
     using Planner for Plan;
 

--- a/test/position-managers/PositionManager.t.sol
+++ b/test/position-managers/PositionManager.t.sol
@@ -6,7 +6,7 @@ import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
@@ -39,7 +39,6 @@ contract PositionManagerTest is Test, PosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
     using CurrencyLibrary for Currency;
     using Planner for Plan;
-    using PoolIdLibrary for PoolKey;
     using StateLibrary for IPoolManager;
 
     PoolId poolId;

--- a/test/shared/FeeMath.sol
+++ b/test/shared/FeeMath.sol
@@ -8,7 +8,7 @@ import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {BalanceDelta, toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
-import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
 import {IPositionManager} from "../../src/interfaces/IPositionManager.sol";
@@ -18,8 +18,6 @@ import {PositionConfig} from "../../src/libraries/PositionConfig.sol";
 library FeeMath {
     using SafeCast for uint256;
     using StateLibrary for IPoolManager;
-    using PoolIdLibrary for PoolKey;
-    using PoolIdLibrary for PoolKey;
 
     /// @notice Calculates the fees accrued to a position. Used for testing purposes.
     function getFeesOwed(IPositionManager posm, IPoolManager manager, PositionConfig memory config, uint256 tokenId)


### PR DESCRIPTION
## Description of changes

:heavy_minus_sign: Get rid of unused `CurrencyLibrary` usages

:x:  Get rid of all `using PoolIdLibrary for PoolKey;` directives and `PoolIdLibrary` imports

:heavy_plus_sign:  Add global usage of `PositionConfigIdLibrary` for `PositionConfigId`

:heavy_plus_sign:  Add global usage of `PositionConfigLibrary` for `PositionConfig`

:heavy_plus_sign:  Add global usage of `PathKeyLib` for `PathKey`

