### PR TITLE
Remove Wrap__ notation from permit2 revert reason

### DIFF
--- a/src/base/Permit2Forwarder.sol
+++ b/src/base/Permit2Forwarder.sol
@@ -9,8 +9,6 @@ contract Permit2Forwarder {
     /// @notice the Permit2 contract to forward approvals
     IAllowanceTransfer public immutable permit2;
 
-    error Wrap__Permit2Reverted(address _permit2, bytes reason);
-
     constructor(IAllowanceTransfer _permit2) {
         permit2 = _permit2;
     }
@@ -28,7 +26,7 @@ contract Permit2Forwarder {
         // use try/catch in case an actor front-runs the permit, which would DOS multicalls
         try permit2.permit(owner, permitSingle, signature) {}
         catch (bytes memory reason) {
-            err = abi.encodeWithSelector(Wrap__Permit2Reverted.selector, address(permit2), reason);
+            err = reason;
         }
     }
 
@@ -45,7 +43,7 @@ contract Permit2Forwarder {
         // use try/catch in case an actor front-runs the permit, which would DOS multicalls
         try permit2.permit(owner, _permitBatch, signature) {}
         catch (bytes memory reason) {
-            err = abi.encodeWithSelector(Wrap__Permit2Reverted.selector, address(permit2), reason);
+            err = reason;
         }
     }
 }

--- a/test/position-managers/PositionManager.multicall.t.sol
+++ b/test/position-managers/PositionManager.multicall.t.sol
@@ -424,23 +424,11 @@ contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTest
         bytes[] memory results = lpm.multicall(calls);
         assertEq(
             results[0],
-            abi.encode(
-                abi.encodeWithSelector(
-                    Permit2Forwarder.Wrap__Permit2Reverted.selector,
-                    address(permit2),
-                    abi.encodeWithSelector(InvalidNonce.selector)
-                )
-            )
+            abi.encode(abi.encodeWithSelector(InvalidNonce.selector))
         );
         assertEq(
             results[1],
-            abi.encode(
-                abi.encodeWithSelector(
-                    Permit2Forwarder.Wrap__Permit2Reverted.selector,
-                    address(permit2),
-                    abi.encodeWithSelector(InvalidNonce.selector)
-                )
-            )
+            abi.encode(abi.encodeWithSelector(InvalidNonce.selector))
         );
 
         assertEq(lpm.ownerOf(tokenId), charlie);
@@ -493,13 +481,7 @@ contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTest
         bytes[] memory results = lpm.multicall(calls);
         assertEq(
             results[0],
-            abi.encode(
-                abi.encodeWithSelector(
-                    Permit2Forwarder.Wrap__Permit2Reverted.selector,
-                    address(permit2),
-                    abi.encodeWithSelector(InvalidNonce.selector)
-                )
-            )
+            abi.encode(abi.encodeWithSelector(InvalidNonce.selector))
         );
 
         assertEq(lpm.ownerOf(tokenId), charlie);

--- a/test/position-managers/PositionManager.multicall.t.sol
+++ b/test/position-managers/PositionManager.multicall.t.sol
@@ -422,14 +422,8 @@ contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTest
         lpm.ownerOf(tokenId); // token does not exist
 
         bytes[] memory results = lpm.multicall(calls);
-        assertEq(
-            results[0],
-            abi.encode(abi.encodeWithSelector(InvalidNonce.selector))
-        );
-        assertEq(
-            results[1],
-            abi.encode(abi.encodeWithSelector(InvalidNonce.selector))
-        );
+        assertEq(results[0], abi.encode(abi.encodeWithSelector(InvalidNonce.selector)));
+        assertEq(results[1], abi.encode(abi.encodeWithSelector(InvalidNonce.selector)));
 
         assertEq(lpm.ownerOf(tokenId), charlie);
     }
@@ -479,10 +473,7 @@ contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTest
         lpm.ownerOf(tokenId); // token does not exist
 
         bytes[] memory results = lpm.multicall(calls);
-        assertEq(
-            results[0],
-            abi.encode(abi.encodeWithSelector(InvalidNonce.selector))
-        );
+        assertEq(results[0], abi.encode(abi.encodeWithSelector(InvalidNonce.selector)));
 
         assertEq(lpm.ownerOf(tokenId), charlie);
     }


### PR DESCRIPTION
## Related Issue

We believe the `Wrap__` notation should only be reserved for "unknown"/"variable" external calls (subscribers, hooks, tokens, etc). So we are removing it from permit2 error handling, to be consistent with external calls to PoolManager

## Description of changes

Removed `Wrap__` notation from permit2 error handling