### PR TITLE
Update BaseHook.sol import path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you are building hooks, it may be useful to inherit from the `BaseHook` contr
 
 ```solidity
 
-import {BaseHook} from 'v4-periphery/src/base/hooks/BaseHook.sol';
+import {BaseHook} from 'v4-periphery/src/utils/BaseHook.sol';
 
 contract CoolHook is BaseHook {
     // Override the hook callbacks you want on your hook


### PR DESCRIPTION
## Related Issue

Following this PR: https://github.com/Uniswap/v4-periphery/pull/438 the `BaseHook.sol` file is in a new folder, the README.md became obsolete. This PR fixes it.

## Description of changes

Fix import of `BaseHook.sol` in README.md