### PR TITLE
Wrapped token tests

### DIFF
--- a/src/hooks/permissionedPools/BaseAllowListChecker.sol
+++ b/src/hooks/permissionedPools/BaseAllowListChecker.sol
@@ -5,7 +5,7 @@ import {IAllowlistChecker, IERC165} from "./interfaces/IAllowlistChecker.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 abstract contract BaseAllowlistChecker is IAllowlistChecker, ERC165 {
-    function checkAllowList(address account) public view virtual returns (bool);
+    function checkAllowlist(address account) public view virtual returns (bool);
 
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
         return interfaceId == type(IAllowlistChecker).interfaceId || super.supportsInterface(interfaceId);

--- a/src/hooks/permissionedPools/WrappedPermissionedToken.sol
+++ b/src/hooks/permissionedPools/WrappedPermissionedToken.sol
@@ -51,7 +51,7 @@ contract WrappedPermissionedToken is ERC20, Ownable2Step, IWrappedPermissionedTo
 
     /// @inheritdoc IWrappedPermissionedToken
     function isAllowed(address account) public view returns (bool) {
-        return allowListChecker.checkAllowList(account);
+        return allowListChecker.checkAllowlist(account);
     }
 
     function _updateAllowListChecker(IAllowlistChecker newAllowListChecker) internal {
@@ -105,5 +105,9 @@ contract WrappedPermissionedToken is ERC20, Ownable2Step, IWrappedPermissionedTo
 
     function _getSymbol(IERC20 permissionedToken) private view returns (string memory) {
         return string.concat("uw", ERC20(address(permissionedToken)).symbol());
+    }
+
+    function decimals() public view override returns (uint8) {
+        return ERC20(address(PERMISSIONED_TOKEN)).decimals();
     }
 }

--- a/src/hooks/permissionedPools/WrappedPermissionedTokenFactory.sol
+++ b/src/hooks/permissionedPools/WrappedPermissionedTokenFactory.sol
@@ -35,7 +35,7 @@ contract WrappedPermissionedTokenFactory is IWrappedPermissionedTokenFactory {
         IERC20 permissionedToken = IERC20(permissionedTokenOf[wrappedToken]);
         if (address(permissionedToken) == address(0)) revert WrappedTokenNotFound(wrappedToken);
         if (verifiedPermissionedTokenOf[wrappedToken] != address(0)) revert WrappedTokenAlreadyVerified(wrappedToken);
-        if (permissionedToken.balanceOf(wrappedToken) != 0) revert WrappedTokenNotVerified(wrappedToken);
+        if (permissionedToken.balanceOf(wrappedToken) == 0) revert WrappedTokenNotVerified(wrappedToken);
         verifiedPermissionedTokenOf[wrappedToken] = address(permissionedToken);
         emit WrappedTokenVerified(wrappedToken, address(permissionedToken));
     }

--- a/src/hooks/permissionedPools/interfaces/IAllowlistChecker.sol
+++ b/src/hooks/permissionedPools/interfaces/IAllowlistChecker.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.0;
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 interface IAllowlistChecker is IERC165 {
-    function checkAllowList(address account) external view returns (bool);
+    function checkAllowlist(address account) external view returns (bool);
 }

--- a/src/hooks/permissionedPools/interfaces/IWrappedPermissionedTokenFactory.sol
+++ b/src/hooks/permissionedPools/interfaces/IWrappedPermissionedTokenFactory.sol
@@ -45,4 +45,8 @@ interface IWrappedPermissionedTokenFactory {
     /// @return permissionedToken The verified permissioned token
     /// @dev A reverse lookup of the permissioned token is required, otherwise anyone could create a wrapped token for a non-permissioned token
     function verifiedPermissionedTokenOf(address wrappedToken) external view returns (address permissionedToken);
+
+    /// @notice Returns the v4 pool manager
+    /// @return poolManager The v4 pool manager
+    function POOL_MANAGER() external view returns (address poolManager);
 }

