### PR TITLE
fix: Fix typo in test file and expose poolKeys in IPositionManager in…

### DIFF
--- a/src/interfaces/IPositionManager.sol
+++ b/src/interfaces/IPositionManager.sol
@@ -65,4 +65,9 @@ interface IPositionManager is
     /// @param tokenId the ERC721 tokenId
     /// @return a uint256 packed value holding information about the position including the range (tickLower, tickUpper)
     function positionInfo(uint256 tokenId) external view returns (PositionInfo);
+
+    /// @notice Returns the pool key for a given pool ID
+    /// @param poolId the truncated pool ID (bytes25)
+    /// @return poolKey the pool key associated with the pool ID
+    function poolKeys(bytes25 poolId) external view returns (PoolKey memory);
 }

--- a/test/script/DeployPoolModifyLiquidityTest.t.sol
+++ b/test/script/DeployPoolModifyLiquidityTest.t.sol
@@ -24,3 +24,4 @@ contract DeployPoolModifyLiquidityTestTest is Test {
         assertEq(address(testModifyLiquidityRouter.manager()), address(manager));
     }
 }
+


### PR DESCRIPTION
## Related Issue
Fixes #[issue-number-1] - Typo in the name of test file
Fixes #[issue-number-2] - IPositionManager doesn't expose `poolKeys(bytes32)`

## Description of changes

This PR fixes two bugs:

1. **Fixed typo in test file name**: Renamed `DeployPoolMofifyLiquidityTest.t.sol` to `DeployPoolModifyLiquidityTest.t.sol` (corrected "Mofify" → "Modify")

2. **Exposed `poolKeys` function in IPositionManager interface**: Added the missing `poolKeys(bytes25 poolId)` function declaration to the `IPositionManager` interface. The `PositionManager` contract already has a public mapping `poolKeys`, but it wasn't exposed in the interface, making it inaccessible through the interface.

## Changes Made
- Renamed `test/script/DeployPoolMofifyLiquidityTest.t.sol` → `test/script/DeployPoolModifyLiquidityTest.t.sol`
- Added `function poolKeys(bytes25 poolId) external view returns (PoolKey memory);` to `src/interfaces/IPositionManager.sol`

## Testing
- [x] Code compiles without errors
- [x] No linter errors
- [ ] Tests pass (run `forge test`)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Changes are documented with natspec comments
- [x] PR references the related issues