### PR TITLE
fix: Remove incorrect amount propagation in exact output swaps

### DIFF
--- a/src/V4Router.sol
+++ b/src/V4Router.sol
@@ -145,7 +145,6 @@ abstract contract V4Router is IV4Router, BaseActionsRouter, DeltaResolver {
                 amountIn = (uint256(-int256(_swap(poolKey, !oneForZero, int256(uint256(amountOut)), pathKey.hookData))))
                     .toUint128();
 
-                amountOut = amountIn;
                 currencyOut = pathKey.intermediateCurrency;
             }
             if (amountIn > params.amountInMaximum) revert V4TooMuchRequested(params.amountInMaximum, amountIn);


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?
This PR fixes a critical issue in the V4Router's _swapExactOutput function 
where amounts were incorrectly propagated in multi-hop trades
## Description of changes
The bug was 
caused by unnecessarily setting amountOut = amountIn in each iteration, which 
led to incorrect calculations for subsequent hops.

- Removed the line `amountOut = amountIn` from the _swapExactOutput function
- Maintains correct output amount throughout the path traversal
- Ensures accurate input amount calculations for each hop

This fix prevents:
- Incorrect slippage calculations in multi-hop trades
- Potential trade failures due to amount mismatches
- Inaccurate price impact calculations