### PR TITLE
change name for UR

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -18,7 +18,7 @@ import {ERC721Permit_v4} from "./base/ERC721Permit_v4.sol";
 import {ReentrancyLock} from "./base/ReentrancyLock.sol";
 import {IPositionManager} from "./interfaces/IPositionManager.sol";
 import {Multicall_v4} from "./base/Multicall_v4.sol";
-import {PoolInitializer} from "./base/PoolInitializer.sol";
+import {PoolInitializer_v4} from "./base/PoolInitializer_v4.sol";
 import {DeltaResolver} from "./base/DeltaResolver.sol";
 import {BaseActionsRouter} from "./base/BaseActionsRouter.sol";
 import {Actions} from "./libraries/Actions.sol";
@@ -100,7 +100,7 @@ import {IWETH9} from "./interfaces/external/IWETH9.sol";
 contract PositionManager is
     IPositionManager,
     ERC721Permit_v4,
-    PoolInitializer,
+    PoolInitializer_v4,
     Multicall_v4,
     DeltaResolver,
     ReentrancyLock,

--- a/src/base/PoolInitializer_v4.sol
+++ b/src/base/PoolInitializer_v4.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.0;
 
 import {ImmutableState} from "./ImmutableState.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {IPoolInitializer} from "../interfaces/IPoolInitializer.sol";
+import {IPoolInitializer_v4} from "../interfaces/IPoolInitializer_v4.sol";
 
 /// @title Pool Initializer
 /// @notice Initializes a Uniswap v4 Pool
 /// @dev Enables create pool + mint liquidity in a single transaction with multicall
-abstract contract PoolInitializer is ImmutableState, IPoolInitializer {
-    /// @inheritdoc IPoolInitializer
+abstract contract PoolInitializer_v4 is ImmutableState, IPoolInitializer_v4 {
+    /// @inheritdoc IPoolInitializer_v4
     function initializePool(PoolKey calldata key, uint160 sqrtPriceX96) external payable returns (int24) {
         try poolManager.initialize(key, sqrtPriceX96) returns (int24 tick) {
             return tick;

--- a/src/interfaces/IPoolInitializer_v4.sol
+++ b/src/interfaces/IPoolInitializer_v4.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
-interface IPoolInitializer {
+interface IPoolInitializer_v4 {
     /// @notice Initialize a Uniswap v4 Pool
     /// @dev If the pool is already initialized, this function will not revert and just return type(int24).max
     /// @param key The PoolKey of the pool to initialize

--- a/src/interfaces/IPositionManager.sol
+++ b/src/interfaces/IPositionManager.sol
@@ -9,7 +9,7 @@ import {IImmutableState} from "./IImmutableState.sol";
 import {IERC721Permit_v4} from "./IERC721Permit_v4.sol";
 import {IEIP712_v4} from "./IEIP712_v4.sol";
 import {IMulticall_v4} from "./IMulticall_v4.sol";
-import {IPoolInitializer} from "./IPoolInitializer.sol";
+import {IPoolInitializer_v4} from "./IPoolInitializer_v4.sol";
 import {IUnorderedNonce} from "./IUnorderedNonce.sol";
 import {IPermit2Forwarder} from "./IPermit2Forwarder.sol";
 
@@ -21,7 +21,7 @@ interface IPositionManager is
     IERC721Permit_v4,
     IEIP712_v4,
     IMulticall_v4,
-    IPoolInitializer,
+    IPoolInitializer_v4,
     IUnorderedNonce,
     IPermit2Forwarder
 {

--- a/test/position-managers/PositionManager.gas.t.sol
+++ b/test/position-managers/PositionManager.gas.t.sol
@@ -15,7 +15,7 @@ import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
-import {IPositionManager, IPoolInitializer} from "../../src/interfaces/IPositionManager.sol";
+import {IPositionManager, IPoolInitializer_v4} from "../../src/interfaces/IPositionManager.sol";
 import {Actions} from "../../src/libraries/Actions.sol";
 import {PositionConfig} from "../shared/PositionConfig.sol";
 import {IMulticall_v4} from "../../src/interfaces/IMulticall_v4.sol";
@@ -395,7 +395,7 @@ contract PosMGasTest is Test, PosmTestSetup {
 
         // Use multicall to initialize a pool and mint liquidity
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeWithSelector(IPoolInitializer.initializePool.selector, key, SQRT_PRICE_1_1);
+        calls[0] = abi.encodeWithSelector(IPoolInitializer_v4.initializePool.selector, key, SQRT_PRICE_1_1);
 
         config = PositionConfig({
             poolKey: key,

--- a/test/position-managers/PositionManager.multicall.t.sol
+++ b/test/position-managers/PositionManager.multicall.t.sol
@@ -18,7 +18,7 @@ import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {IERC721} from "forge-std/interfaces/IERC721.sol";
 
-import {IPositionManager, IPoolInitializer} from "../../src/interfaces/IPositionManager.sol";
+import {IPositionManager, IPoolInitializer_v4} from "../../src/interfaces/IPositionManager.sol";
 import {Actions} from "../../src/libraries/Actions.sol";
 import {PositionConfig} from "../shared/PositionConfig.sol";
 import {IMulticall_v4} from "../../src/interfaces/IMulticall_v4.sol";
@@ -97,7 +97,7 @@ contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTest
 
         // Use multicall to initialize a pool and mint liquidity
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeWithSelector(IPoolInitializer.initializePool.selector, key, SQRT_PRICE_1_1);
+        calls[0] = abi.encodeWithSelector(IPoolInitializer_v4.initializePool.selector, key, SQRT_PRICE_1_1);
 
         config = PositionConfig({
             poolKey: key,
@@ -138,7 +138,7 @@ contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTest
 
         // Use multicall to initialize the pool again.
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeWithSelector(IPoolInitializer.initializePool.selector, key, SQRT_PRICE_1_1);
+        calls[0] = abi.encodeWithSelector(IPoolInitializer_v4.initializePool.selector, key, SQRT_PRICE_1_1);
 
         config = PositionConfig({
             poolKey: key,
@@ -184,7 +184,7 @@ contract PositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTest
 
         // Use multicall to initialize a pool and mint liquidity
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeWithSelector(IPoolInitializer.initializePool.selector, key, SQRT_PRICE_1_1);
+        calls[0] = abi.encodeWithSelector(IPoolInitializer_v4.initializePool.selector, key, SQRT_PRICE_1_1);
 
         config = PositionConfig({
             poolKey: key,


### PR DESCRIPTION
## Related Issue
typechain error in universal router
`Cannot redefine property: IPoolInitializer__factory`

## Description of changes
rename PoolInitializer in v4 so it's not the same as v3