### PR TITLE
Pashov M-01 fix hook address

### DIFF
--- a/src/libraries/SVG.sol
+++ b/src/libraries/SVG.sol
@@ -346,7 +346,7 @@ library SVG {
         string memory tickLowerStr = tickToString(tickLower);
         string memory tickUpperStr = tickToString(tickUpper);
         uint256 str1length = bytes(tokenId).length + 4;
-        string memory hookSlice = string(abi.encodePacked(substring(hookStr, 0, 5), "...", substring(hookStr, 37, 40)));
+        string memory hookSlice = string(abi.encodePacked(substring(hookStr, 0, 5), "...", substring(hookStr, 39, 42)));
         uint256 str2length = bytes(hookSlice).length + 5;
         uint256 str3length = bytes(tickLowerStr).length + 10;
         uint256 str4length = bytes(tickUpperStr).length + 10;


### PR DESCRIPTION
## Related Issue
Pashov M-01 https://github.com/PashovAuditGroup/Uniswap_October_MERGED/issues/12
Hook address is not correctly represented in the SVG

## Description of changes
make sure the last 3 characters of the hook address are displayed