--- a/test/hooks/permissionedPools/PermissionedPoolsBase.sol
+++ b/test/hooks/permissionedPools/PermissionedPoolsBase.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {IAllowlistChecker, IERC165} from "src/hooks/permissionedPools/interfaces/IAllowlistChecker.sol";
+import {BaseAllowlistChecker} from "../../../src/hooks/permissionedPools/BaseAllowListChecker.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockToken is ERC20 {
@@ -36,19 +36,15 @@ contract MockPermissionedToken is MockToken {
     }
 }
 
-contract MockAllowlistChecker is IAllowlistChecker {
+contract MockAllowlistChecker is BaseAllowlistChecker {
     MockPermissionedToken public token;
 
     constructor(MockPermissionedToken token_) {
         token = token_;
     }
 
-    function checkAllowlist(address account) public view returns (bool) {
+    function checkAllowlist(address account) public view override returns (bool) {
         return token.isAllowed(account);
-    }
-
-    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
-        return interfaceId == type(IAllowlistChecker).interfaceId || interfaceId == type(IERC165).interfaceId;
     }
 }
 

--- a/test/hooks/permissionedPools/PermissionedPoolsBase.sol
+++ b/test/hooks/permissionedPools/PermissionedPoolsBase.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {IAllowlistChecker, IERC165} from "src/hooks/permissionedPools/interfaces/IAllowlistChecker.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("MockToken", "MT") {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) public {
+        _burn(from, amount);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+}
+
+contract MockPermissionedToken is MockToken {
+    mapping(address account => bool allowed) public isAllowed;
+
+    error Unauthorized();
+
+    function setAllowlist(address account, bool allowed) public {
+        isAllowed[account] = allowed;
+    }
+
+    function _update(address from, address to, uint256 amount) internal override {
+        if (!isAllowed[to]) revert Unauthorized();
+        super._update(from, to, amount);
+    }
+}
+
+contract MockAllowlistChecker is IAllowlistChecker {
+    MockPermissionedToken public token;
+
+    constructor(MockPermissionedToken token_) {
+        token = token_;
+    }
+
+    function checkAllowlist(address account) public view returns (bool) {
+        return token.isAllowed(account);
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(IAllowlistChecker).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+}
+
+contract PermissionedPoolsBase is Test {
+    MockPermissionedToken public permissionedToken;
+    MockAllowlistChecker public allowlistChecker;
+
+    function setUp() public virtual {
+        permissionedToken = new MockPermissionedToken();
+        allowlistChecker = new MockAllowlistChecker(permissionedToken);
+    }
+}

--- a/test/hooks/permissionedPools/WrappedPermissionedToken.t.sol
+++ b/test/hooks/permissionedPools/WrappedPermissionedToken.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {
     IWrappedPermissionedToken,
     IAllowlistChecker
-} from "src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol";
+} from "../../../src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol";
 import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {PermissionedPoolsBase, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
@@ -124,7 +124,9 @@ contract WrappedPermissionedTokenTest is PermissionedPoolsBase {
     }
 
     function test_UnwrapOnPoolManagerTransfer(uint256 mintAmount, uint256 transferAmount, address recipient) public {
-        vm.assume(recipient != address(0));
+        vm.assume(
+            recipient != address(0) && recipient != mockPoolManager && recipient != address(wrappedPermissionedToken)
+        );
         assertEq(permissionedToken.balanceOf(recipient), 0);
         permissionedToken.setAllowlist(recipient, true);
         transferAmount = bound(transferAmount, 0, mintAmount);

--- a/test/hooks/permissionedPools/WrappedPermissionedToken.t.sol
+++ b/test/hooks/permissionedPools/WrappedPermissionedToken.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {
+    IWrappedPermissionedToken,
+    IAllowlistChecker
+} from "src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol";
+import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {PermissionedPoolsBase, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract WrappedPermissionedTokenTest is PermissionedPoolsBase {
+    IWrappedPermissionedToken public wrappedPermissionedToken;
+    address public mockPoolManager;
+    address public owner;
+
+    function setUp() public override {
+        super.setUp();
+        mockPoolManager = makeAddr("mockPoolManager");
+        owner = makeAddr("owner");
+        bytes memory args = abi.encode(permissionedToken, mockPoolManager, owner, allowlistChecker);
+        bytes memory initcode =
+            abi.encodePacked(vm.getCode("WrappedPermissionedToken.sol:WrappedPermissionedToken"), args);
+        assembly {
+            sstore(wrappedPermissionedToken.slot, create(0, add(initcode, 0x20), mload(initcode)))
+        }
+        permissionedToken.setAllowlist(address(wrappedPermissionedToken), true);
+        vm.prank(owner);
+        wrappedPermissionedToken.updateAllowedWrapper(address(this), true);
+    }
+
+    function test_InitialState() public view {
+        assertEq(IERC20Metadata(address(wrappedPermissionedToken)).name(), "Uniswap v4 Wrapped MockToken");
+        assertEq(IERC20Metadata(address(wrappedPermissionedToken)).symbol(), "uwMT");
+        assertEq(IERC20Metadata(address(wrappedPermissionedToken)).decimals(), permissionedToken.decimals());
+        assertEq(wrappedPermissionedToken.totalSupply(), 0);
+        assertEq(wrappedPermissionedToken.balanceOf(mockPoolManager), 0);
+        assertEq(address(wrappedPermissionedToken.allowListChecker()), address(allowlistChecker));
+        assertEq(wrappedPermissionedToken.POOL_MANAGER(), mockPoolManager);
+        assertEq(address(wrappedPermissionedToken.PERMISSIONED_TOKEN()), address(permissionedToken));
+    }
+
+    function testRevert_WhenNotOwner(address account) public {
+        vm.assume(account != owner);
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, account));
+        wrappedPermissionedToken.updateAllowedWrapper(account, true);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, account));
+        wrappedPermissionedToken.updateAllowListChecker(allowlistChecker);
+        vm.stopPrank();
+    }
+
+    function testRevert_WhenNotAllowedWrapper(address wrapper) public {
+        vm.assume(wrapper != address(this));
+        assertFalse(wrappedPermissionedToken.allowedWrappers(wrapper));
+        vm.prank(wrapper);
+        vm.expectRevert(abi.encodeWithSelector(IWrappedPermissionedToken.UnauthorizedWrapper.selector, wrapper));
+        wrappedPermissionedToken.wrapToPoolManager(100);
+    }
+
+    function testRevert_WhenInsufficientBalance(uint256 amount, uint256 transferAmount) public {
+        vm.assume(amount != 0);
+        transferAmount = bound(amount, 0, amount - 1);
+        permissionedToken.mint(address(wrappedPermissionedToken), transferAmount);
+        vm.expectRevert(
+            abi.encodeWithSelector(IWrappedPermissionedToken.InsufficientBalance.selector, amount, transferAmount)
+        );
+        wrappedPermissionedToken.wrapToPoolManager(amount);
+    }
+
+    function test_WrapToPoolManager(uint256 amount, uint256 actualAmount) public {
+        actualAmount = bound(amount, amount, type(uint256).max);
+        permissionedToken.mint(address(wrappedPermissionedToken), actualAmount);
+        vm.expectEmit(true, true, true, true);
+        emit IERC20.Transfer(address(0), mockPoolManager, amount);
+        wrappedPermissionedToken.wrapToPoolManager(amount);
+        assertEq(wrappedPermissionedToken.balanceOf(mockPoolManager), amount);
+        assertEq(permissionedToken.balanceOf(mockPoolManager), actualAmount - amount);
+    }
+
+    function test_UpdateAllowedWrapper(address wrapper, bool allowed) public {
+        vm.assume(wrapper != address(this));
+        assertFalse(wrappedPermissionedToken.allowedWrappers(wrapper));
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit IWrappedPermissionedToken.AllowedWrapperUpdated(wrapper, allowed);
+        wrappedPermissionedToken.updateAllowedWrapper(wrapper, allowed);
+        assertEq(wrappedPermissionedToken.allowedWrappers(wrapper), allowed);
+    }
+
+    function testRevert_WhenNotSupportedInterfaceEOA(IAllowlistChecker newAllowListCheckerEOA) public {
+        vm.assume(newAllowListCheckerEOA != allowlistChecker);
+        vm.prank(owner);
+        vm.expectRevert(); // expect revert without data
+        wrappedPermissionedToken.updateAllowListChecker(newAllowListCheckerEOA);
+    }
+
+    function testRevert_WhenNotSupportedInterfaceContract() public {
+        IAllowlistChecker newAllowListCheckerContract = new ImproperAllowlistChecker();
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWrappedPermissionedToken.InvalidAllowListChecker.selector, newAllowListCheckerContract
+            )
+        );
+        wrappedPermissionedToken.updateAllowListChecker(newAllowListCheckerContract);
+    }
+
+    function test_UpdateAllowListChecker() public {
+        IAllowlistChecker newAllowListChecker = new MockAllowlistChecker(permissionedToken);
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit IWrappedPermissionedToken.AllowListCheckerUpdated(newAllowListChecker);
+        wrappedPermissionedToken.updateAllowListChecker(newAllowListChecker);
+        assertEq(address(wrappedPermissionedToken.allowListChecker()), address(newAllowListChecker));
+    }
+
+    function testRevert_WhenInvalidTransfer(address from, address to) public {
+        vm.assume(from != address(0) && from != mockPoolManager);
+        vm.assume(to != address(0) && to != mockPoolManager);
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IWrappedPermissionedToken.InvalidTransfer.selector, from, to));
+        wrappedPermissionedToken.transfer(to, 0);
+    }
+
+    function test_UnwrapOnPoolManagerTransfer(uint256 mintAmount, uint256 transferAmount, address recipient) public {
+        vm.assume(recipient != address(0));
+        assertEq(permissionedToken.balanceOf(recipient), 0);
+        permissionedToken.setAllowlist(recipient, true);
+        transferAmount = bound(transferAmount, 0, mintAmount);
+        permissionedToken.mint(address(wrappedPermissionedToken), mintAmount);
+        wrappedPermissionedToken.wrapToPoolManager(mintAmount);
+        vm.prank(mockPoolManager);
+        vm.expectEmit(true, true, true, true);
+        emit IERC20.Transfer(mockPoolManager, recipient, transferAmount);
+        vm.expectEmit(true, true, true, true);
+        emit IERC20.Transfer(recipient, address(0), transferAmount);
+        wrappedPermissionedToken.transfer(recipient, transferAmount);
+        assertEq(wrappedPermissionedToken.balanceOf(mockPoolManager), mintAmount - transferAmount);
+        assertEq(permissionedToken.balanceOf(recipient), transferAmount);
+    }
+}
+
+contract ImproperAllowlistChecker is IAllowlistChecker {
+    function checkAllowlist(address) public pure returns (bool) {
+        return true;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return false;
+    }
+}

