### PR TITLE
Add weth wrapping hook

### DIFF
--- a/src/base/hooks/BaseTokenWrapperHook.sol
+++ b/src/base/hooks/BaseTokenWrapperHook.sol
@@ -15,8 +15,6 @@ import {BaseHook} from "./BaseHook.sol";
 /// @dev This contract provides the base functionality for wrapping/unwrapping tokens through V4 pools
 /// @dev All liquidity operations are blocked as liquidity is managed through the underlying token wrapper
 /// @dev Implementing contracts must provide deposit() and withdraw() functions
-/// @dev This base wrapper should only be used for wrappers that are 1:1.
-///   Support for moving rate can be added with additional handling for exact output trades
 abstract contract BaseTokenWrapperHook is BaseHook {
     using CurrencyLibrary for Currency;
 

--- a/src/base/hooks/BaseTokenWrapperHook.sol
+++ b/src/base/hooks/BaseTokenWrapperHook.sol
@@ -1,0 +1,194 @@
+pragma solidity ^0.8.0;
+
+import {
+    toBeforeSwapDelta, BeforeSwapDelta, BeforeSwapDeltaLibrary
+} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {BaseHook} from "./BaseHook.sol";
+
+/// @title Base Token Wrapper Hook
+/// @notice Abstract base contract for implementing token wrapper hooks in Uniswap V4
+/// @dev This contract provides the base functionality for wrapping/unwrapping tokens through V4 pools
+/// @dev All liquidity operations are blocked as liquidity is managed through the underlying token wrapper
+/// @dev Implementing contracts must provide deposit() and withdraw() functions
+/// @dev This base wrapper should only be used for wrappers that are 1:1.
+///   Support for moving rate can be added with additional handling for exact output trades
+abstract contract BaseTokenWrapperHook is BaseHook {
+    using CurrencyLibrary for Currency;
+
+    /// @notice Thrown when attempting to add or remove liquidity
+    /// @dev Liquidity operations are blocked since all liquidity is managed by the token wrapper
+    error LiquidityNotAllowed();
+
+    /// @notice Thrown when initializing a pool with invalid tokens
+    /// @dev Pool must contain exactly one wrapper token and its underlying token
+    error InvalidPoolToken();
+
+    /// @notice Thrown when initializing a pool with non-zero fee
+    /// @dev Fee must be 0 as wrapper pools don't charge fees
+    error InvalidPoolFee();
+
+    /// @notice The wrapped token currency (e.g., WETH)
+    Currency public immutable wrapperCurrency;
+
+    /// @notice The underlying token currency (e.g., ETH)
+    Currency public immutable underlyingCurrency;
+
+    /// @notice Creates a new token wrapper hook
+    /// @param _manager The Uniswap V4 pool manager
+    /// @param _wrapper The wrapped token currency (e.g., WETH)
+    /// @param _underlying The underlying token currency (e.g., ETH)
+    constructor(IPoolManager _manager, Currency _wrapper, Currency _underlying) BaseHook(_manager) {
+        wrapperCurrency = _wrapper;
+        underlyingCurrency = _underlying;
+    }
+
+    /// @notice Returns a struct of permissions to signal which hook functions are to be implemented
+    /// @dev Used at deployment to validate the address correctly represents the expected permissions
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: true,
+            beforeAddLiquidity: true,
+            beforeRemoveLiquidity: true,
+            beforeSwap: true,
+            beforeSwapReturnDelta: true,
+            afterSwap: false,
+            afterInitialize: false,
+            afterAddLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeDonate: false,
+            afterDonate: false,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    /// @inheritdoc IHooks
+    function beforeInitialize(address, PoolKey calldata poolKey, uint160) external view override returns (bytes4) {
+        // ensure pool tokens are the wrapper currency and underlying currency
+        bool isValidPair = (poolKey.currency0 == wrapperCurrency && poolKey.currency1 == underlyingCurrency)
+            || (poolKey.currency0 == underlyingCurrency && poolKey.currency1 == wrapperCurrency);
+
+        if (!isValidPair) revert InvalidPoolToken();
+        if (poolKey.fee != 0) revert InvalidPoolFee();
+
+        return IHooks.beforeInitialize.selector;
+    }
+
+    /// @inheritdoc IHooks
+    function beforeAddLiquidity(address, PoolKey calldata, IPoolManager.ModifyLiquidityParams calldata, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        revert LiquidityNotAllowed();
+    }
+
+    /// @inheritdoc IHooks
+    function beforeRemoveLiquidity(
+        address,
+        PoolKey calldata,
+        IPoolManager.ModifyLiquidityParams calldata,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        revert LiquidityNotAllowed();
+    }
+
+    /// @inheritdoc IHooks
+    /// @notice Handles the wrapping/unwrapping of tokens during a swap
+    /// @dev Takes input tokens from sender, performs wrap/unwrap, and settles output tokens
+    /// @dev No fees are charged on these operations
+    function beforeSwap(address, PoolKey calldata poolKey, IPoolManager.SwapParams calldata params, bytes calldata)
+        external
+        override
+        returns (bytes4 selector, BeforeSwapDelta swapDelta, uint24 lpFeeOverride)
+    {
+        bool isWrapping = _isWrapping(poolKey, params.zeroForOne);
+        bool isExactInput = params.amountSpecified > 0;
+        uint256 amount = isExactInput ? uint256(params.amountSpecified) : uint256(-params.amountSpecified);
+
+        if (isWrapping) {
+            if (isExactInput) {
+                // Take underlying tokens, wrap them, and settle wrapped tokens
+                poolManager.take(underlyingCurrency, address(this), amount);
+                uint256 wrappedAmount = deposit(amount);
+                _settle(wrapperCurrency, wrappedAmount);
+                swapDelta = toBeforeSwapDelta(-int128(int256(amount)), int128(int256(wrappedAmount)));
+            } else {
+                // For exact output, we need the exact amount of wrapped tokens requested
+                uint256 wrappedAmount = amount;
+                // Take the same amount of underlying (1:1 ratio)
+                poolManager.take(underlyingCurrency, address(this), amount);
+                deposit(amount);
+                _settle(wrapperCurrency, wrappedAmount);
+                swapDelta = toBeforeSwapDelta(int128(int256(amount)), -int128(int256(wrappedAmount)));
+            }
+        } else {
+            if (isExactInput) {
+                // Take wrapper tokens, unwrap them, and settle underlying tokens
+                poolManager.take(wrapperCurrency, address(this), amount);
+                uint256 unwrappedAmount = withdraw(amount);
+                _settle(underlyingCurrency, unwrappedAmount);
+                swapDelta = toBeforeSwapDelta(-int128(int256(amount)), int128(int256(unwrappedAmount)));
+            } else {
+                // For exact output, we need the exact amount of underlying tokens requested
+                uint256 unwrappedAmount = amount;
+                // Take the same amount of wrapped tokens (1:1 ratio)
+                poolManager.take(wrapperCurrency, address(this), amount);
+                withdraw(amount);
+                _settle(underlyingCurrency, unwrappedAmount);
+                swapDelta = toBeforeSwapDelta(int128(int256(amount)), -int128(int256(unwrappedAmount)));
+            }
+        }
+
+        return (IHooks.beforeSwap.selector, swapDelta, 0);
+    }
+
+    /// @notice Deposits underlying tokens to receive wrapper tokens
+    /// @param underlyingAmount The amount of underlying tokens to deposit
+    /// @return wrapperAmount The amount of wrapper tokens received
+    /// @dev Implementing contracts should handle the wrapping operation
+    ///      The base contract will handle settling tokens with the pool manager
+    function deposit(uint256 underlyingAmount) internal virtual returns (uint256 wrapperAmount);
+
+    /// @notice Withdraws wrapper tokens to receive underlying tokens
+    /// @param wrapperAmount The amount of wrapper tokens to withdraw
+    /// @return underlyingAmount The amount of underlying tokens received
+    /// @dev Implementing contracts should handle the unwrapping operation
+    ///      The base contract will handle settling tokens with the pool manager
+    function withdraw(uint256 wrapperAmount) internal virtual returns (uint256 underlyingAmount);
+
+    /// @notice Helper function to determine if the swap is wrapping underlying to wrapper tokens
+    /// @param poolKey The pool being used for the swap
+    /// @param zeroForOne The direction of the swap
+    /// @return True if swapping underlying to wrapper, false if unwrapping
+    function _isWrapping(PoolKey calldata poolKey, bool zeroForOne) internal view returns (bool) {
+        Currency inputCurrency = zeroForOne ? poolKey.currency0 : poolKey.currency1;
+        return inputCurrency == underlyingCurrency;
+    }
+
+    /// @notice Settles tokens with the pool manager after a wrap/unwrap operation
+    /// @param currency The currency being settled (wrapper or underlying)
+    /// @param amount The amount of tokens to settle
+    /// @dev Handles both native currency (ETH) and ERC20 tokens:
+    ///      - For native currency: Uses settle with value
+    ///      - For ERC20: Syncs pool state, transfers tokens, then settles
+    function _settle(Currency currency, uint256 amount) internal {
+        if (currency.isAddressZero()) {
+            poolManager.settle{value: amount}();
+        } else {
+            poolManager.sync(currency);
+            currency.transfer(address(poolManager), amount);
+            poolManager.settle();
+        }
+    }
+
+    // TODO: for exact output
+    // funcion precalculateSwap
+}

--- a/src/hooks/WETHHook.sol
+++ b/src/hooks/WETHHook.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {WETH} from "solmate/src/tokens/WETH.sol";
+import {BaseTokenWrapperHook} from "../base/hooks/BaseTokenWrapperHook.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+
+/// @title Wrapped Ether Hook
+/// @notice Hook for wrapping/unwrapping ETH in Uniswap V4 pools
+/// @dev Implements 1:1 wrapping/unwrapping of ETH to WETH
+contract WETHHook is BaseTokenWrapperHook {
+    /// @notice The WETH9 contract
+    WETH public immutable weth;
+
+    error WithdrawFailed();
+
+    /// @notice Creates a new WETH wrapper hook
+    /// @param _manager The Uniswap V4 pool manager
+    /// @param _weth The WETH9 contract address
+    constructor(IPoolManager _manager, address payable _weth)
+        BaseTokenWrapperHook(
+            _manager,
+            Currency.wrap(_weth), // wrapper token is WETH
+            CurrencyLibrary.ADDRESS_ZERO // underlying token is ETH (address(0))
+        )
+    {
+        weth = WETH(payable(_weth));
+    }
+
+    /// @inheritdoc BaseTokenWrapperHook
+    function deposit(uint256 underlyingAmount) internal override returns (uint256 wrapperAmount) {
+        weth.deposit{value: underlyingAmount}();
+        return underlyingAmount; // 1:1 ratio
+    }
+
+    /// @inheritdoc BaseTokenWrapperHook
+    function withdraw(uint256 wrapperAmount) internal override returns (uint256 underlyingAmount) {
+        weth.withdraw(wrapperAmount);
+        return wrapperAmount; // 1:1 ratio
+    }
+
+    /// @notice Required to receive ETH
+    receive() external payable {}
+}

--- a/test/V4Quoter.t.sol
+++ b/test/V4Quoter.t.sol
@@ -225,7 +225,7 @@ contract QuoterTest is Test, Deployers {
 
         vm.snapshotGasLastCall("Quoter_quoteExactInput_oneHop_startingInitialized");
 
-        assertGt(gasEstimate, 50000);
+        assertGt(gasEstimate, 40000);
         assertLt(gasEstimate, 400000);
         assertEq(amountOut, 198);
     }

--- a/test/hooks/WETHHook.t.sol
+++ b/test/hooks/WETHHook.t.sol
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
+import {CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {CustomRevert} from "@uniswap/v4-core/src/libraries/CustomRevert.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+
+import {BaseTokenWrapperHook} from "../../src/base/hooks/BaseTokenWrapperHook.sol";
+import {WETHHook} from "../../src/hooks/WETHHook.sol";
+
+contract WETHHookTest is Test, Deployers {
+    using PoolIdLibrary for PoolKey;
+    using CurrencyLibrary for Currency;
+
+    WETHHook public hook;
+    WETH public weth;
+    PoolKey poolKey;
+    uint160 initSqrtPriceX96;
+
+    // Users
+    address payable alice = payable(makeAddr("alice"));
+    address payable bob = payable(makeAddr("bob"));
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        weth = new WETH();
+
+        // Deploy WETH hook
+        hook = WETHHook(
+            payable(
+                address(
+                    uint160(
+                        type(uint160).max & clearAllHookPermissionsMask | Hooks.BEFORE_SWAP_FLAG
+                            | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                            | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG | Hooks.BEFORE_INITIALIZE_FLAG
+                    )
+                )
+            )
+        );
+        deployCodeTo("./foundry-out/WETHHook.sol/WETHHook.default.json", abi.encode(manager, weth), address(hook));
+
+        // Create pool key for ETH/WETH
+        poolKey = PoolKey({
+            currency0: CurrencyLibrary.ADDRESS_ZERO,
+            currency1: Currency.wrap(address(weth)),
+            fee: 0, // Must be 0 for wrapper pools
+            tickSpacing: 60,
+            hooks: IHooks(address(hook))
+        });
+
+        // Initialize pool at 1:1 price
+        initSqrtPriceX96 = uint160(TickMath.getSqrtPriceAtTick(0));
+        manager.initialize(poolKey, initSqrtPriceX96);
+
+        // Give users some ETH
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+        vm.deal(address(this), 200 ether);
+        (bool success,) = address(weth).call{value: 200 ether}("");
+        require(success, "WETH transfer failed");
+        weth.transfer(alice, 100 ether);
+        weth.transfer(bob, 100 ether);
+        _addUnrelatedLiquidity();
+    }
+
+    function test_initialization() public view {
+        assertEq(address(hook.weth()), address(weth));
+        assertEq(Currency.unwrap(hook.wrapperCurrency()), address(weth));
+        assertEq(Currency.unwrap(hook.underlyingCurrency()), address(0));
+    }
+
+    function test_wrapETH() public {
+        uint256 wrapAmount = 1 ether;
+
+        uint256 aliceEthBalanceBefore = alice.balance;
+        uint256 aliceWethBalanceBefore = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceBefore = address(manager).balance;
+        uint256 managerWethBalanceBefore = weth.balanceOf(address(manager));
+
+        vm.startPrank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0), address(hook), wrapAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(manager), address(alice), wrapAmount);
+
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
+        swapRouter.swap{value: wrapAmount}(
+            poolKey,
+            IPoolManager.SwapParams({
+                zeroForOne: true, // ETH (0) to WETH (1)
+                amountSpecified: int256(wrapAmount),
+                sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+            }),
+            testSettings,
+            ""
+        );
+
+        vm.stopPrank();
+
+        uint256 aliceEthBalanceAfter = alice.balance;
+        uint256 aliceWethBalanceAfter = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceAfter = address(manager).balance;
+        uint256 managerWethBalanceAfter = weth.balanceOf(address(manager));
+        assertEq(aliceEthBalanceBefore - aliceEthBalanceAfter, wrapAmount);
+        assertEq(aliceWethBalanceAfter - aliceWethBalanceBefore, wrapAmount);
+        assertEq(managerEthBalanceBefore, managerEthBalanceAfter);
+        assertEq(managerWethBalanceBefore, managerWethBalanceAfter);
+    }
+
+    function test_unwrapWETH() public {
+        uint256 unwrapAmount = 1 ether;
+
+        // Directly deposit WETH to the manager
+        uint256 aliceEthBalanceBefore = alice.balance;
+        uint256 aliceWethBalanceBefore = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceBefore = address(manager).balance;
+        uint256 managerWethBalanceBefore = weth.balanceOf(address(manager));
+
+        vm.startPrank(alice);
+        weth.approve(address(swapRouter), type(uint256).max);
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
+
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(hook), address(0), unwrapAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(alice), address(manager), unwrapAmount);
+
+        swapRouter.swap(
+            poolKey,
+            IPoolManager.SwapParams({
+                zeroForOne: false, // WETH (1) to ETH (0)
+                amountSpecified: int256(unwrapAmount),
+                sqrtPriceLimitX96: TickMath.MAX_SQRT_PRICE - 1
+            }),
+            testSettings,
+            ""
+        );
+
+        vm.stopPrank();
+
+        uint256 aliceEthBalanceAfter = alice.balance;
+        uint256 aliceWethBalanceAfter = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceAfter = address(manager).balance;
+        uint256 managerWethBalanceAfter = weth.balanceOf(address(manager));
+        assertEq(aliceEthBalanceAfter - aliceEthBalanceBefore, unwrapAmount);
+        assertEq(aliceWethBalanceBefore - aliceWethBalanceAfter, unwrapAmount);
+        assertEq(managerEthBalanceBefore, managerEthBalanceAfter);
+        assertEq(managerWethBalanceBefore, managerWethBalanceAfter);
+    }
+
+    function test_wrapETH_exactOut() public {
+        uint256 wrapAmount = 1 ether;
+
+        uint256 aliceEthBalanceBefore = alice.balance;
+        uint256 aliceWethBalanceBefore = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceBefore = address(manager).balance;
+        uint256 managerWethBalanceBefore = weth.balanceOf(address(manager));
+
+        vm.startPrank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0), address(hook), wrapAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(manager), address(alice), wrapAmount);
+
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
+        swapRouter.swap{value: wrapAmount}(
+            poolKey,
+            IPoolManager.SwapParams({
+                zeroForOne: true, // ETH (0) to WETH (1)
+                amountSpecified: -int256(wrapAmount), // Negative for exact output
+                sqrtPriceLimitX96: TickMath.MIN_SQRT_PRICE + 1
+            }),
+            testSettings,
+            ""
+        );
+
+        vm.stopPrank();
+
+        uint256 aliceEthBalanceAfter = alice.balance;
+        uint256 aliceWethBalanceAfter = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceAfter = address(manager).balance;
+        uint256 managerWethBalanceAfter = weth.balanceOf(address(manager));
+        assertEq(aliceEthBalanceBefore - aliceEthBalanceAfter, wrapAmount);
+        assertEq(aliceWethBalanceAfter - aliceWethBalanceBefore, wrapAmount);
+        assertEq(managerEthBalanceBefore, managerEthBalanceAfter);
+        assertEq(managerWethBalanceBefore, managerWethBalanceAfter);
+    }
+
+    function test_unwrapWETH_exactOut() public {
+        uint256 unwrapAmount = 1 ether;
+
+        uint256 aliceEthBalanceBefore = alice.balance;
+        uint256 aliceWethBalanceBefore = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceBefore = address(manager).balance;
+        uint256 managerWethBalanceBefore = weth.balanceOf(address(manager));
+
+        vm.startPrank(alice);
+        weth.approve(address(swapRouter), type(uint256).max);
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
+
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(hook), address(0), unwrapAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(alice), address(manager), unwrapAmount);
+
+        swapRouter.swap(
+            poolKey,
+            IPoolManager.SwapParams({
+                zeroForOne: false, // WETH (1) to ETH (0)
+                amountSpecified: -int256(unwrapAmount), // Negative for exact output
+                sqrtPriceLimitX96: TickMath.MAX_SQRT_PRICE - 1
+            }),
+            testSettings,
+            ""
+        );
+
+        vm.stopPrank();
+
+        uint256 aliceEthBalanceAfter = alice.balance;
+        uint256 aliceWethBalanceAfter = weth.balanceOf(address(alice));
+        uint256 managerEthBalanceAfter = address(manager).balance;
+        uint256 managerWethBalanceAfter = weth.balanceOf(address(manager));
+        assertEq(aliceEthBalanceAfter - aliceEthBalanceBefore, unwrapAmount);
+        assertEq(aliceWethBalanceBefore - aliceWethBalanceAfter, unwrapAmount);
+        assertEq(managerEthBalanceBefore, managerEthBalanceAfter);
+        assertEq(managerWethBalanceBefore, managerWethBalanceAfter);
+    }
+
+    function test_revertAddLiquidity() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(hook),
+                IHooks.beforeAddLiquidity.selector,
+                abi.encodeWithSelector(BaseTokenWrapperHook.LiquidityNotAllowed.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+
+        modifyLiquidityRouter.modifyLiquidity(
+            poolKey,
+            IPoolManager.ModifyLiquidityParams({
+                tickLower: -120,
+                tickUpper: 120,
+                liquidityDelta: 1000e18,
+                salt: bytes32(0)
+            }),
+            ""
+        );
+    }
+
+    function test_revertRemoveLiquidity() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(hook),
+                IHooks.beforeRemoveLiquidity.selector,
+                abi.encodeWithSelector(BaseTokenWrapperHook.LiquidityNotAllowed.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+
+        modifyLiquidityRouter.modifyLiquidity(
+            poolKey,
+            IPoolManager.ModifyLiquidityParams({
+                tickLower: -120,
+                tickUpper: 120,
+                liquidityDelta: -1000e18,
+                salt: bytes32(0)
+            }),
+            ""
+        );
+    }
+
+    function test_revertInvalidPoolInitialization() public {
+        // Try to initialize with non-zero fee
+        PoolKey memory invalidKey = PoolKey({
+            currency0: CurrencyLibrary.ADDRESS_ZERO,
+            currency1: Currency.wrap(address(weth)),
+            fee: 3000, // Invalid: must be 0
+            tickSpacing: 60,
+            hooks: IHooks(address(hook))
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(hook),
+                IHooks.beforeInitialize.selector,
+                abi.encodeWithSelector(BaseTokenWrapperHook.InvalidPoolFee.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+        manager.initialize(invalidKey, initSqrtPriceX96);
+
+        // Try to initialize with wrong token pair
+        MockERC20 randomToken = new MockERC20("Random", "RND", 18);
+        // sort tokens
+        (Currency currency0, Currency currency1) = address(randomToken) < address(weth)
+            ? (Currency.wrap(address(randomToken)), Currency.wrap(address(weth)))
+            : (Currency.wrap(address(weth)), Currency.wrap(address(randomToken)));
+        invalidKey =
+            PoolKey({currency0: currency0, currency1: currency1, fee: 0, tickSpacing: 60, hooks: IHooks(address(hook))});
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(hook),
+                IHooks.beforeInitialize.selector,
+                abi.encodeWithSelector(BaseTokenWrapperHook.InvalidPoolToken.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+        manager.initialize(invalidKey, initSqrtPriceX96);
+    }
+
+    // add some unrelated ETH and WETH liquidity that the hook can use
+    function _addUnrelatedLiquidity() internal {
+        // Create a hookless pool key for ETH/WETH
+        PoolKey memory unrelatedPoolKey = PoolKey({
+            currency0: CurrencyLibrary.ADDRESS_ZERO,
+            currency1: Currency.wrap(address(weth)),
+            fee: 100, // Must be 0 for wrapper pools
+            tickSpacing: 60,
+            hooks: IHooks(address(0))
+        });
+
+        manager.initialize(unrelatedPoolKey, uint160(TickMath.getSqrtPriceAtTick(0)));
+
+        vm.deal(address(this), 100 ether);
+        deal(address(weth), address(this), 100 ether);
+        weth.approve(address(modifyLiquidityRouter), type(uint256).max);
+        modifyLiquidityRouter.modifyLiquidity{value: 100 ether}(
+            unrelatedPoolKey,
+            IPoolManager.ModifyLiquidityParams({
+                tickLower: -120,
+                tickUpper: 120,
+                liquidityDelta: 1000e18,
+                salt: bytes32(0)
+            }),
+            ""
+        );
+    }
+}


### PR DESCRIPTION
# WETH wrapper adapter Implementation for Uniswap v4

## Overview
This PR introduces a WETH (Wrapped Ether) hook for Uniswap v4, enabling native ETH to WETH conversions directly through v4 pools. The implementation provides a convenient gas-efficient way to wrap and unwrap ETH within a v4 lock / route.