### PR TITLE
chore: OZ-L04 adherence to CEI in unsubscribe

### DIFF
--- a/src/base/Notifier.sol
+++ b/src/base/Notifier.sol
@@ -69,11 +69,11 @@ abstract contract Notifier is INotifier {
         _positionConfigs(tokenId).setUnsubscribe();
         ISubscriber _subscriber = subscriber[tokenId];
 
-        uint256 subscriberGasLimit = block.gaslimit.calculatePortion(BLOCK_LIMIT_BPS);
+        delete subscriber[tokenId];
 
+        uint256 subscriberGasLimit = block.gaslimit.calculatePortion(BLOCK_LIMIT_BPS);
         try _subscriber.notifyUnsubscribe{gas: subscriberGasLimit}(tokenId, config, data) {} catch {}
 
-        delete subscriber[tokenId];
         emit Unsubscribed(tokenId, address(_subscriber));
     }
 


### PR DESCRIPTION
## Related Issue
`unsubscribe()` does not follow check-effect-interaction pattern

* This would lead to obscure cases where integrators (called by subscribers) may mistaken that a tokenId has a subscriber


## Description of changes

`delete subscriber[tokenId]` before calling `subscriber.notifyUnsubscribe()`