--- a/test/hooks/permissionedPools/WrappedPermissionedTokenFactory.t.sol
+++ b/test/hooks/permissionedPools/WrappedPermissionedTokenFactory.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {
+    IWrappedPermissionedToken,
+    IAllowlistChecker
+} from "src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol";
+import {IWrappedPermissionedTokenFactory} from
+    "src/hooks/permissionedPools/interfaces/IWrappedPermissionedTokenFactory.sol";
+import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {PermissionedPoolsBase, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract WrappedPermissionedTokenFactoryTest is PermissionedPoolsBase {
+    IWrappedPermissionedTokenFactory public wrappedPermissionedTokenFactory;
+    address public mockPoolManager;
+
+    function setUp() public override {
+        super.setUp();
+        mockPoolManager = makeAddr("mockPoolManager");
+        bytes memory args = abi.encode(mockPoolManager);
+        bytes memory initcode =
+            abi.encodePacked(vm.getCode("WrappedPermissionedTokenFactory.sol:WrappedPermissionedTokenFactory"), args);
+        assembly {
+            sstore(wrappedPermissionedTokenFactory.slot, create(0, add(initcode, 0x20), mload(initcode)))
+        }
+    }
+
+    function test_InitialState() public view {
+        assertEq(wrappedPermissionedTokenFactory.POOL_MANAGER(), mockPoolManager);
+    }
+
+    function test_CreateWrappedPermissionedToken(address initialOwner) public {
+        vm.assume(initialOwner != address(0));
+        address expectedWrappedPermissionedToken = vm.computeCreateAddress(address(wrappedPermissionedTokenFactory), 1);
+        vm.expectEmit(true, true, true, true);
+        emit IWrappedPermissionedTokenFactory.WrappedPermissionedTokenCreated(
+            expectedWrappedPermissionedToken, address(permissionedToken)
+        );
+        address wrappedPermissionedToken = wrappedPermissionedTokenFactory.createWrappedPermissionedToken(
+            permissionedToken, initialOwner, allowlistChecker
+        );
+        assertEq(wrappedPermissionedToken, expectedWrappedPermissionedToken);
+        assertEq(
+            wrappedPermissionedTokenFactory.permissionedTokenOf(wrappedPermissionedToken), address(permissionedToken)
+        );
+        assertEq(wrappedPermissionedTokenFactory.verifiedPermissionedTokenOf(wrappedPermissionedToken), address(0));
+    }
+
+    function testRevert_WhenWrappedTokenNotDeployed(address wrappedToken) public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IWrappedPermissionedTokenFactory.WrappedTokenNotFound.selector, wrappedToken)
+        );
+        wrappedPermissionedTokenFactory.verifyWrappedToken(wrappedToken);
+    }
+
+    function testRevert_WhenWrappedTokenNotVerified() public {
+        address wrappedPermissionedToken = wrappedPermissionedTokenFactory.createWrappedPermissionedToken(
+            permissionedToken, makeAddr("initialOwner"), allowlistChecker
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWrappedPermissionedTokenFactory.WrappedTokenNotVerified.selector, wrappedPermissionedToken
+            )
+        );
+        wrappedPermissionedTokenFactory.verifyWrappedToken(wrappedPermissionedToken);
+    }
+
+    function test_VerifyWrappedToken() public {
+        address wrappedPermissionedToken = wrappedPermissionedTokenFactory.createWrappedPermissionedToken(
+            permissionedToken, makeAddr("initialOwner"), allowlistChecker
+        );
+        permissionedToken.setAllowlist(wrappedPermissionedToken, true);
+        permissionedToken.mint(wrappedPermissionedToken, 1);
+        vm.expectEmit(true, true, true, true);
+        emit IWrappedPermissionedTokenFactory.WrappedTokenVerified(wrappedPermissionedToken, address(permissionedToken));
+        wrappedPermissionedTokenFactory.verifyWrappedToken(wrappedPermissionedToken);
+        assertEq(
+            wrappedPermissionedTokenFactory.verifiedPermissionedTokenOf(wrappedPermissionedToken),
+            address(permissionedToken)
+        );
+    }
+
+    function testRevert_WhenWrappedTokenAlreadyVerified() public {
+        address wrappedPermissionedToken = wrappedPermissionedTokenFactory.createWrappedPermissionedToken(
+            permissionedToken, makeAddr("initialOwner"), allowlistChecker
+        );
+        permissionedToken.setAllowlist(wrappedPermissionedToken, true);
+        permissionedToken.mint(wrappedPermissionedToken, 1);
+        wrappedPermissionedTokenFactory.verifyWrappedToken(wrappedPermissionedToken);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWrappedPermissionedTokenFactory.WrappedTokenAlreadyVerified.selector, wrappedPermissionedToken
+            )
+        );
+        wrappedPermissionedTokenFactory.verifyWrappedToken(wrappedPermissionedToken);
+    }
+}

