### PR TITLE
🛠️ fix: add memory-safe assembly annotation to resolve stack depth error

### DIFF
--- a/src/base/Multicall_v4.sol
+++ b/src/base/Multicall_v4.sol
@@ -14,7 +14,7 @@ abstract contract Multicall_v4 is IMulticall_v4 {
 
             if (!success) {
                 // bubble up the revert reason
-                assembly {
+                assembly ("memory-safe") {
                     revert(add(result, 0x20), mload(result))
                 }
             }

--- a/src/libraries/Locker.sol
+++ b/src/libraries/Locker.sol
@@ -8,13 +8,13 @@ library Locker {
     bytes32 constant LOCKED_BY_SLOT = 0x0aedd6bde10e3aa2adec092b02a3e3e805795516cda41f27aa145b8f300af87a;
 
     function set(address locker) internal {
-        assembly {
+        assembly ("memory-safe") {
             tstore(LOCKED_BY_SLOT, locker)
         }
     }
 
     function get() internal view returns (address locker) {
-        assembly {
+        assembly ("memory-safe") {
             locker := tload(LOCKED_BY_SLOT)
         }
     }

--- a/src/libraries/PositionInfoLibrary.sol
+++ b/src/libraries/PositionInfoLibrary.sol
@@ -94,7 +94,7 @@ library PositionInfoLibrary {
         returns (PositionInfo info)
     {
         bytes25 _poolId = bytes25(PoolId.unwrap(_poolKey.toId()));
-        assembly {
+        assembly ("memory-safe") {
             info :=
                 or(
                     or(and(MASK_UPPER_200_BITS, _poolId), shl(TICK_UPPER_OFFSET, and(MASK_24_BITS, _tickUpper))),

--- a/test/base64.sol
+++ b/test/base64.sol
@@ -25,7 +25,7 @@ library Base64 {
         // add some extra buffer at the end required for the writing
         bytes memory result = new bytes(decodedLen + 32);
 
-        assembly {
+        assembly ("memory-safe") {
             // padding with '='
             let lastBytes := mload(add(data, mload(data)))
             if eq(and(lastBytes, 0xFF), 0x3d) {

--- a/test/mocks/MockBadSubscribers.sol
+++ b/test/mocks/MockBadSubscribers.sol
@@ -36,7 +36,7 @@ contract MockReturnDataSubscriber is ISubscriber {
     function notifyUnsubscribe(uint256) external onlyByPosm {
         notifyUnsubscribeCount++;
         uint256 _memPtr = memPtr;
-        assembly {
+        assembly ("memory-safe") {
             let fmp := mload(0x40)
             mstore(fmp, 0xBEEF)
             mstore(add(fmp, 0x20), 0xCAFE)

--- a/test/shared/Deploy.sol
+++ b/test/shared/Deploy.sol
@@ -20,7 +20,7 @@ library Deploy {
     ) internal returns (IPositionManager manager) {
         bytes memory args = abi.encode(poolManager, permit2, unsubscribeGasLimit, positionDescriptor_, wrappedNative);
         bytes memory initcode = abi.encodePacked(vm.getCode("PositionManager.sol:PositionManager"), args);
-        assembly {
+        assembly ("memory-safe") {
             manager := create2(0, add(initcode, 0x20), mload(initcode), salt)
         }
     }
@@ -28,7 +28,7 @@ library Deploy {
     function stateView(address poolManager, bytes memory salt) internal returns (IStateView stateView_) {
         bytes memory args = abi.encode(poolManager);
         bytes memory initcode = abi.encodePacked(vm.getCode("StateView.sol:StateView"), args);
-        assembly {
+        assembly ("memory-safe") {
             stateView_ := create2(0, add(initcode, 0x20), mload(initcode), salt)
         }
     }
@@ -36,7 +36,7 @@ library Deploy {
     function v4Quoter(address poolManager, bytes memory salt) internal returns (IV4Quoter quoter) {
         bytes memory args = abi.encode(poolManager);
         bytes memory initcode = abi.encodePacked(vm.getCode("V4Quoter.sol:V4Quoter"), args);
-        assembly {
+        assembly ("memory-safe") {
             quoter := create2(0, add(initcode, 0x20), mload(initcode), salt)
         }
     }
@@ -49,7 +49,7 @@ library Deploy {
     ) internal returns (IPositionDescriptor descriptor) {
         bytes memory args = abi.encode(poolManager, wrappedNative, nativeCurrencyLabel);
         bytes memory initcode = abi.encodePacked(vm.getCode("PositionDescriptor.sol:PositionDescriptor"), args);
-        assembly {
+        assembly ("memory-safe") {
             descriptor := create2(0, add(initcode, 0x20), mload(initcode), salt)
         }
     }


### PR DESCRIPTION
## Related Issue
Fixes [#422](https://github.com/Uniswap/v4-periphery/issues/422)

## Description of changes

### Fix Stack Depth Error in Yul Compilation

#### Issue
When running `forge build`, compilation failed due to a stack depth error in Yul:
```
Compiler run failed:
Error: Yul exception:Variable expr_mpos_2 is 1 too deep in the stack [ _10 expr_14 expr_15 expr_mpos_2 expr expr_13 expr_component expr_6 expr_5 expr_14 expr_mpos_1 expr_mpos expr_address_1 _10 expr_13 _10 _11 _11 _12 expr_18 ]

No memoryguard was present. Consider using memory-safe assembly only and annotating it via 'assembly ("memory-safe") { ... }'.

YulException: Variable expr_mpos_2 is 1 too deep in the stack [ _10 expr_14 expr_15 expr_mpos_2 expr expr_13 expr_component expr_6 expr_5 expr_14 expr_mpos_1 expr_mpos expr_address_1 _10 expr_13 _10 _11 _11 _12 expr_18 ]

No memoryguard was present. Consider using memory-safe assembly only and annotating it via 'assembly ("memory-safe") { ... }'.
```

The error indicates that assembly blocks were missing memory safety annotations, causing stack depth to exceed limits during compilation.

#### Fix
Added `("memory-safe")` annotation to assembly blocks:
```solidity
- assembly {
+ assembly ("memory-safe") {
```

This resolves the stack depth error by properly annotating memory-safe assembly operations, allowing successful compilation with `forge build`.