### PR TITLE
fix: pin npm to specific version in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,7 +41,7 @@ jobs:
         run: forge build
 
       - name: Install npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.7.0
 
       - name: Release
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,7 +41,7 @@ jobs:
         run: forge build
 
       - name: Install npm
-        run: npm install -g npm@11.7.0
+        run: npm install -g github:npm/cli#6d1db8724b1d0e5457a87bb31e62e43d566348ce # npm@11.7.0
 
       - name: Release
         run: |


### PR DESCRIPTION
## Summary
Pin `npm@latest` to `npm@11.7.0` in the deploy workflow to prevent automatically pulling compromised versions of npm or its dependencies.

## What changed
- `.github/workflows/deploy.yaml`: Changed `npm install -g npm@latest` to `npm install -g npm@11.7.0`

## Motivation
The [axios npm supply chain compromise (2026-03-30)](https://github.com/nicedayzhu/axios) demonstrated the risk of using unpinned `@latest` tags in CI pipelines. An attacker who publishes a malicious version to npm can immediately compromise any workflow that installs `@latest`. Pinning to a known-good version eliminates this attack vector.

## Test plan
- [ ] Verify the deploy workflow still runs successfully with the pinned npm version
- [ ] Confirm `npm@11.7.0` is a valid, uncompromised release

🤖 Generated with [Claude Code](https://claude.com/claude-code)