### PR TITLE
fix(permissioned-pools): address audit findings N-01, N-02, N-06 (ECO-200, ECO-222, ECO-226) 

### DIFF
--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "231176"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "231126"
 }

--- a/src/base/DeltaResolver.sol
+++ b/src/base/DeltaResolver.sol
@@ -12,9 +12,9 @@ import {ActionConstants} from "../libraries/ActionConstants.sol";
 abstract contract DeltaResolver is ImmutableState {
     using TransientStateLibrary for IPoolManager;
 
-    /// @notice Emitted trying to take a negative delta.
+    /// @notice Emitted when unexpected negative delta is found.
     error DeltaNotPositive(Currency currency);
-    /// @notice Emitted trying to settle a positive delta.
+    /// @notice Emitted when unexpected positive delta is found.
     error DeltaNotNegative(Currency currency);
     /// @notice Emitted when the contract does not have enough balance to wrap or unwrap.
     error InsufficientBalance();

--- a/src/base/DeltaResolver.sol
+++ b/src/base/DeltaResolver.sol
@@ -12,9 +12,9 @@ import {ActionConstants} from "../libraries/ActionConstants.sol";
 abstract contract DeltaResolver is ImmutableState {
     using TransientStateLibrary for IPoolManager;
 
-    /// @notice Emitted trying to settle a positive delta.
-    error DeltaNotPositive(Currency currency);
     /// @notice Emitted trying to take a negative delta.
+    error DeltaNotPositive(Currency currency);
+    /// @notice Emitted trying to settle a positive delta.
     error DeltaNotNegative(Currency currency);
     /// @notice Emitted when the contract does not have enough balance to wrap or unwrap.
     error InsufficientBalance();

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -37,6 +37,8 @@ contract PermissionedPositionManager is PositionManager {
         IPermissionsAdapterFactory _permissionsAdapterFactory
     ) PositionManager(_poolManager, _permit2, _unsubscribeGasLimit, _tokenDescriptor, _weth9) {
         PERMISSIONS_ADAPTER_FACTORY = _permissionsAdapterFactory;
+        name = "Uniswap v4 Permissioned Positions NFT";
+        symbol = "UNI-V4-PERM-POSM";
     }
 
     /// @notice Sets the allowed hook for a given permissions adapter

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -101,9 +101,7 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
             revert InvalidTransfer(from, to);
         }
         super._update(from, to, amount);
-        if (from == POOL_MANAGER) {
-            _unwrap(to, amount);
-        }
+        _unwrap(to, amount);
         // the pool manager must always be the only holder of the permissions adapter
         assert(balanceOf(POOL_MANAGER) == totalSupply());
     }

--- a/src/hooks/permissionedPools/PermissionsAdapterFactory.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapterFactory.sol
@@ -36,13 +36,13 @@ contract PermissionsAdapterFactory is IPermissionsAdapterFactory {
         IERC20 permissionedToken = IERC20(permissionsAdapterOf[permissionsAdapter]);
         if (address(permissionedToken) == address(0)) revert PermissionsAdapterNotFound(permissionsAdapter);
         if (verifiedPermissionsAdapterOf[permissionsAdapter] != address(0)) {
-            revert PemissionsAdapterAlreadyVerified(permissionsAdapter);
+            revert PermissionsAdapterAlreadyVerified(permissionsAdapter);
         }
         // this requires that the verifier has some control or ownership of the permissioned token
         if (permissionedToken.balanceOf(permissionsAdapter) == 0) {
-            revert PemissionsAdapterNotVerified(permissionsAdapter);
+            revert PermissionsAdapterNotVerified(permissionsAdapter);
         }
         verifiedPermissionsAdapterOf[permissionsAdapter] = address(permissionedToken);
-        emit PemissionsAdapterVerified(permissionsAdapter, address(permissionedToken));
+        emit PermissionsAdapterVerified(permissionsAdapter, address(permissionedToken));
     }
 }

