### PR TITLE
OZ L-09

### DIFF
--- a/src/base/Notifier.sol
+++ b/src/base/Notifier.sol
@@ -48,9 +48,8 @@ abstract contract Notifier is INotifier {
         if (_subscriber != NO_SUBSCRIBER) revert AlreadySubscribed(address(_subscriber));
         subscriber[tokenId] = ISubscriber(newSubscriber);
 
-        bool success = _call(
-            address(newSubscriber), abi.encodeWithSelector(ISubscriber.notifySubscribe.selector, tokenId, config, data)
-        );
+        bool success =
+            _call(address(newSubscriber), abi.encodeCall(ISubscriber.notifySubscribe, (tokenId, config, data)));
 
         if (!success) {
             Wrap__SubsciptionReverted.selector.bubbleUpAndRevertWith(address(newSubscriber));
@@ -87,9 +86,7 @@ abstract contract Notifier is INotifier {
 
         bool success = _call(
             address(_subscriber),
-            abi.encodeWithSelector(
-                ISubscriber.notifyModifyLiquidity.selector, tokenId, config, liquidityChange, feesAccrued
-            )
+            abi.encodeCall(ISubscriber.notifyModifyLiquidity, (tokenId, config, liquidityChange, feesAccrued))
         );
 
         if (!success) {
@@ -100,10 +97,8 @@ abstract contract Notifier is INotifier {
     function _notifyTransfer(uint256 tokenId, address previousOwner, address newOwner) internal {
         ISubscriber _subscriber = subscriber[tokenId];
 
-        bool success = _call(
-            address(_subscriber),
-            abi.encodeWithSelector(ISubscriber.notifyTransfer.selector, tokenId, previousOwner, newOwner)
-        );
+        bool success =
+            _call(address(_subscriber), abi.encodeCall(ISubscriber.notifyTransfer, (tokenId, previousOwner, newOwner)));
 
         if (!success) {
             Wrap__TransferNotificationReverted.selector.bubbleUpAndRevertWith(address(_subscriber));

--- a/src/lens/Quoter.sol
+++ b/src/lens/Quoter.sol
@@ -60,7 +60,7 @@ contract Quoter is IQuoter, SafeCallback {
         override
         returns (int128[] memory deltaAmounts, uint160 sqrtPriceX96After, uint32 initializedTicksLoaded)
     {
-        try poolManager.unlock(abi.encodeWithSelector(this._quoteExactInputSingle.selector, params)) {}
+        try poolManager.unlock(abi.encodeCall(this._quoteExactInputSingle, (params))) {}
         catch (bytes memory reason) {
             return _handleRevertSingle(reason);
         }
@@ -75,7 +75,7 @@ contract Quoter is IQuoter, SafeCallback {
             uint32[] memory initializedTicksLoadedList
         )
     {
-        try poolManager.unlock(abi.encodeWithSelector(this._quoteExactInput.selector, params)) {}
+        try poolManager.unlock(abi.encodeCall(this._quoteExactInput, (params))) {}
         catch (bytes memory reason) {
             return _handleRevert(reason);
         }
@@ -87,7 +87,7 @@ contract Quoter is IQuoter, SafeCallback {
         override
         returns (int128[] memory deltaAmounts, uint160 sqrtPriceX96After, uint32 initializedTicksLoaded)
     {
-        try poolManager.unlock(abi.encodeWithSelector(this._quoteExactOutputSingle.selector, params)) {}
+        try poolManager.unlock(abi.encodeCall(this._quoteExactOutputSingle, (params))) {}
         catch (bytes memory reason) {
             if (params.sqrtPriceLimitX96 == 0) delete amountOutCached;
             return _handleRevertSingle(reason);
@@ -104,7 +104,7 @@ contract Quoter is IQuoter, SafeCallback {
             uint32[] memory initializedTicksLoadedList
         )
     {
-        try poolManager.unlock(abi.encodeWithSelector(this._quoteExactOutput.selector, params)) {}
+        try poolManager.unlock(abi.encodeCall(this._quoteExactOutput, (params))) {}
         catch (bytes memory reason) {
             return _handleRevert(reason);
         }


### PR DESCRIPTION
## Related Issue
OZ L-09
https://defender.openzeppelin.com/v2/#/audit/43d4e491-c5b4-42ba-b0fc-7f5adc46a6b6/issues/L-09

## Description of changes
Use `abi.encodeCall` instead of `abi.encodeWithSelector` since `abi.encodeWithSelector` is not type safe and `abi.encodeWithSignature` is not typo safe