--- a/test/hooks/permissionedPools/WrappedPermissionedTokenFactory.t.sol
+++ b/test/hooks/permissionedPools/WrappedPermissionedTokenFactory.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.20;
 import {
     IWrappedPermissionedToken,
     IAllowlistChecker
-} from "src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol";
+} from "../../../src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol";
 import {IWrappedPermissionedTokenFactory} from
-    "src/hooks/permissionedPools/interfaces/IWrappedPermissionedTokenFactory.sol";
+    "../../../src/hooks/permissionedPools/interfaces/IWrappedPermissionedTokenFactory.sol";
 import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {PermissionedPoolsBase, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";


### PR DESCRIPTION
This pull request introduces several updates and new features to the permissioned pools functionality, including refactoring existing code, adding new methods, and implementing comprehensive test coverage. The most significant changes include renaming methods for consistency, adding support for token decimals, updating verification logic, and introducing extensive unit tests for both `WrappedPermissionedToken` and `WrappedPermissionedTokenFactory`.

### Code Refactoring and Enhancements:
* Renamed `checkAllowList` to `checkAllowlist` in `IAllowlistChecker` and its implementation for naming consistency. (`[[1]](diffhunk://#diff-cf396ff55c3eae958295860a08f467a35f0a3a0fb96a54d0fa163c5b1ecb8758L54-R54)`, `[[2]](diffhunk://#diff-8c320aa170995dcf703394866bd4a12e0775efc0bbc59b93e55f6b0507d9a543L7-R7)`)
* Added a `decimals()` method in `WrappedPermissionedToken` to retrieve the decimals of the underlying permissioned token. (`[src/hooks/permissionedPools/WrappedPermissionedToken.solR109-R112](diffhunk://#diff-cf396ff55c3eae958295860a08f467a35f0a3a0fb96a54d0fa163c5b1ecb8758R109-R112)`)
* Fixed a logical error in `WrappedPermissionedTokenFactory` by changing the condition to check for zero balance before verifying a wrapped token. (`[src/hooks/permissionedPools/WrappedPermissionedTokenFactory.solL38-R38](diffhunk://#diff-22e487f2f36a9c2268dee9f6deebc6043bc5e97a746d91925e65ecc9e9bb0f99L38-R38)`)
* Added a `POOL_MANAGER()` method to `IWrappedPermissionedTokenFactory` for retrieving the v4 pool manager address. (`[src/hooks/permissionedPools/interfaces/IWrappedPermissionedTokenFactory.solR48-R51](diffhunk://#diff-0a910efa78c83d5c36b5e2e7e85ba7d7640a81aea9cda201ec693a51c1562558R48-R51)`)

### Test Suite Additions:
* Introduced `PermissionedPoolsBase` to provide reusable mock contracts (`MockToken`, `MockPermissionedToken`, `MockAllowlistChecker`) and setup logic for testing. (`[test/hooks/permissionedPools/PermissionedPoolsBase.solR1-R63](diffhunk://#diff-729c6db6c18babe6f5e749ee2605cb6a83678b2c37c5583235482e9a273a1253R1-R63)`)
* Added a comprehensive test suite for `WrappedPermissionedToken`, covering initialization, permission checks, wrapping/unwrapping logic, and allowlist updates. (`[test/hooks/permissionedPools/WrappedPermissionedToken.t.solR1-R152](diffhunk://#diff-84ace63d703534c34e97d3add7b5beaad9b56a1e0fca28e7db943e7880b78060R1-R152)`)
* Added a test suite for `WrappedPermissionedTokenFactory`, including tests for token creation, verification, and error handling for invalid states. (`[test/hooks/permissionedPools/WrappedPermissionedTokenFactory.t.solR1-R98](diffhunk://#diff-46e18bbeacb02ad8bfcfa9985e18f4e51f0aa94bfc58dcd8126a89c23256a6b9R1-R98)`) 

These changes improve code clarity, enhance functionality, and ensure robust test coverage for the permissioned pools feature.