--- a/src/hooks/permissionedPools/interfaces/IPermissionsAdapterFactory.sol
+++ b/src/hooks/permissionedPools/interfaces/IPermissionsAdapterFactory.sol
@@ -9,16 +9,16 @@ interface IPermissionsAdapterFactory {
     event PermissionsAdapterCreated(address indexed permissionsAdapter, address indexed permissionedToken);
 
     /// @notice Emitted when a permissions adapter is verified
-    event PemissionsAdapterVerified(address indexed permissionsAdapter, address indexed permissionedToken);
+    event PermissionsAdapterVerified(address indexed permissionsAdapter, address indexed permissionedToken);
 
     /// @notice Thrown when the permissions adapter does not exist
     error PermissionsAdapterNotFound(address permissionsAdapter);
 
     /// @notice Thrown when the permissions adapter is already verified
-    error PemissionsAdapterAlreadyVerified(address permissionsAdapter);
+    error PermissionsAdapterAlreadyVerified(address permissionsAdapter);
 
     /// @notice Thrown when the permissions adapter is not verified
-    error PemissionsAdapterNotVerified(address permissionsAdapter);
+    error PermissionsAdapterNotVerified(address permissionsAdapter);
 
     /// @notice Creates a new permissions adapter
     /// @param permissionedToken The permissioned token to wrap

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -18,6 +18,7 @@ import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol"
 import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 
 import {IPositionManager} from "../../../src/interfaces/IPositionManager.sol";
+import {ERC721} from "solmate/src/tokens/ERC721.sol";
 import {Actions} from "../../../src/libraries/Actions.sol";
 import {DeltaResolver} from "../../../src/base/DeltaResolver.sol";
 import {PositionConfig} from "test/shared/PositionConfig.sol";
@@ -229,6 +230,12 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         bytes memory data = abi.encodeWithSelector(selector, currency, permissionedHooks_, true);
         (bool success,) = address(posm).call(data);
         require(success, "Failed to set hooks");
+    }
+
+    function test_erc721_metadata_distinct_from_positionManager() public view {
+        ERC721 posm = ERC721(address(lpm));
+        assertEq(posm.name(), "Uniswap v4 Permissioned Positions NFT");
+        assertEq(posm.symbol(), "UNI-V4-PERM-POSM");
     }
 
     function test_modifyLiquidities_reverts_deadlinePassed() public {

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -158,7 +158,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
                 break;
             }
         }
-        setUpPemissionsAdapter(permissionsAdapter0, currency0);
+        setUpPermissionsAdapter(permissionsAdapter0, currency0);
     }
 
     function setUpCurrencyTwo() internal {
@@ -176,7 +176,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
                 break;
             }
         }
-        setUpPemissionsAdapter(permissionsAdapter2, currency2);
+        setUpPermissionsAdapter(permissionsAdapter2, currency2);
     }
 
     function setUpAllowlist(Currency currency) internal {
@@ -195,7 +195,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             .setAllowlist(address(permissionedHooks), PermissionFlags.ALL_ALLOWED);
     }
 
