### PR TITLE
fix(permissioned-position-manager): validate recipient in transferFrom (ECO-196)

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -58,7 +58,8 @@ contract PermissionedPositionManager is PositionManager {
     }
 
     /// @inheritdoc PositionManager
-    /// @dev Only allow admins of permissioned tokens to transfer positions that contain their tokens
+    /// @dev Only allow admins of permissioned tokens to transfer positions that contain their tokens,
+    /// and only to recipients that are allowlisted for each permissioned currency in the pool.
     function transferFrom(address from, address to, uint256 id) public override onlyIfPoolManagerLocked {
         (PoolKey memory poolKey,) = getPoolAndPositionInfo(id);
         address admin1 = _getOwner(poolKey.currency0);
@@ -66,6 +67,8 @@ contract PermissionedPositionManager is PositionManager {
         if (msg.sender != admin1 && msg.sender != admin2) {
             revert Unauthorized();
         }
+        _checkRecipientAllowed(poolKey.currency0, to);
+        _checkRecipientAllowed(poolKey.currency1, to);
         getApproved[id] = msg.sender;
         super.transferFrom(from, to, id);
     }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1090,6 +1090,51 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         IERC721(address(lpm)).transferFrom(alice, address(this), tokenId3);
     }
 
+    function test_transferFrom_revert_recipient_not_allowlisted_mixed_pool() public {
+        // key0 is permissioned/normal, key1 is normal/permissioned
+        uint256 tokenId0 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+        uint256 tokenId1 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key1);
+
+        address notAllowed = makeAddr("NOT_ALLOWED");
+
+        // admin is address(this) for both adapters; recipient is not on either allowlist
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId0);
+
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId1);
+    }
+
+    function test_transferFrom_revert_recipient_not_allowlisted_both_permissioned() public {
+        // key2 has two permissioned currencies
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        address notAllowed = makeAddr("NOT_ALLOWED");
+
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId);
+    }
+
+    function test_transferFrom_success_recipient_allowlisted_after_seize() public {
+        // admin can seize a key2 position to a fresh recipient after allowlisting them
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        address recipient = makeAddr("NEW_HOLDER");
+
+        vm.expectRevert(Unauthorized.selector);
+        IERC721(address(lpm)).transferFrom(alice, recipient, tokenId);
+
+        // admin allowlists the recipient on the permissioned token backing the shared checker
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(recipient, PermissionFlags.ALL_ALLOWED);
+
+        IERC721(address(lpm)).transferFrom(alice, recipient, tokenId);
+        assertEq(IERC721(address(lpm)).ownerOf(tokenId), recipient);
+    }
+
     error SafeTransferDisabled();
 
     function test_safe_transfer_from_reverts() public {


### PR DESCRIPTION
## Summary
- Addresses **ECO-196**: admin-initiated `transferFrom` on `PermissionedPositionManager` did not validate the `to` address, so an authorized admin could transfer a permissioned position NFT to an address that is not allowlisted, bypassing holder-level policy.
- Applies the existing `_checkRecipientAllowed` check (same `LIQUIDITY_ALLOWED` policy already enforced in `_mint`) to the recipient for each permissioned currency in the pool before calling `super.transferFrom`.
- No behavior change for non-permissioned currencies (`_checkRecipientAllowed` no-ops when `_verifiedPermissionedTokenOf` returns `address(0)`).

## Behavior change
Admins can no longer transfer a permissioned position to arbitrary addresses — the recipient must be allowlisted for every permissioned currency in the pool (including the admin themselves on a self-seize).

## Test plan
- [x] `test_transferFrom_revert_recipient_not_allowlisted_mixed_pool` — admin→non-allowlisted reverts on `key0` and `key1` (mixed permissioned/normal).
- [x] `test_transferFrom_revert_recipient_not_allowlisted_both_permissioned` — admin→non-allowlisted reverts on `key2` (both currencies permissioned).
- [x] `test_transferFrom_success_recipient_allowlisted_after_seize` — fresh recipient becomes transferable after being allowlisted.
- [x] Existing `test_transferFrom_success_seize_by_admin` / `_by_either_admin` / `_revert_not_admin` still pass.
- [x] Full `PermissionedPositionManager.t.sol` suite green (49/49).

Note: a fourth scenario ("allowlisted on only one side of a dual-permissioned pool must still revert") is not expressible in the current test harness because both `PermissionsAdapter`s share one `MockAllowlistChecker` backed by `currency0`'s permissions. The dual-currency revert is still covered by `test_transferFrom_revert_recipient_not_allowlisted_both_permissioned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)