### PR TITLE
Permissioned Pools: Transfers by admins

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -46,7 +46,6 @@ contract PermissionedPositionManager is PositionManager {
             revert Unauthorized();
         }
         getApproved[id] = msg.sender;
-        emit Approval(from, msg.sender, id);
         super.transferFrom(from, to, id);
     }
 

--- a/src/hooks/permissionedPools/WrappedPermissionedToken.sol
+++ b/src/hooks/permissionedPools/WrappedPermissionedToken.sol
@@ -110,4 +110,8 @@ contract WrappedPermissionedToken is ERC20, Ownable2Step, IWrappedPermissionedTo
     function decimals() public view override returns (uint8) {
         return ERC20(address(PERMISSIONED_TOKEN)).decimals();
     }
+
+    function owner() public view override(Ownable, IWrappedPermissionedToken) returns (address) {
+        return super.owner();
+    }
 }

--- a/src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol
+++ b/src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol
@@ -57,4 +57,7 @@ interface IWrappedPermissionedToken is IERC20 {
 
     /// @notice Returns the permissioned token that is wrapped by this contract
     function PERMISSIONED_TOKEN() external view returns (IERC20);
+
+    /// @notice Returns the admin of the wrapped permissioned token
+    function owner() external view returns (address);
 }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -47,9 +47,14 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     IPositionManager public secondaryPosm;
     IPositionManager public tertiaryPosm;
 
+    // permissioned / normal
     PoolKey public key0;
+    // normal / permissioned
     PoolKey public key1;
+    // permissioned / permissioned
     PoolKey public key2;
+    // normal / normal
+    PoolKey public key3;
     PoolKey public keyFake0;
     PoolKey public keyFake1;
     PoolKey public keyFake2;
@@ -102,6 +107,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             3000,
             SQRT_PRICE_1_1
         );
+        (key3, poolId) = initPool(currency2, currency0, permissionedHooks, 3000, SQRT_PRICE_1_1);
         (keyFake0, poolId) =
             initPool(Currency.wrap(address(wrappedToken0)), currency1, secondaryPermissionedHooks, 3000, SQRT_PRICE_1_1);
         (keyFake1, poolId) =
@@ -934,28 +940,89 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         assertEq(lpFee, fee);
     }
 
