### PR TITLE
fix: OpenZeppelin token wrapper audit

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:

--- a/src/base/hooks/BaseTokenWrapperHook.sol
+++ b/src/base/hooks/BaseTokenWrapperHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import {
     toBeforeSwapDelta, BeforeSwapDelta, BeforeSwapDeltaLibrary

--- a/src/base/hooks/BaseTokenWrapperHook.sol
+++ b/src/base/hooks/BaseTokenWrapperHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.26;
 
 import {
     toBeforeSwapDelta, BeforeSwapDelta, BeforeSwapDeltaLibrary
@@ -114,7 +114,7 @@ abstract contract BaseTokenWrapperHook is BaseHook, DeltaResolver {
     function _beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata params, bytes calldata)
         internal
         override
-        returns (bytes4 selector, BeforeSwapDelta swapDelta, uint24 lpFeeOverride)
+        returns (bytes4, BeforeSwapDelta, uint24)
     {
         bool isExactInput = params.amountSpecified < 0;
 

--- a/src/base/hooks/BaseTokenWrapperHook.sol
+++ b/src/base/hooks/BaseTokenWrapperHook.sol
@@ -114,7 +114,7 @@ abstract contract BaseTokenWrapperHook is BaseHook, DeltaResolver {
     function _beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata params, bytes calldata)
         internal
         override
-        returns (bytes4, BeforeSwapDelta, uint24)
+        returns (bytes4, BeforeSwapDelta swapDelta, uint24)
     {
         bool isExactInput = params.amountSpecified < 0;
 

--- a/src/hooks/WETHHook.sol
+++ b/src/hooks/WETHHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.26;
 
 import {WETH} from "solmate/src/tokens/WETH.sol";
 import {BaseTokenWrapperHook} from "../base/hooks/BaseTokenWrapperHook.sol";

--- a/src/hooks/WstETHHook.sol
+++ b/src/hooks/WstETHHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.26;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";

--- a/src/utils/BaseHook.sol
+++ b/src/utils/BaseHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";

--- a/src/utils/BaseHook.sol
+++ b/src/utils/BaseHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.26;
 
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
@@ -20,6 +20,7 @@ abstract contract BaseHook is IHooks, ImmutableState {
 
     /// @notice Returns a struct of permissions to signal which hook functions are to be implemented
     /// @dev Used at deployment to validate the address correctly represents the expected permissions
+    /// @return Permissions struct
     function getHookPermissions() public pure virtual returns (Hooks.Permissions memory);
 
     /// @notice Validates the deployed hook address agrees with the expected permissions of the hook


### PR DESCRIPTION
L01 - fix basehook docstring
L02 - fix floating pragmas
N01 - remove unused named returns

## Related Issue
Which issue does this pull request resolve?

## Description of changes