### PR TITLE
fix(permissioned-position-manager): updating the name and symbol of perm-posm to be different from regular posm

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -37,6 +37,7 @@ contract PermissionedPositionManager is PositionManager {
         IPermissionsAdapterFactory _permissionsAdapterFactory
     ) PositionManager(_poolManager, _permit2, _unsubscribeGasLimit, _tokenDescriptor, _weth9) {
         PERMISSIONS_ADAPTER_FACTORY = _permissionsAdapterFactory;
+        /// @dev The EIP712 domain separator still uses "Uniswap v4 Positions NFT" as the name
         name = "Uniswap v4 Permissioned Positions NFT";
         symbol = "UNI-V4-PERM-POSM";
     }

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -37,6 +37,8 @@ contract PermissionedPositionManager is PositionManager {
         IPermissionsAdapterFactory _permissionsAdapterFactory
     ) PositionManager(_poolManager, _permit2, _unsubscribeGasLimit, _tokenDescriptor, _weth9) {
         PERMISSIONS_ADAPTER_FACTORY = _permissionsAdapterFactory;
+        name = "Uniswap v4 Permissioned Positions NFT";
+        symbol = "UNI-V4-PERM-POSM";
     }
 
     /// @notice Sets the allowed hook for a given permissions adapter

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -18,6 +18,7 @@ import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol"
 import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 
 import {IPositionManager} from "../../../src/interfaces/IPositionManager.sol";
+import {ERC721} from "solmate/src/tokens/ERC721.sol";
 import {Actions} from "../../../src/libraries/Actions.sol";
 import {DeltaResolver} from "../../../src/base/DeltaResolver.sol";
 import {PositionConfig} from "test/shared/PositionConfig.sol";
@@ -229,6 +230,12 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         bytes memory data = abi.encodeWithSelector(selector, currency, permissionedHooks_, true);
         (bool success,) = address(posm).call(data);
         require(success, "Failed to set hooks");
+    }
+
+    function test_erc721_metadata_distinct_from_positionManager() public view {
+        ERC721 posm = ERC721(address(lpm));
+        assertEq(posm.name(), "Uniswap v4 Permissioned Positions NFT");
+        assertEq(posm.symbol(), "UNI-V4-PERM-POSM");
     }
 
     function test_modifyLiquidities_reverts_deadlinePassed() public {

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -232,7 +232,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         require(success, "Failed to set hooks");
     }
 
-    function test_erc721_metadata_distinct_from_positionManager() public view {
+    function test_nameAndSymbol() public view {
         ERC721 posm = ERC721(address(lpm));
         assertEq(posm.name(), "Uniswap v4 Permissioned Positions NFT");
         assertEq(posm.symbol(), "UNI-V4-PERM-POSM");


### PR DESCRIPTION
## Related Issue                                                                                                                                                                                                                               
[ECO-199](https://linear.app/uniswap/issue/ECO-199/sc-l-05-permissionedpositionmanager-uses-the-same-erc-721-name-and)
                                                                                                                                                                                                                                                 
## Description of changes
- `PermissionedPositionManager` inherited the same ERC-721 `name` and `symbol` as `PositionManager` (`"Uniswap v4 Positions NFT"` / `"UNI-V4-POSM"`). This overrides them in the constructor with distinct values (`"Uniswap v4 Permissioned Positions NFT"` / `"UNI-V4-PERM-POSM"`) so offchain tools can reliably distinguish the two collections.
- Adds a unit test to verify.  