-    function test_liquidity_token_transfer_reverts() public {
-        _test_liquidity_token_transfer_reverts(key0);
-        _test_liquidity_token_transfer_reverts(key1);
-        _test_liquidity_token_transfer_reverts(key2);
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    function test_transferFrom_success_seize_by_admin() public {
+        _testRevert_transferFrom_success_seize_by_admin(key0);
+        _testRevert_transferFrom_success_seize_by_admin(key1);
     }
 
-    function _test_liquidity_token_transfer_reverts(PoolKey memory key) internal {
-        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
-
-        uint256 liquidity = 1e18;
+    function _testRevert_transferFrom_success_seize_by_admin(PoolKey memory poolKey) internal {
         uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(poolKey);
 
-        vm.startPrank(alice);
-
-        mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
-
-        assertEq(IERC721(address(lpm)).ownerOf(tokenId), alice);
-
-        vm.expectRevert();
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, address(this), tokenId);
+        // address(this) is admin
         IERC721(address(lpm)).transferFrom(alice, address(this), tokenId);
-        vm.stopPrank();
     }
+
+    function test_transferFrom_success_seize_by_either_admin() public {
+        uint256 tokenId0 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+        uint256 tokenId1 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+        uint256 tokenId2 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, address(this), tokenId0);
+        // address(this) is admin of both permissioned tokens
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId0);
+
+        address owner0 = makeAddr("owner0");
+        address owner1 = makeAddr("owner1");
+        wrappedToken0.transferOwnership(owner0);
+        vm.prank(owner0);
+        wrappedToken0.acceptOwnership();
+        wrappedToken2.transferOwnership(owner1);
+        vm.prank(owner1);
+        wrappedToken2.acceptOwnership();
+
+        vm.prank(owner0);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, address(this), tokenId1);
+        // owner0 is admin of wrappedToken0
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId1);
+
+        vm.prank(owner1);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, address(this), tokenId2);
+        // owner1 is admin of wrappedToken2
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId2);
+    }
+
+    error Unauthorized();
+
+    function test_transferFrom_revert_not_admin(address notAdmin) public {
+        vm.assume(notAdmin != address(this) && notAdmin != address(0));
+        uint256 tokenId0 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+        uint256 tokenId1 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key1);
+        uint256 tokenId2 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+        uint256 tokenId3 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        vm.prank(notAdmin);
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId0);
+
+        vm.prank(notAdmin);
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId1);
+
+        vm.prank(notAdmin);
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId2);
+
+        vm.prank(notAdmin);
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId3);
+    }
+
+    error SafeTransferDisabled();
 
     function test_safe_transfer_from_reverts() public {
         bytes memory encodedCall =
@@ -964,7 +1031,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         address target = address(lpm);
 
         vm.startPrank(alice);
-        vm.expectRevert(abi.encode("Transfer disabled"));
+        vm.expectRevert(SafeTransferDisabled.selector);
 
         bool success;
         assembly ("memory-safe") {
@@ -979,7 +1046,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         address target = address(lpm);
 
         vm.startPrank(alice);
-        vm.expectRevert(abi.encode("Transfer disabled"));
+        vm.expectRevert(SafeTransferDisabled.selector);
 
         bool success;
         assembly ("memory-safe") {

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1053,8 +1053,6 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         IERC721(address(lpm)).transferFrom(alice, address(this), tokenId2);
     }
 
-    error Unauthorized();
-
     function test_transferFrom_revert_not_admin(address notAdmin) public {
         vm.assume(notAdmin != address(this) && notAdmin != address(0));
         uint256 tokenId0 = lpm.nextTokenId();


### PR DESCRIPTION
This pull request introduces changes to the `PermissionedPositionManager` contract and related files to enhance permission management for token transfers and improve test coverage. Key updates include adding stricter transfer rules, introducing helper methods for permission checks, and expanding test cases to validate the new functionality.

### Updates to Permission Management:

* [`src/hooks/permissionedPools/PermissionedPositionManager.sol`](diffhunk://#diff-85dca6b1a9231c32006abbbffdf0e3e896edc4f1c5bf7fb599f84226cdb0e0d9L39-R58): Enhanced the `transferFrom` method to allow only admins of permissioned tokens to transfer positions containing their tokens. Added `_getOwner` and `_verifiedPermissionedTokenOf` helper methods for permission checks. Introduced new error types `Unauthorized` and `SafeTransferDisabled`. [[1]](diffhunk://#diff-85dca6b1a9231c32006abbbffdf0e3e896edc4f1c5bf7fb599f84226cdb0e0d9L39-R58) [[2]](diffhunk://#diff-85dca6b1a9231c32006abbbffdf0e3e896edc4f1c5bf7fb599f84226cdb0e0d9L70-R79) [[3]](diffhunk://#diff-85dca6b1a9231c32006abbbffdf0e3e896edc4f1c5bf7fb599f84226cdb0e0d9R100-R110)

* [`src/hooks/permissionedPools/WrappedPermissionedToken.sol`](diffhunk://#diff-cf396ff55c3eae958295860a08f467a35f0a3a0fb96a54d0fa163c5b1ecb8758R113-R116): Added an override for the `owner` method to expose the admin of wrapped permissioned tokens.

* [`src/hooks/permissionedPools/interfaces/IWrappedPermissionedToken.sol`](diffhunk://#diff-d9cfae313fac16955e05c8c5f482eb7f43cf3bb6d3a1250c12df0a745ac3eeddR60-R62): Updated the interface to include the `owner` method for retrieving the admin of wrapped permissioned tokens.

### Test Enhancements:

* [`test/hooks/permissionedPools/PermissionedPositionManager.t.sol`](diffhunk://#diff-f3b9a20146fc479d6cecfe1b2f38d3c22bc6a04827591ea3361486f20b705c6cR50-R57): Replaced outdated tests for transfer reverts with new tests validating successful transfers by admins and reverts for unauthorized users. Added test cases for `safeTransferFrom` reverts and expanded pool key setup for various token combinations. [[1]](diffhunk://#diff-f3b9a20146fc479d6cecfe1b2f38d3c22bc6a04827591ea3361486f20b705c6cR50-R57) [[2]](diffhunk://#diff-f3b9a20146fc479d6cecfe1b2f38d3c22bc6a04827591ea3361486f20b705c6cR110) [[3]](diffhunk://#diff-f3b9a20146fc479d6cecfe1b2f38d3c22bc6a04827591ea3361486f20b705c6cL937-R1034) [[4]](diffhunk://#diff-f3b9a20146fc479d6cecfe1b2f38d3c22bc6a04827591ea3361486f20b705c6cL982-R1049)