### PR TITLE
Add `msgSender()` to V4Quoter

### DIFF
--- a/snapshots/QuoterTest.json
+++ b/snapshots/QuoterTest.json
@@ -1,15 +1,15 @@
 {
-  "Quoter_exactInputSingle_oneForZero_multiplePositions": "145902",
-  "Quoter_exactInputSingle_zeroForOne_multiplePositions": "152117",
-  "Quoter_exactOutputSingle_oneForZero": "79267",
-  "Quoter_exactOutputSingle_zeroForOne": "84512",
-  "Quoter_quoteExactInput_oneHop_1TickLoaded": "122728",
-  "Quoter_quoteExactInput_oneHop_initializedAfter": "147363",
-  "Quoter_quoteExactInput_oneHop_startingInitialized": "80638",
-  "Quoter_quoteExactInput_twoHops": "204942",
-  "Quoter_quoteExactOutput_oneHop_1TickLoaded": "122224",
-  "Quoter_quoteExactOutput_oneHop_2TicksLoaded": "152879",
-  "Quoter_quoteExactOutput_oneHop_initializedAfter": "122251",
-  "Quoter_quoteExactOutput_oneHop_startingInitialized": "98545",
-  "Quoter_quoteExactOutput_twoHops": "204670"
+  "Quoter_exactInputSingle_oneForZero_multiplePositions": "146134",
+  "Quoter_exactInputSingle_zeroForOne_multiplePositions": "152349",
+  "Quoter_exactOutputSingle_oneForZero": "79477",
+  "Quoter_exactOutputSingle_zeroForOne": "84722",
+  "Quoter_quoteExactInput_oneHop_1TickLoaded": "122938",
+  "Quoter_quoteExactInput_oneHop_initializedAfter": "147573",
+  "Quoter_quoteExactInput_oneHop_startingInitialized": "80848",
+  "Quoter_quoteExactInput_twoHops": "205152",
+  "Quoter_quoteExactOutput_oneHop_1TickLoaded": "122434",
+  "Quoter_quoteExactOutput_oneHop_2TicksLoaded": "153089",
+  "Quoter_quoteExactOutput_oneHop_initializedAfter": "122461",
+  "Quoter_quoteExactOutput_oneHop_startingInitialized": "98755",
+  "Quoter_quoteExactOutput_twoHops": "204880"
 }

--- a/src/base/BaseActionsRouter.sol
+++ b/src/base/BaseActionsRouter.sol
@@ -5,10 +5,11 @@ import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {SafeCallback} from "./SafeCallback.sol";
 import {CalldataDecoder} from "../libraries/CalldataDecoder.sol";
 import {ActionConstants} from "../libraries/ActionConstants.sol";
+import {IMsgSender} from "../interfaces/IMsgSender.sol";
 
 /// @notice Abstract contract for performing a combination of actions on Uniswap v4.
 /// @dev Suggested uint256 action values are defined in Actions.sol, however any definition can be used
