### PR TITLE
SB-L73: payable initializePool

### DIFF
--- a/src/base/PoolInitializer.sol
+++ b/src/base/PoolInitializer.sol
@@ -8,6 +8,7 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 abstract contract PoolInitializer is ImmutableState {
     function initializePool(PoolKey calldata key, uint160 sqrtPriceX96, bytes calldata hookData)
         external
+        payable
         returns (int24)
     {
         return poolManager.initialize(key, sqrtPriceX96, hookData);


### PR DESCRIPTION
## Related Issue
SB-L73: missing payable

**NOTE:** the spearbit issue states we are missing `payable` on the ERC721 methods. However, we cannot override Solmate's functions and change from `nonpayable` to `payable`

## Description of changes

* Added `payable` to `initializePool` 
* unit test `multicall(initializePool, mint)`