### PR TITLE
fix(test): correct alice balance1 token in mint transfer burn test

### DIFF
--- a/test/position-managers/PositionManager.t.sol
+++ b/test/position-managers/PositionManager.t.sol
@@ -745,7 +745,7 @@ contract PositionManagerTest is Test, PosmTestSetup, LiquidityFuzzers {
         bytes memory calls = getBurnEncoded(tokenId, config, ZERO_BYTES);
 
         uint256 balance0BeforeAlice = currency0.balanceOf(alice);
-        uint256 balance1BeforeAlice = currency0.balanceOf(alice);
+        uint256 balance1BeforeAlice = currency1.balanceOf(alice);
 
         vm.prank(alice);
         lpm.modifyLiquidities(calls, _deadline);


### PR DESCRIPTION
## Related Issue
N/A

## Description of changes
- Fixed token balance tracking bug in mint-transfer-burn test.
- In test_mintTransferBurn, changed `balance1BeforeAlice` to read from `currency1.balanceOf(alice)` instead of `currency0.balanceOf(alice)`.
- This ensures the assertion for token1 payout after burn compares against the correct pre-burn balance.