-abstract contract BaseActionsRouter is SafeCallback {
+abstract contract BaseActionsRouter is IMsgSender, SafeCallback {
     using CalldataDecoder for bytes;
 
     /// @notice emitted when different numbers of parameters and actions are provided

--- a/src/interfaces/IMsgSender.sol
+++ b/src/interfaces/IMsgSender.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IMsgSender
+/// @notice Interface for contracts that expose the original msg.sender
+interface IMsgSender {
+    function msgSender() external view returns (address);
+}

--- a/src/interfaces/IMsgSender.sol
+++ b/src/interfaces/IMsgSender.sol
@@ -7,7 +7,7 @@ interface IMsgSender {
     /// @notice Returns the address of the original caller (msg.sender)
     /// @dev Uniswap v4 periphery contracts implement a callback pattern which lose
     /// the original msg.sender caller context. This view function provides a way for
-    /// integrating contracts (hooks) to access the original caller address.
+    /// integrating contracts (e.g. hooks) to access the original caller address.
     /// @return The address of the original caller
     function msgSender() external view returns (address);
 }

--- a/src/interfaces/IMsgSender.sol
+++ b/src/interfaces/IMsgSender.sol
@@ -2,7 +2,12 @@
 pragma solidity ^0.8.0;
 
 /// @title IMsgSender
-/// @notice Interface for contracts that expose the original msg.sender
+/// @notice Interface for contracts that expose the original caller
 interface IMsgSender {
+    /// @notice Returns the address of the original caller (msg.sender)
+    /// @dev Uniswap v4 periphery contracts implement a callback pattern which lose
+    /// the original msg.sender caller context. This view function provides a way for
+    /// integrating contracts (hooks) to access the original caller address.
+    /// @return The address of the original caller
     function msgSender() external view returns (address);
 }

--- a/src/interfaces/IV4Quoter.sol
+++ b/src/interfaces/IV4Quoter.sol
@@ -5,10 +5,11 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PathKey} from "../libraries/PathKey.sol";
 import {IImmutableState} from "./IImmutableState.sol";
+import {IMsgSender} from "./IMsgSender.sol";
 
 /// @title IV4Quoter
 /// @notice Interface for the V4Quoter contract
-interface IV4Quoter is IImmutableState {
+interface IV4Quoter is IImmutableState, IMsgSender {
     struct QuoteExactSingleParams {
         PoolKey poolKey;
         bool zeroForOne;

--- a/src/lens/V4Quoter.sol
+++ b/src/lens/V4Quoter.sol
@@ -10,6 +10,7 @@ import {IV4Quoter} from "../interfaces/IV4Quoter.sol";
 import {PathKey} from "../libraries/PathKey.sol";
 import {QuoterRevert} from "../libraries/QuoterRevert.sol";
 import {BaseV4Quoter} from "../base/BaseV4Quoter.sol";
+import {Locker} from "../libraries/Locker.sol";
 
 /// @title V4Quoter
 /// @notice Supports quoting the delta amounts for exact input or exact output swaps.
@@ -23,6 +24,7 @@ contract V4Quoter is IV4Quoter, BaseV4Quoter {
     /// @inheritdoc IV4Quoter
     function quoteExactInputSingle(QuoteExactSingleParams memory params)
         external
+        setMsgSender
         returns (uint256 amountOut, uint256 gasEstimate)
     {
         uint256 gasBefore = gasleft();
@@ -37,6 +39,7 @@ contract V4Quoter is IV4Quoter, BaseV4Quoter {
     /// @inheritdoc IV4Quoter
     function quoteExactInput(QuoteExactParams memory params)
         external
+        setMsgSender
         returns (uint256 amountOut, uint256 gasEstimate)
     {
         uint256 gasBefore = gasleft();
@@ -51,6 +54,7 @@ contract V4Quoter is IV4Quoter, BaseV4Quoter {
     /// @inheritdoc IV4Quoter
     function quoteExactOutputSingle(QuoteExactSingleParams memory params)
         external
+        setMsgSender
         returns (uint256 amountIn, uint256 gasEstimate)
     {
         uint256 gasBefore = gasleft();
@@ -65,6 +69,7 @@ contract V4Quoter is IV4Quoter, BaseV4Quoter {
     /// @inheritdoc IV4Quoter
     function quoteExactOutput(QuoteExactParams memory params)
         external
+        setMsgSender
         returns (uint256 amountIn, uint256 gasEstimate)
     {
         uint256 gasBefore = gasleft();
@@ -137,5 +142,16 @@ contract V4Quoter is IV4Quoter, BaseV4Quoter {
         // the input delta of a swap is negative so we must flip it
         uint256 amountIn = params.zeroForOne ? uint128(-swapDelta.amount0()) : uint128(-swapDelta.amount1());
         amountIn.revertQuote();
+    }
+
+    function msgSender() external view returns (address) {
+        // despite using the Locker library, V4Quoter does not have a reentrancy lock
+        return Locker.get();
+    }
+
+    modifier setMsgSender() {
+        Locker.set(msg.sender);
+        _; // execute the function
+        Locker.set(address(0)); // reset the locker
     }
 }

--- a/test/mocks/MockMsgSenderHook.sol
+++ b/test/mocks/MockMsgSenderHook.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {BaseTestHooks} from "@uniswap/v4-core/src/test/BaseTestHooks.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {IMsgSender} from "../../src/interfaces/IMsgSender.sol";
+
+contract MockMsgSenderHook is BaseTestHooks {
+    event BeforeSwapMsgSender(address msgSender);
+    event AfterSwapMsgSender(address msgSender);
+
+    function beforeSwap(address periphery, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
+        external
+        override
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        emit BeforeSwapMsgSender(IMsgSender(periphery).msgSender());
+        return (BaseTestHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+    }
+
+    function afterSwap(
+        address periphery,
+        PoolKey calldata,
+        IPoolManager.SwapParams calldata,
+        BalanceDelta,
+        bytes calldata
+    ) external override returns (bytes4, int128) {
+        emit AfterSwapMsgSender(IMsgSender(periphery).msgSender());
+        return (BaseTestHooks.afterSwap.selector, 0);
+    }
+}


### PR DESCRIPTION
## Related Issue

There's a growing subset of hooks which read the "wallet" of the swapper (or position creator). These hooks normally use the `msgSender()` view function exposed by Universal Router and PosM, and can facilitate transactions without failure

However, `msgSender()` was not available on V4Quoter, causing reverts/failures when using the quoter against a hook'd pool reading `msgSender()`


## Description of changes

Add `msgSender() external view returns (address)` to V4Quoter.sol via transient storage

Add `IMsgSender` and added inheritance to IV4Quoter, BaseActionsRouter