### PR TITLE
test: add full coverage for DeltaResolver

### DIFF
--- a/test/DeltaResolver.t.sol
+++ b/test/DeltaResolver.t.sol
@@ -6,11 +6,21 @@ import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
 import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {ERC20} from "solmate/src/tokens/ERC20.sol";
-
+import {DeltaResolver} from "../src/base/DeltaResolver.sol";
+import {ActionConstants} from "../src/libraries/ActionConstants.sol";
 import {MockDeltaResolver} from "./mocks/MockDeltaResolver.sol";
 
 contract DeltaResolverTest is Test, Deployers {
     MockDeltaResolver resolver;
+
+    // Execution modes mirrored from MockDeltaResolver
+    uint8 internal constant MODE_DEBT_AFTER_TAKE = 1;
+    uint8 internal constant MODE_FORCE_CREDIT = 2;
+    uint8 internal constant MODE_DEBT_REVERT_ON_CREDIT = 3;
+    uint8 internal constant MODE_CREDIT_REVERT_ON_DEBT = 4;
+    uint8 internal constant MODE_MAP_SETTLE_OPEN_DELTA = 5;
+    uint8 internal constant MODE_MAP_TAKE_OPEN_DELTA = 6;
+    uint8 internal constant MODE_MAP_WRAP_UNWRAP_OPEN_DELTA = 7;
 
     function setUp() public {
         initializeManagerRoutersAndPoolsWithLiq(IHooks(address(0)));
@@ -36,5 +46,158 @@ contract DeltaResolverTest is Test, Deployers {
 
         // check `pay` was called
         assertEq(resolver.payCallCount(), 1);
+    }
+
+    function test_take_amount_zero_returns_early() public {
+        // _take should no-op on zero amount
+        resolver.exposed_take(currency0, address(this), 0);
+    }
+
+    function test_settle_amount_zero_returns_early_native() public {
+        // _settle should no-op on zero amount
+        uint256 payCallsBefore = resolver.payCallCount();
+
+        resolver.exposed_settle(CurrencyLibrary.ADDRESS_ZERO, address(this), 0);
+
+        assertEq(resolver.payCallCount(), payCallsBefore);
+    }
+
+    function test_settle_amount_zero_returns_early_token() public {
+        uint256 payCallsBefore = resolver.payCallCount();
+
+        resolver.exposed_settle(currency0, address(this), 0);
+
+        assertEq(resolver.payCallCount(), payCallsBefore);
+    }
+
+    function test_getFullDebt_returns_after_take(uint256 amount) public {
+        // Negative delta created via take, then queried inside unlock context
+        amount = bound(amount, 1, currency0.balanceOf(address(manager)));
+
+        bytes memory data = resolver.executeMode(
+            MODE_DEBT_AFTER_TAKE, currency0, amount, CurrencyLibrary.ADDRESS_ZERO, CurrencyLibrary.ADDRESS_ZERO
+        );
+
+        uint256 debt = abi.decode(data, (uint256));
+        assertEq(debt, amount);
+    }
+
+    function test_getFullDebt_reverts_when_credit_positive(uint256 amount) public {
+        // Reading debt when delta is positive should revert
+        amount = bound(amount, 1, 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(DeltaResolver.DeltaNotNegative.selector, currency0));
+        resolver.executeMode(
+            MODE_DEBT_REVERT_ON_CREDIT, currency0, amount, CurrencyLibrary.ADDRESS_ZERO, CurrencyLibrary.ADDRESS_ZERO
+        );
+    }
+
+    function test_getFullCredit_returns_after_force_credit(uint256 amount) public {
+        // Positive delta is injected via transient state mock
+        amount = bound(amount, 1, 1e18);
+
+        bytes memory data = resolver.executeMode(
+            MODE_FORCE_CREDIT, currency0, amount, CurrencyLibrary.ADDRESS_ZERO, CurrencyLibrary.ADDRESS_ZERO
+        );
+
+        uint256 credit = abi.decode(data, (uint256));
+        assertEq(credit, amount);
+    }
+
+    function test_getFullCredit_reverts_when_debt_negative(uint256 amount) public {
+        // Reading credit when delta is negative should revert
+        amount = bound(amount, 1, currency0.balanceOf(address(manager)));
+
+        vm.expectRevert(abi.encodeWithSelector(DeltaResolver.DeltaNotPositive.selector, currency0));
+        resolver.executeMode(
+            MODE_CREDIT_REVERT_ON_DEBT, currency0, amount, CurrencyLibrary.ADDRESS_ZERO, CurrencyLibrary.ADDRESS_ZERO
+        );
+    }
+
+    function test_mapSettleAmount_contract_balance_token(uint256 balance) public {
+        // CONTRACT_BALANCE resolves to resolver's token balance
+        balance = bound(balance, 0, 1e18);
+        deal(Currency.unwrap(currency0), address(resolver), balance);
+
+        uint256 mapped = resolver.exposed_mapSettleAmount(ActionConstants.CONTRACT_BALANCE, currency0);
+        assertEq(mapped, balance);
+    }
+
+    function test_mapSettleAmount_literal_passthrough(uint256 amount) public view {
+        // Literal amounts pass through unchanged
+        amount = bound(amount, 0, type(uint128).max);
+
+        uint256 mapped = resolver.exposed_mapSettleAmount(amount, currency0);
+        assertEq(mapped, amount);
+    }
+
+    function test_mapSettleAmount_open_delta_uses_debt(uint256 amount) public {
+        // OPEN_DELTA resolves to full debt
+        amount = bound(amount, 1, currency0.balanceOf(address(manager)));
+
+        bytes memory data = resolver.executeMode(
+            MODE_MAP_SETTLE_OPEN_DELTA, currency0, amount, CurrencyLibrary.ADDRESS_ZERO, CurrencyLibrary.ADDRESS_ZERO
+        );
+
+        uint256 mapped = abi.decode(data, (uint256));
+        assertEq(mapped, amount);
+    }
+
+    function test_mapTakeAmount_literal_passthrough(uint256 amount) public view {
+        amount = bound(amount, 0, type(uint128).max);
+
+        uint256 mapped = resolver.exposed_mapTakeAmount(amount, currency0);
+        assertEq(mapped, amount);
+    }
+
+    function test_mapTakeAmount_open_delta_uses_credit(uint256 amount) public {
+        // OPEN_DELTA resolves to full credit
+        amount = bound(amount, 1, 1e18);
+
+        bytes memory data = resolver.executeMode(
+            MODE_MAP_TAKE_OPEN_DELTA, currency0, amount, CurrencyLibrary.ADDRESS_ZERO, CurrencyLibrary.ADDRESS_ZERO
+        );
+
+        uint256 mapped = abi.decode(data, (uint256));
+        assertEq(mapped, amount);
+    }
+
+    function test_mapWrapUnwrapAmount_contract_balance_token(uint256 balance) public {
+        // CONTRACT_BALANCE returns resolver's balance before wrap/unwrap
+        balance = bound(balance, 0, 1e18);
+        deal(Currency.unwrap(currency0), address(resolver), balance);
+
+        uint256 mapped = resolver.exposed_mapWrapUnwrapAmount(currency0, ActionConstants.CONTRACT_BALANCE, currency0);
+        assertEq(mapped, balance);
+    }
+
+    function test_mapWrapUnwrapAmount_literal_amount_ok(uint256 amount) public {
+        amount = bound(amount, 0, 1e18);
+        deal(Currency.unwrap(currency0), address(resolver), amount);
+
+        uint256 mapped = resolver.exposed_mapWrapUnwrapAmount(currency0, amount, currency0);
+        assertEq(mapped, amount);
+    }
+
+    function test_mapWrapUnwrapAmount_reverts_insufficient_balance(uint256 amount) public {
+        // Amount larger than resolver balance should revert
+        amount = bound(amount, 1, 1e18);
+        deal(Currency.unwrap(currency0), address(resolver), amount - 1);
+
+        vm.expectRevert(DeltaResolver.InsufficientBalance.selector);
+        resolver.exposed_mapWrapUnwrapAmount(currency0, amount, currency0);
+    }
+
+    function test_mapWrapUnwrapAmount_open_delta_uses_output_debt_and_checks_input_balance(uint256 amount) public {
+        // OPEN_DELTA resolves using debt in output currency,
+        // while checking balance in input currency
+        amount = bound(amount, 1, currency0.balanceOf(address(manager)));
+        deal(Currency.unwrap(currency0), address(resolver), amount);
+
+        bytes memory data =
+            resolver.executeMode(MODE_MAP_WRAP_UNWRAP_OPEN_DELTA, currency0, amount, currency0, currency0);
+
+        uint256 mapped = abi.decode(data, (uint256));
+        assertEq(mapped, amount);
     }
 }

--- a/test/mocks/MockDeltaResolver.sol
+++ b/test/mocks/MockDeltaResolver.sol
@@ -4,44 +4,192 @@ pragma solidity ^0.8.24;
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "@uniswap/v4-core/src/interfaces/callback/IUnlockCallback.sol";
+import {ActionConstants} from "../../src/libraries/ActionConstants.sol";
 import {DeltaResolver} from "../../src/base/DeltaResolver.sol";
 import {ImmutableState} from "../../src/base/ImmutableState.sol";
 import {ERC20} from "solmate/src/tokens/ERC20.sol";
 import {Test} from "forge-std/Test.sol";
 
 contract MockDeltaResolver is Test, DeltaResolver, IUnlockCallback {
+    // `exttload` is overloaded in some v4-core versions, so we select the bytes32 variant explicitly.
+    bytes4 private constant EXTTLOAD_BYTES32_SELECTOR = bytes4(keccak256("exttload(bytes32)"));
+
+    // Modes executed inside `unlockCallback` where transient deltas are visible.
+    uint8 internal constant MODE_ORIGINAL = 0;
+    uint8 internal constant MODE_DEBT_AFTER_TAKE = 1;
+    uint8 internal constant MODE_FORCE_CREDIT = 2;
+    uint8 internal constant MODE_DEBT_REVERT_ON_CREDIT = 3;
+    uint8 internal constant MODE_CREDIT_REVERT_ON_DEBT = 4;
+    uint8 internal constant MODE_MAP_SETTLE_OPEN_DELTA = 5;
+    uint8 internal constant MODE_MAP_TAKE_OPEN_DELTA = 6;
+    uint8 internal constant MODE_MAP_WRAP_UNWRAP_OPEN_DELTA = 7;
+
     uint256 public payCallCount;
 
     constructor(IPoolManager _poolManager) ImmutableState(_poolManager) {}
 
-    function executeTest(Currency currency, uint256 amount) external {
-        poolManager.unlock(abi.encode(currency, msg.sender, amount));
+    function executeTest(Currency _currency, uint256 _amount) external returns (bytes memory) {
+        return poolManager.unlock(
+            abi.encode(
+                MODE_ORIGINAL, _currency, msg.sender, _amount, Currency.wrap(address(0)), Currency.wrap(address(0))
+            )
+        );
     }
 
-    function unlockCallback(bytes calldata data) external returns (bytes memory) {
-        (Currency currency, address caller, uint256 amount) = abi.decode(data, (Currency, address, uint256));
-        address recipient = (currency.isAddressZero()) ? address(this) : caller;
-
-        uint256 balanceBefore = currency.balanceOf(recipient);
-        _take(currency, recipient, amount);
-        uint256 balanceAfter = currency.balanceOf(recipient);
-
-        assertEq(balanceBefore + amount, balanceAfter);
-
-        balanceBefore = balanceAfter;
-        _settle(currency, recipient, amount);
-        balanceAfter = currency.balanceOf(recipient);
-
-        assertEq(balanceBefore - amount, balanceAfter);
-
-        return "";
+    function executeMode(
+        uint8 _mode,
+        Currency _currency,
+        uint256 _amount,
+        Currency _inputCurrency,
+        Currency _outputCurrency
+    ) external returns (bytes memory) {
+        // `unlock` provides the transient accounting context that `currencyDelta` reads from.
+        return poolManager.unlock(abi.encode(_mode, _currency, msg.sender, _amount, _inputCurrency, _outputCurrency));
     }
 
-    function _pay(Currency token, address payer, uint256 amount) internal override {
-        ERC20(Currency.unwrap(token)).transferFrom(payer, address(poolManager), amount);
+    function unlockCallback(bytes calldata _data) external returns (bytes memory) {
+        (
+            uint8 mode,
+            Currency currency,
+            address caller,
+            uint256 amount,
+            Currency inputCurrency,
+            Currency outputCurrency
+        ) = abi.decode(_data, (uint8, Currency, address, uint256, Currency, Currency));
+
+        if (mode == MODE_ORIGINAL) {
+            // Matches the original test flow, take then settle the same amount.
+            address recipient = currency.isAddressZero() ? address(this) : caller;
+
+            uint256 balanceBefore = currency.balanceOf(recipient);
+            _take(currency, recipient, amount);
+            uint256 balanceAfter = currency.balanceOf(recipient);
+            assertEq(balanceAfter, balanceBefore + amount);
+
+            balanceBefore = balanceAfter;
+            _settle(currency, recipient, amount);
+            balanceAfter = currency.balanceOf(recipient);
+            assertEq(balanceAfter, balanceBefore - amount);
+
+            return "";
+        }
+
+        if (mode == MODE_DEBT_AFTER_TAKE) {
+            // Create a negative delta via take, then query it.
+            _take(currency, address(this), amount);
+            uint256 debt = _getFullDebt(currency);
+
+            // PoolManager requires all deltas to be cleared by the end of `unlockCallback`.
+            _settle(currency, address(this), amount);
+
+            return abi.encode(debt);
+        }
+
+        if (mode == MODE_FORCE_CREDIT) {
+            // Simulate a positive delta without violating v4 settle invariants.
+            _mockDelta(address(this), currency, int256(amount));
+            return abi.encode(_getFullCredit(currency));
+        }
+
+        if (mode == MODE_DEBT_REVERT_ON_CREDIT) {
+            // Debt query on a positive delta should revert.
+            _mockDelta(address(this), currency, int256(amount));
+            _getFullDebt(currency);
+            return "";
+        }
+
+        if (mode == MODE_CREDIT_REVERT_ON_DEBT) {
+            // Credit query on a negative delta should revert (this path is expected to revert).
+            _take(currency, address(this), amount);
+            _getFullCredit(currency);
+            return "";
+        }
+
+        if (mode == MODE_MAP_SETTLE_OPEN_DELTA) {
+            // OPEN_DELTA maps to full debt for settle.
+            _take(currency, address(this), amount);
+
+            uint256 mapped = _mapSettleAmount(ActionConstants.OPEN_DELTA, currency);
+
+            // Clear the delta before returning.
+            _settle(currency, address(this), amount);
+
+            return abi.encode(mapped);
+        }
+
+        if (mode == MODE_MAP_TAKE_OPEN_DELTA) {
+            // OPEN_DELTA maps to full credit for take.
+            _mockDelta(address(this), currency, int256(amount));
+            return abi.encode(_mapTakeAmount(ActionConstants.OPEN_DELTA, currency));
+        }
+
+        if (mode == MODE_MAP_WRAP_UNWRAP_OPEN_DELTA) {
+            // OPEN_DELTA for wrap/unwrap resolves debt in output currency and checks balance in input currency.
+            _take(outputCurrency, address(this), amount);
+
+            uint256 mapped = _mapWrapUnwrapAmount(inputCurrency, ActionConstants.OPEN_DELTA, outputCurrency);
+
+            _settle(outputCurrency, address(this), amount);
+
+            return abi.encode(mapped);
+        }
+
+        revert("Unknown mode");
+    }
+
+    function _mockDelta(address _target, Currency _currency, int256 _delta) internal {
+        // TransientStateLibrary uses `keccak256(abi.encode(target, currency))` as the key for currency deltas.
+        bytes32 key;
+        assembly ("memory-safe") {
+            mstore(0, and(_target, 0xffffffffffffffffffffffffffffffffffffffff))
+            mstore(32, and(_currency, 0xffffffffffffffffffffffffffffffffffffffff))
+            key := keccak256(0, 64)
+        }
+
+        // currencyDelta reads: int256(uint256(poolManager.exttload(key)))
+        vm.mockCall(
+            address(poolManager),
+            abi.encodeWithSelector(EXTTLOAD_BYTES32_SELECTOR, key),
+            abi.encode(bytes32(uint256(int256(_delta))))
+        );
+    }
+
+    function _pay(Currency _token, address _payer, uint256 _amount) internal override {
+        ERC20 token = ERC20(Currency.unwrap(_token));
+
+        if (_payer == address(this)) {
+            // Solmate `transferFrom` would underflow on allowance[this][this].
+            token.transfer(address(poolManager), _amount);
+        } else {
+            token.transferFrom(_payer, address(poolManager), _amount);
+        }
+
         payCallCount++;
     }
 
-    // needs to receive native tokens from the `take` call
+    function exposed_take(Currency _currency, address _to, uint256 _amount) external {
+        _take(_currency, _to, _amount);
+    }
+
+    function exposed_settle(Currency _currency, address _payer, uint256 _amount) external payable {
+        _settle(_currency, _payer, _amount);
+    }
+
+    function exposed_mapSettleAmount(uint256 _amount, Currency _currency) external view returns (uint256) {
+        return _mapSettleAmount(_amount, _currency);
+    }
+
+    function exposed_mapTakeAmount(uint256 _amount, Currency _currency) external view returns (uint256) {
+        return _mapTakeAmount(_amount, _currency);
+    }
+
+    function exposed_mapWrapUnwrapAmount(Currency _inputCurrency, uint256 _amount, Currency _outputCurrency)
+        external
+        view
+        returns (uint256)
+    {
+        return _mapWrapUnwrapAmount(_inputCurrency, _amount, _outputCurrency);
+    }
+
     receive() external payable {}
 }


### PR DESCRIPTION
### Summary

Adds full branch coverage for `DeltaResolver.sol` by updating `MockDeltaResolver` and `DeltaResolver.t.sol`.

The new tests exercise:
- positive and negative delta paths in `_getFullDebt` / `_getFullCredit`
- early-return behavior in `_take` and `_settle`
- `OPEN_DELTA` and `CONTRACT_BALANCE` handling in amount mapping helpers
- wrap / unwrap balance checks and revert paths

### Notes

- Tests only, no production code changes
- Uses `unlock` context to safely observe transient deltas
- Ensures all deltas are cleared before returning to satisfy PoolManager invariants
