### PR TITLE
Socksnflops/eco 194 sc m 03 positions can be opened before adapter verification

### DIFF
--- a/src/hooks/permissionedPools/PermissionedHooks.sol
+++ b/src/hooks/permissionedPools/PermissionedHooks.sol
@@ -18,6 +18,7 @@ contract PermissionedHooks is IHooks, ReentrancyLock, BaseHook {
 
     error Unauthorized();
     error SwappingDisabled();
+    error NoVerifiedAdapter();
 
     constructor(IPoolManager manager, IPermissionsAdapterFactory permissionsAdapterFactory) BaseHook(manager) {
         PERMISSIONS_ADAPTER_FACTORY = permissionsAdapterFactory;
@@ -26,8 +27,19 @@ contract PermissionedHooks is IHooks, ReentrancyLock, BaseHook {
 
     /// @dev Returns the hook permissions configuration for this contract
     function getHookPermissions() public pure override returns (Hooks.Permissions memory permissions) {
+        permissions.beforeInitialize = true;
         permissions.beforeSwap = true;
         permissions.beforeAddLiquidity = true;
+    }
+
+    /// @dev Requires at least one pool currency to be a verified permissions adapter
+    function _beforeInitialize(address, PoolKey calldata key, uint160) internal view override returns (bytes4) {
+        bool currency0Verified =
+            PERMISSIONS_ADAPTER_FACTORY.verifiedPermissionsAdapterOf(Currency.unwrap(key.currency0)) != address(0);
+        bool currency1Verified =
+            PERMISSIONS_ADAPTER_FACTORY.verifiedPermissionsAdapterOf(Currency.unwrap(key.currency1)) != address(0);
+        if (!currency0Verified && !currency1Verified) revert NoVerifiedAdapter();
+        return IHooks.beforeInitialize.selector;
     }
 
     /// @dev Does not need to verify msg.sender address directly, as verifying the allowlist is sufficient due to the fact that any valid senders are allowed wrappers

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -115,14 +115,6 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             SQRT_PRICE_1_1
         );
 
-        Currency currencyA = currency2;
-        Currency currencyB = currency0;
-        if (currencyA > currencyB) {
-            currencyA = currency0;
-            currencyB = currency2;
-        }
-
-        (key3, poolId) = initPool(currencyA, currencyB, permissionedHooks, 3000, SQRT_PRICE_1_1);
         (keyFake0, poolId) = initPool(
             Currency.wrap(address(permissionsAdapter0)), currency1, secondaryPermissionedHooks, 3000, SQRT_PRICE_1_1
         );
@@ -269,15 +261,16 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     function test_modifyLiquidities_reverts_reentrancy() public {
         PoolKey memory key;
 
-        // Create a reentrant token and initialize the pool
+        // Create a reentrant token and initialize the pool with a verified adapter so beforeInitialize passes
         Currency reentrantToken = Currency.wrap(address(new ReentrantToken(lpm)));
-        (currency0, currency1) = (Currency.unwrap(reentrantToken) < Currency.unwrap(currency1))
-            ? (reentrantToken, currency1)
-            : (currency1, reentrantToken);
+        Currency adapterCurrency = Currency.wrap(address(permissionsAdapter0));
+        (Currency c0, Currency c1) = (Currency.unwrap(reentrantToken) < Currency.unwrap(adapterCurrency))
+            ? (reentrantToken, adapterCurrency)
+            : (adapterCurrency, reentrantToken);
 
         // Set up approvals for the reentrant token
         approvePosmCurrency(reentrantToken);
-        (key, poolId) = initPool(currency0, currency1, permissionedHooks, 3000, SQRT_PRICE_1_1);
+        (key, poolId) = initPool(c0, c1, permissionedHooks, 3000, SQRT_PRICE_1_1);
 
         // Try to add liquidity at that range, but the token reenters posm
         PositionConfig memory config =

--- a/test/hooks/permissionedPools/PermissionedV4Router.t.sol
+++ b/test/hooks/permissionedPools/PermissionedV4Router.t.sol
@@ -15,7 +15,7 @@ import {PermissionedRoutingTestHelpers} from "./shared/PermissionedRoutingTestHe
 import {Planner} from "../../shared/Planner.sol";
 import {Actions} from "../../../src/libraries/Actions.sol";
 import {ActionConstants} from "../../../src/libraries/ActionConstants.sol";
-import {MockPermissionedToken} from "./PermissionedPoolsBase.sol";
+import {MockPermissionedToken, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
 import {PermissionFlags, PermissionFlag} from "../../../src/hooks/permissionedPools/libraries/PermissionFlags.sol";
 import {PathKey} from "../../../src/libraries/PathKey.sol";
 
@@ -27,6 +27,7 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
     error Unauthorized();
     error HookCallFailed();
     error SliceOutOfBounds();
+    error NoVerifiedAdapter();
     error InvalidCommandType(uint256 commandType);
     error ExecutionFailed(uint256 commandIndex, bytes output);
 
@@ -1031,8 +1032,17 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
         tokenPath.push(currency2);
         tokenPath.push(currency3);
 
-        IV4Router.ExactInputParams memory params =
-            _getExactInputParamsWithHook(tokenPath, amountIn, address(permissionedHooks), expectedAmountOut);
+        // Build path manually: first two hops use permissionedHooks, last hop uses address(0) (key2 is hookless)
+        PathKey[] memory path = new PathKey[](3);
+        path[0] = PathKey(permissionsAdapter1Currency, 3000, 60, IHooks(address(permissionedHooks)), bytes(""));
+        path[1] = PathKey(currency2, 3000, 60, IHooks(address(permissionedHooks)), bytes(""));
+        path[2] = PathKey(currency3, 3000, 60, IHooks(address(0)), bytes(""));
+        IV4Router.ExactInputParams memory params = IV4Router.ExactInputParams({
+            currencyIn: permissionsAdapter0Currency,
+            path: path,
+            amountIn: uint128(amountIn),
+            amountOutMinimum: uint128(expectedAmountOut)
+        });
 
         plan = plan.add(Actions.SWAP_EXACT_IN, abi.encode(params));
 
@@ -1493,8 +1503,20 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
         tokenPath.push(currency2);
         tokenPath.push(currency3);
 
-        IV4Router.ExactOutputParams memory params =
-            _getExactOutputParamsWithHook(tokenPath, amountOut, address(permissionedHooks), expectedAmountIn);
+        // Build path following _getExactOutputParamsWithHook pattern:
+        // path[2] = currency2 (hop: currency3→currency2, hookless pool)
+        // path[1] = adapter1 (hop: currency2→adapter1, permissioned)
+        // path[0] = adapter0 (hop: adapter1→adapter0, permissioned)
+        PathKey[] memory path = new PathKey[](3);
+        path[0] = PathKey(permissionsAdapter0Currency, 3000, 60, IHooks(address(permissionedHooks)), bytes(""));
+        path[1] = PathKey(permissionsAdapter1Currency, 3000, 60, IHooks(address(permissionedHooks)), bytes(""));
+        path[2] = PathKey(currency2, 3000, 60, IHooks(address(0)), bytes(""));
+        IV4Router.ExactOutputParams memory params = IV4Router.ExactOutputParams({
+            currencyOut: currency3,
+            path: path,
+            amountOut: uint128(amountOut),
+            amountInMaximum: uint128(expectedAmountIn)
+        });
 
         plan = plan.add(Actions.SWAP_EXACT_OUT, abi.encode(params));
 
@@ -1925,8 +1947,6 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
         vm.expectRevert(HookNotImplemented.selector);
         permissionedHooks.afterSwap(address(this), key0, swapParams, balanceDelta, bytes(""));
         vm.expectRevert(HookNotImplemented.selector);
-        permissionedHooks.beforeInitialize(address(this), key0, 0);
-        vm.expectRevert(HookNotImplemented.selector);
         permissionedHooks.afterInitialize(address(this), key0, 0, 0);
         vm.expectRevert(HookNotImplemented.selector);
         permissionedHooks.beforeRemoveLiquidity(address(this), key0, modifyLiquidityParams, bytes(""));
@@ -1973,6 +1993,50 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
         weth9.approve(address(permissionedRouter), 1 ether);
         weth9.withdraw(1 ether);
         vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    POOL INITIALIZATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_initialize_reverts_no_verified_adapter() public {
+        // Two non-permissioned tokens — neither is a verified adapter
+        (Currency c0, Currency c1) = currency2 < currency3 ? (currency2, currency3) : (currency3, currency2);
+        PoolKey memory unverifiedKey = PoolKey(c0, c1, 3000, 60, permissionedHooks);
+        vm.expectRevert();
+        manager.initialize(unverifiedKey, SQRT_PRICE_1_1);
+    }
+
+    function test_initialize_succeeds_one_verified_adapter() public {
+        Currency adapterCurrency = Currency.wrap(address(permissionsAdapter1));
+        (Currency c0, Currency c1) =
+            adapterCurrency < currency3 ? (adapterCurrency, currency3) : (currency3, adapterCurrency);
+        PoolKey memory oneAdapterKey = PoolKey(c0, c1, 500, 10, permissionedHooks);
+        manager.initialize(oneAdapterKey, SQRT_PRICE_1_1);
+    }
+
+    function test_initialize_succeeds_two_verified_adapters() public {
+        Currency a0 = Currency.wrap(address(permissionsAdapter0));
+        Currency a1 = Currency.wrap(address(permissionsAdapter1));
+        (Currency c0, Currency c1) = a0 < a1 ? (a0, a1) : (a1, a0);
+        PoolKey memory twoAdapterKey = PoolKey(c0, c1, 500, 10, permissionedHooks);
+        manager.initialize(twoAdapterKey, SQRT_PRICE_1_1);
+    }
+
+    function test_initialize_reverts_unverified_adapter() public {
+        // Create an adapter for a permissioned token but do NOT verify it — the M-03 attack path
+        // currency0 is a MockPermissionedToken (first 2 tokens in setup are permissioned)
+        IERC20 token = IERC20(Currency.unwrap(currency0));
+        MockAllowlistChecker checker = new MockAllowlistChecker(MockPermissionedToken(address(token)));
+        address unverifiedAdapter = permissionsAdapterFactory.createPermissionsAdapter(token, address(this), checker);
+        // Do NOT verify — skip transferring 1 wei and calling verifyPermissionsAdapter
+
+        Currency adapterCurrency = Currency.wrap(unverifiedAdapter);
+        (Currency c0, Currency c1) =
+            adapterCurrency < currency4 ? (adapterCurrency, currency4) : (currency4, adapterCurrency);
+        PoolKey memory attackKey = PoolKey(c0, c1, 3000, 60, permissionedHooks);
+        vm.expectRevert();
+        manager.initialize(attackKey, SQRT_PRICE_1_1);
     }
 
     receive() external payable {}

--- a/test/hooks/permissionedPools/shared/PermissionedDeployers.sol
+++ b/test/hooks/permissionedPools/shared/PermissionedDeployers.sol
@@ -131,7 +131,7 @@ contract PermissionedDeployers is Test {
         internal
         returns (address deployedHooksAddr)
     {
-        uint160 flags = (1 << 11) | (1 << 7);
+        uint160 flags = (1 << 13) | (1 << 11) | (1 << 7);
         (address calculatedAddr, bytes32 salt) = HookMiner.find(
             address(this),
             flags,

--- a/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
+++ b/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
@@ -432,7 +432,7 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
         );
         key1 =
             createPoolWithLiquidity(Currency.wrap(address(permissionsAdapter1)), currency2, address(permissionedHooks));
-        key2 = createPoolWithLiquidity(currency2, currency3, address(permissionedHooks));
+        key2 = createPoolWithLiquidity(currency2, currency3, address(0));
         key3 =
             createPoolWithLiquidity(Currency.wrap(address(permissionsAdapter0)), currency4, address(permissionedHooks));
         insecureKey = createPoolWithLiquidity(


### PR DESCRIPTION
## Related Issue                                                                                                                                                                                                                               
ECO-194](https://linear.app/uniswap/issue/ECO-194/sc-m-03-positions-can-be-opened-before-adapter-verification-and-later)
                                                                                                                                                                                                                                                 
## Description of changes                                     
- Added `beforeInitialize` hook to `PermissionedHooks` that requires at least one pool currency to be a verified adapter, preventing positions from being opened before adapter verification                                                   
- Fixed existing unit tests to remove pools with non-verified-permissions-adapter tokens from permissionedHooks (converted them to regular pools)