### PR TITLE
docs: update BaseHook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,17 @@ To utilize the contracts and deploy to a local testnet, you can install the code
 forge install https://github.com/Uniswap/v4-periphery
 ```
 
-If you are building hooks, it may be useful to inherit from the `BaseHook` contract:
+If you are building hooks, it may be useful to inherit from the [`BaseHook`](https://github.com/Uniswap/v4-hooks-public/blob/main/src/base/BaseHook.sol) contract from [v4-hooks-public](https://github.com/Uniswap/v4-hooks-public):
 
 ```solidity
-
-import {BaseHook} from 'v4-periphery/src/utils/BaseHook.sol';
-
 contract CoolHook is BaseHook {
     // Override the hook callbacks you want on your hook
-    function beforeAddLiquidity(
+    function _beforeAddLiquidity(
         address,
-        IPoolManager.PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params
-    ) external override onlyByManager returns (bytes4) {
+        PoolKey calldata key,
+        ModifyLiquidityParams calldata params,
+        bytes calldata hookData
+    ) internal override returns (bytes4) {
         // hook logic
         return BaseHook.beforeAddLiquidity.selector;
     }


### PR DESCRIPTION
## Summary

`BaseHook` was removed from this repository in [`5da22e6`](https://github.com/Uniswap/v4-periphery/commit/5da22e609fd78c01fb7ddf2a6abb1f2ec7dc2b87)

This PR updates `README.md` to reflect that change by linking to `BaseHook` in `v4-hooks-public` and replacing the outdated example

The README currently points users to a `BaseHook` path that no longer exists in `v4-periphery`, which can be confusing for hook authors