### PR TITLE
Add WstETHRoutingHook, fix rounding bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v4-periphery",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "🦄 Peripheral smart contracts for interacting with Uniswap v4",
   "repository": {
     "type": "git",

--- a/src/hooks/WstETHHook.sol
+++ b/src/hooks/WstETHHook.sol
@@ -60,9 +60,13 @@ contract WstETHHook is BaseTokenWrapperHook {
         _take(wrapperCurrency, address(this), wrapperAmount);
         actualWrappedAmount = wrapperAmount;
         uint256 unwrappedAmount = wstETH.unwrap(actualWrappedAmount);
+
+        // check pool manager balance to account for balance mismatch on transfers due to rounding errors
+        uint256 poolManagerBalanceBefore = IStETH(Currency.unwrap(underlyingCurrency)).balanceOf(address(poolManager));
         _settle(underlyingCurrency, address(this), unwrappedAmount);
-        uint256 transferredShares = IStETH(Currency.unwrap(underlyingCurrency)).getSharesByPooledEth(unwrappedAmount);
-        actualUnwrappedAmount = IStETH(Currency.unwrap(underlyingCurrency)).getPooledEthByShares(transferredShares);
+        uint256 poolManagerBalanceAfter = IStETH(Currency.unwrap(underlyingCurrency)).balanceOf(address(poolManager));
+
+        actualUnwrappedAmount = poolManagerBalanceAfter - poolManagerBalanceBefore;
     }
 
     /// @inheritdoc BaseTokenWrapperHook

--- a/src/hooks/WstETHHook.sol
+++ b/src/hooks/WstETHHook.sol
@@ -38,6 +38,7 @@ contract WstETHHook is BaseTokenWrapperHook {
     /// @inheritdoc BaseTokenWrapperHook
     function _deposit(uint256 underlyingAmount)
         internal
+        virtual
         override
         returns (uint256 actualUnderlyingAmount, uint256 wrappedAmount)
     {
@@ -54,12 +55,14 @@ contract WstETHHook is BaseTokenWrapperHook {
     function _withdraw(uint256 wrapperAmount)
         internal
         override
-        returns (uint256 actualWrappedAmount, uint256 unwrappedAmount)
+        returns (uint256 actualWrappedAmount, uint256 actualUnwrappedAmount)
     {
         _take(wrapperCurrency, address(this), wrapperAmount);
         actualWrappedAmount = wrapperAmount;
-        unwrappedAmount = wstETH.unwrap(actualWrappedAmount);
+        uint256 unwrappedAmount = wstETH.unwrap(actualWrappedAmount);
         _settle(underlyingCurrency, address(this), unwrappedAmount);
+        uint256 transferredShares = IStETH(Currency.unwrap(underlyingCurrency)).getSharesByPooledEth(unwrappedAmount);
+        actualUnwrappedAmount = IStETH(Currency.unwrap(underlyingCurrency)).getPooledEthByShares(transferredShares);
     }
 
     /// @inheritdoc BaseTokenWrapperHook

--- a/src/hooks/WstETHRoutingHook.sol
+++ b/src/hooks/WstETHRoutingHook.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IWstETH, IStETH} from "../interfaces/external/IWstETH.sol";
+import {WstETHHook, BaseTokenWrapperHook, IPoolManager, Currency} from "./WstETHHook.sol";
+
+/// @title WstETHRoutingHook
+/// @notice A hook that allows simulating the WstETHHook with the v4 Quoter
+/// @dev The WstETHHook takes the amount deposited by the swapper into the PoolManager and wraps it to wstETH. When simulating the WstETHHook, no underlying stETH are deposited into the PoolManager and the WstETHHook reverts. This hook acts as a replacement for the WstETHHook in the Quoter and calculates the amount of wstETH that would be minted by the WstETHHook, without executing the actual wrapping.
+/// @dev The withdraw function doesn't need to be overridden, as the PoolManager has a sufficient balance of WstETH to cover the withdrawal in the simulation.
+contract WstETHRoutingHook is WstETHHook {
+    constructor(IPoolManager _poolManager, IWstETH _wstETH) WstETHHook(_poolManager, _wstETH) {}
+
+    /// @inheritdoc BaseTokenWrapperHook
+    function _deposit(uint256 underlyingAmount)
+        internal
+        view
+        override
+        returns (uint256 actualUnderlyingAmount, uint256 wrappedAmount)
+    {
+        // simulate taking stETH from the PoolManager
+        // _take(underlyingCurrency, address(this), underlyingAmount);
+        // actualUnderlyingAmount = stETH.balanceOf(address(this));
+        //
+        // when calling take on the PoolManager the amount is rounded down to the nearest share
+        // the following code calculates the amount of shares that would be transferred by the PoolManager and their corresponding amount of ETH
+        IStETH stETH = IStETH(Currency.unwrap(underlyingCurrency));
+        uint256 transferredShares = stETH.getSharesByPooledEth(underlyingAmount);
+        actualUnderlyingAmount = stETH.getPooledEthByShares(transferredShares);
+
+        // simulate wrapping stETH to wstETH
+        // wrappedAmount = wstETH.wrap(actualUnderlyingAmount);
+        // _settle(wrapperCurrency, address(this), wrappedAmount);
+        //
+        // when wrapping stETH to wstETH the amount of wstETH minted is calculated by the current stETH/wstETH exchange rate
+        wrappedAmount = wstETH.getWstETHByStETH(actualUnderlyingAmount);
+    }
+}

--- a/test/hooks/WstETHHook.fork.t.sol
+++ b/test/hooks/WstETHHook.fork.t.sol
@@ -201,8 +201,8 @@ contract WstETHHookForkTest is Test, Deployers {
     function test_fork_unwrap_exactInput(uint256 amount, uint256 dustStEth) public onlyForked {
         uint256 unwrapAmount = (bound(amount, 0.1 ether, 10 ether));
         dustStEth = bound(dustStEth, 1, 10 ether);
-        vm.prank(WSTETH_WHALE);
-        IERC20(WSTETH).transfer(address(manager), dustStEth);
+        vm.prank(STETH_WHALE);
+        stETH.transfer(address(manager), dustStEth);
 
         uint256 expectedOutput = wstETH.getStETHByWstETH(unwrapAmount);
 

--- a/test/hooks/WstETHHook.fork.t.sol
+++ b/test/hooks/WstETHHook.fork.t.sol
@@ -17,8 +17,11 @@ import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
 import {BaseTokenWrapperHook} from "../../src/base/hooks/BaseTokenWrapperHook.sol";
 import {WstETHHook} from "../../src/hooks/WstETHHook.sol";
+import {WstETHRoutingHook} from "../../src/hooks/WstETHRoutingHook.sol";
 import {IWstETH} from "../../src/interfaces/external/IWstETH.sol";
 import {TestRouter} from "../shared/TestRouter.sol";
+import {IV4Quoter} from "../../src/interfaces/IV4Quoter.sol";
+import {Deploy} from "../shared/Deploy.sol";
 
 contract WstETHHookForkTest is Test, Deployers {
     using PoolIdLibrary for PoolKey;
@@ -32,11 +35,14 @@ contract WstETHHookForkTest is Test, Deployers {
     address constant WSTETH_WHALE = 0x10CD5fbe1b404B7E19Ef964B63939907bdaf42E2;
 
     WstETHHook public hook;
+    WstETHRoutingHook public hookSim;
     IWstETH public wstETH;
     IERC20 public stETH;
     PoolKey poolKey;
+    PoolKey poolKeySim;
     TestRouter public router;
     uint160 initSqrtPriceX96;
+    IV4Quoter quoter;
 
     // Test user
     address alice = makeAddr("alice");
@@ -50,6 +56,8 @@ contract WstETHHookForkTest is Test, Deployers {
             vm.createSelectFork(vm.rpcUrl("mainnet"), 21_900_000);
 
             deployFreshManagerAndRouters();
+            // replace manager with the real mainnet manager
+            manager = IPoolManager(0x000000000004444c5dc75cB358380D2e3dE08A90);
             router = new TestRouter(manager);
 
             // Use real mainnet contracts
@@ -70,7 +78,20 @@ contract WstETHHookForkTest is Test, Deployers {
                     )
                 )
             );
+            hookSim = WstETHRoutingHook(
+                payable(
+                    address(
+                        uint160(
+                            type(uint160).max & clearAllHookPermissionsMask | Hooks.BEFORE_SWAP_FLAG
+                                | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG
+                                | Hooks.BEFORE_INITIALIZE_FLAG
+                        ) & (type(uint160).max - 2 ** 156)
+                    )
+                )
+            );
             deployCodeTo("WstETHHook", abi.encode(manager, wstETH), address(hook));
+            deployCodeTo("WstETHRoutingHook", abi.encode(manager, wstETH), address(hookSim));
+            quoter = Deploy.v4Quoter(address(manager), hex"00");
 
             // Create pool key for wstETH/stETH (wstETH has lower address)
             poolKey = PoolKey({
@@ -80,21 +101,27 @@ contract WstETHHookForkTest is Test, Deployers {
                 tickSpacing: 60,
                 hooks: IHooks(address(hook))
             });
+            poolKeySim = PoolKey({
+                currency0: Currency.wrap(address(wstETH)),
+                currency1: Currency.wrap(address(stETH)),
+                fee: 0,
+                tickSpacing: 60,
+                hooks: IHooks(address(hookSim))
+            });
 
             // Initialize pool at current exchange rate
             manager.initialize(poolKey, SQRT_PRICE_1_1);
+            manager.initialize(poolKeySim, SQRT_PRICE_1_1);
 
             // Get tokens from whales and set up approvals
             vm.startPrank(STETH_WHALE);
             uint256 stethAmount = 100 ether;
             stETH.transfer(alice, stethAmount);
-            stETH.transfer(address(manager), 1000 ether);
             vm.stopPrank();
 
             vm.startPrank(WSTETH_WHALE);
             uint256 wstethAmount = 100 ether;
             IERC20(WSTETH).transfer(alice, wstethAmount);
-            IERC20(WSTETH).transfer(address(manager), 1000 ether);
             vm.stopPrank();
 
             // Approve tokens
@@ -102,6 +129,7 @@ contract WstETHHookForkTest is Test, Deployers {
             stETH.approve(address(router), type(uint256).max);
             IERC20(WSTETH).approve(address(router), type(uint256).max);
             vm.stopPrank();
+            forked = true;
         } catch {
             console2.log(
                 "Skipping forked tests, no infura key found. Add INFURA_API_KEY env var to .env to run forked tests."
@@ -118,9 +146,34 @@ contract WstETHHookForkTest is Test, Deployers {
         console2.log("skipping forked test");
     }
 
-    function test_fork_wrap_exactInput() public onlyForked {
-        uint256 wrapAmount = 10 ether;
+    function test_fork_wrap_exactInput(uint256 amount, uint256 dustStEth) public onlyForked {
+        uint256 wrapAmount = bound(amount, 0.1 ether, 10 ether);
+        dustStEth = bound(dustStEth, 1, 0.1 ether - 1);
+        vm.prank(STETH_WHALE);
+        stETH.transfer(address(manager), dustStEth);
+
         uint256 expectedOutput = wstETH.getWstETHByStETH(wrapAmount);
+
+        // quoting the swap with the WstETHHook should revert
+        vm.expectRevert();
+        quoter.quoteExactInputSingle(
+            IV4Quoter.QuoteExactSingleParams({
+                poolKey: poolKey,
+                zeroForOne: false,
+                exactAmount: uint128(wrapAmount),
+                hookData: ""
+            })
+        );
+
+        // quoting the swap with the WstETHRoutingHook should not revert
+        (uint256 quotedAmountOut,) = quoter.quoteExactInputSingle(
+            IV4Quoter.QuoteExactSingleParams({
+                poolKey: poolKeySim,
+                zeroForOne: false,
+                exactAmount: uint128(wrapAmount),
+                hookData: ""
+            })
+        );
 
         vm.startPrank(alice);
         uint256 aliceStethBefore = stETH.balanceOf(alice);
@@ -138,14 +191,19 @@ contract WstETHHookForkTest is Test, Deployers {
 
         vm.stopPrank();
 
+        uint256 actualAmountOut = IERC20(WSTETH).balanceOf(alice) - aliceWstethBefore;
+        assertApproxEqAbs(quotedAmountOut, actualAmountOut, 2, "Quoted amount should match the actual amount received");
+
         assertApproxEqAbs(aliceStethBefore - stETH.balanceOf(alice), wrapAmount, 2, "Incorrect stETH spent");
-        assertApproxEqAbs(
-            IERC20(WSTETH).balanceOf(alice) - aliceWstethBefore, expectedOutput, 2, "Incorrect wstETH received"
-        );
+        assertApproxEqAbs(actualAmountOut, expectedOutput, 2, "Incorrect wstETH received");
     }
 
-    function test_fork_unwrap_exactInput() public onlyForked {
-        uint256 unwrapAmount = 10 ether;
+    function test_fork_unwrap_exactInput(uint256 amount, uint256 dustStEth) public onlyForked {
+        uint256 unwrapAmount = (bound(amount, 0.1 ether, 10 ether));
+        dustStEth = bound(dustStEth, 1, 10 ether);
+        vm.prank(WSTETH_WHALE);
+        IERC20(WSTETH).transfer(address(manager), dustStEth);
+
         uint256 expectedOutput = wstETH.getStETHByWstETH(unwrapAmount);
 
         vm.startPrank(alice);
@@ -164,7 +222,35 @@ contract WstETHHookForkTest is Test, Deployers {
 
         vm.stopPrank();
 
-        assertApproxEqAbs(stETH.balanceOf(alice) - aliceStethBefore, expectedOutput, 1, "Incorrect stETH received");
+        // quoting the swap with the WstETHHook should not revert
+        (uint256 quotedAmountOut,) = quoter.quoteExactInputSingle(
+            IV4Quoter.QuoteExactSingleParams({
+                poolKey: poolKey,
+                zeroForOne: true,
+                exactAmount: uint128(unwrapAmount),
+                hookData: ""
+            })
+        );
+
+        // quoting the swap with the WstETHRoutingHook should not revert
+        (uint256 quotedAmountOutSim,) = quoter.quoteExactInputSingle(
+            IV4Quoter.QuoteExactSingleParams({
+                poolKey: poolKeySim,
+                zeroForOne: true,
+                exactAmount: uint128(unwrapAmount),
+                hookData: ""
+            })
+        );
+
+        assertEq(quotedAmountOut, quotedAmountOutSim, "Quotes from WstETHHook and WstETHRoutingHook should match");
+
+        uint256 actualAmountOut = stETH.balanceOf(alice) - aliceStethBefore;
+        // transfer from pool manager to alice can incur a small amount of rounding error
+        assertApproxEqAbs(
+            quotedAmountOutSim, actualAmountOut, 3, "Quoted amount should match the actual amount received"
+        );
+
+        assertApproxEqAbs(actualAmountOut, expectedOutput, 3, "Incorrect stETH received");
         assertEq(aliceWstethBefore - IERC20(WSTETH).balanceOf(alice), unwrapAmount, "Incorrect wstETH spent");
     }
 

--- a/test/hooks/WstETHHook.t.sol
+++ b/test/hooks/WstETHHook.t.sol
@@ -21,13 +21,25 @@ import {MockWstETH} from "../mocks/MockWstETH.sol";
 import {TestRouter} from "../shared/TestRouter.sol";
 import {ModifyLiquidityParams, SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 
+contract MockStETH is MockERC20 {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockERC20(name_, symbol_, decimals_) {}
+
+    function getSharesByPooledEth(uint256 pooledEth) public pure returns (uint256) {
+        return pooledEth;
+    }
+
+    function getPooledEthByShares(uint256 shares) public pure returns (uint256) {
+        return shares;
+    }
+}
+
 contract WstETHHookTest is Test, Deployers {
     using PoolIdLibrary for PoolKey;
     using CurrencyLibrary for Currency;
 
     WstETHHook public hook;
     MockWstETH public wstETH;
-    MockERC20 public stETH;
+    MockStETH public stETH;
     TestRouter public router;
     PoolKey poolKey;
     uint160 initSqrtPriceX96;
@@ -43,7 +55,7 @@ contract WstETHHookTest is Test, Deployers {
         router = new TestRouter(manager);
 
         // Deploy mock stETH and wstETH
-        stETH = new MockERC20("Liquid staked Ether", "stETH", 18);
+        stETH = new MockStETH("Liquid staked Ether", "stETH", 18);
         wstETH = new MockWstETH(address(stETH));
 
         // Deploy WstETH hook


### PR DESCRIPTION
This pull request introduces enhancements to the `WstETHHook` contract, adds a new `WstETHRoutingHook` for simulation purposes, and updates related tests to ensure compatibility and functionality. Key changes include the addition of virtual modifiers, improved precision in withdrawal calculations, and the introduction of a routing hook for simulating swaps without actual deposits. Test cases have been expanded to validate the new functionality.

### Updates to `WstETHHook` Contract:
- Added the `virtual` modifier to the `_deposit` function to allow overriding in derived contracts.
- Enhanced the `_withdraw` function to improve precision by calculating the actual unwrapped amount using stETH shares and their corresponding pooled ETH.

### Introduction of `WstETHRoutingHook`:
- Added a new `WstETHRoutingHook` contract to simulate the behavior of `WstETHHook` with the v4 Quoter. This contract calculates the amount of wstETH that would be minted without performing actual wrapping operations.

### Updates to Test Cases:
#### Forked Tests (`WstETHHook.fork.t.sol`):
- Introduced the `WstETHRoutingHook` in forked tests to validate simulation functionality alongside the original `WstETHHook`. [[1]](diffhunk://#diff-bd93bb7a4e4fc7d380f4961a371a676b9bca016105e2467a014bdca1d3f80281R38-R45) [[2]](diffhunk://#diff-bd93bb7a4e4fc7d380f4961a371a676b9bca016105e2467a014bdca1d3f80281R81-R94)
- Enhanced tests to include quoting swaps using both `WstETHHook` and `WstETHRoutingHook`, ensuring consistency in quoted amounts and verifying actual outputs. [[1]](diffhunk://#diff-bd93bb7a4e4fc7d380f4961a371a676b9bca016105e2467a014bdca1d3f80281L121-R177) [[2]](diffhunk://#diff-bd93bb7a4e4fc7d380f4961a371a676b9bca016105e2467a014bdca1d3f80281L167-R253)

#### Unit Tests (`WstETHHook.t.sol`):
- Replaced the mock `stETH` implementation with `MockStETH`, which includes methods for calculating shares and pooled ETH, aligning with the changes in the `WstETHHook` contract. [[1]](diffhunk://#diff-54b1d3dc59086b5b8bcadfb151ec49c96dd78deb2cf6bb0ece581a4b580e59d0R24-R42) [[2]](diffhunk://#diff-54b1d3dc59086b5b8bcadfb151ec49c96dd78deb2cf6bb0ece581a4b580e59d0L46-R58)