-    function setUpPemissionsAdapter(PermissionsAdapter permissionsAdapter, Currency currency) internal {
+    function setUpPermissionsAdapter(PermissionsAdapter permissionsAdapter, Currency currency) internal {
         adapterToPermissioned[Currency.wrap(address(permissionsAdapter))] = currency;
 
         MockPermissionedToken(Currency.unwrap(currency)).mint(address(this), 1000 ether);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -232,7 +232,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         require(success, "Failed to set hooks");
     }
 
-    function test_erc721_metadata_distinct_from_positionManager() public view {
+    function test_nameAndSymbol() public view {
         ERC721 posm = ERC721(address(lpm));
         assertEq(posm.name(), "Uniswap v4 Permissioned Positions NFT");
         assertEq(posm.symbol(), "UNI-V4-PERM-POSM");

--- a/test/hooks/permissionedPools/PermissionsAdapterFactory.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapterFactory.t.sol
@@ -46,36 +46,38 @@ contract PermissionsAdapterFactoryTest is PermissionedPoolsBase {
         assertEq(permissionsAdapterFactory.verifiedPermissionsAdapterOf(permissionsAdapter), address(0));
     }
 
-    function testRevert_WhenPemissionsAdapterNotDeployed(address permissionsAdapter) public {
+    function testRevert_WhenPermissionsAdapterNotDeployed(address permissionsAdapter) public {
         vm.expectRevert(
             abi.encodeWithSelector(IPermissionsAdapterFactory.PermissionsAdapterNotFound.selector, permissionsAdapter)
         );
         permissionsAdapterFactory.verifyPermissionsAdapter(permissionsAdapter);
     }
 
-    function testRevert_WhenPemissionsAdapterNotVerified() public {
+    function testRevert_WhenPermissionsAdapterNotVerified() public {
         address permissionsAdapter = permissionsAdapterFactory.createPermissionsAdapter(
             permissionedToken, makeAddr("initialOwner"), allowlistChecker
         );
         vm.expectRevert(
-            abi.encodeWithSelector(IPermissionsAdapterFactory.PemissionsAdapterNotVerified.selector, permissionsAdapter)
+            abi.encodeWithSelector(
+                IPermissionsAdapterFactory.PermissionsAdapterNotVerified.selector, permissionsAdapter
+            )
         );
         permissionsAdapterFactory.verifyPermissionsAdapter(permissionsAdapter);
     }
 
-    function test_VerifyPemissionsAdapter() public {
+    function test_VerifyPermissionsAdapter() public {
         address permissionsAdapter = permissionsAdapterFactory.createPermissionsAdapter(
             permissionedToken, makeAddr("initialOwner"), allowlistChecker
         );
         permissionedToken.setAllowlist(permissionsAdapter, PermissionFlags.ALL_ALLOWED);
         permissionedToken.mint(permissionsAdapter, 1);
         vm.expectEmit(true, true, true, true);
-        emit IPermissionsAdapterFactory.PemissionsAdapterVerified(permissionsAdapter, address(permissionedToken));
+        emit IPermissionsAdapterFactory.PermissionsAdapterVerified(permissionsAdapter, address(permissionedToken));
         permissionsAdapterFactory.verifyPermissionsAdapter(permissionsAdapter);
         assertEq(permissionsAdapterFactory.verifiedPermissionsAdapterOf(permissionsAdapter), address(permissionedToken));
     }
 
-    function testRevert_WhenPemissionsAdapterAlreadyVerified() public {
+    function testRevert_WhenPermissionsAdapterAlreadyVerified() public {
         address permissionsAdapter = permissionsAdapterFactory.createPermissionsAdapter(
             permissionedToken, makeAddr("initialOwner"), allowlistChecker
         );
@@ -84,7 +86,7 @@ contract PermissionsAdapterFactoryTest is PermissionedPoolsBase {
         permissionsAdapterFactory.verifyPermissionsAdapter(permissionsAdapter);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IPermissionsAdapterFactory.PemissionsAdapterAlreadyVerified.selector, permissionsAdapter
+                IPermissionsAdapterFactory.PermissionsAdapterAlreadyVerified.selector, permissionsAdapter
             )
         );
         permissionsAdapterFactory.verifyPermissionsAdapter(permissionsAdapter);

--- a/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
+++ b/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
@@ -70,7 +70,7 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
         _deployWETH();
         _deployPositionDescriptor();
         _deployPermit2();
-        _deployPemissionsAdapterFactory();
+        _deployPermissionsAdapterFactory();
         _deployPermissionedHooks();
         _deployInsecureHook();
         _deployMockPermissionedRouter();
@@ -369,7 +369,7 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
         permit2 = IAllowanceTransfer(deployPermit2());
     }
 
-    function _deployPemissionsAdapterFactory() private {
+    function _deployPermissionsAdapterFactory() private {
         bytes memory permissionsAdapterFactoryBytecode = abi.encodePacked(
             vm.getCode("PermissionsAdapterFactory.sol:PermissionsAdapterFactory"), abi.encode(address(manager))
         );


### PR DESCRIPTION
## Related Issue                                                                                                                                                                                                                               
- https://linear.app/uniswap/issue/ECO-200/sc-n-01-redundant-conditional-in-permissionsadapter-update
- https://linear.app/uniswap/issue/ECO-222/sc-n-02-typos-in-events-and-errors-in-ipermissionsadapterfactory                                                                                                                                      
- https://linear.app/uniswap/issue/ECO-226/sc-n-06-inverted-natspec-for-deltanotpositivedeltanotnegative-in                                                                                                                                      
                                                                                                                                                                                                                                                 
  ## Description of changes
- Merge after: https://github.com/Uniswap/v4-periphery/pull/529
- Addresses three minor audit notes:
  - **N-01**: Removes redundant `if (from == POOL_MANAGER)` conditional in `PermissionsAdapter._update` — after prior checks, `from` is guaranteed to be `POOL_MANAGER` at that point.
  - **N-02**: Fixes `Pemissions` → `Permissions` typo in `IPermissionsAdapterFactory` errors/events and all references in the factory and tests.
  - **N-06**: Swaps inverted NatSpec on `DeltaNotPositive` / `DeltaNotNegative` in `DeltaResolver` to match actual usage.