### PR TITLE
fix(permissioned-pools): use solmate SafeTransferLib in PermissionsAdapter._unwrap (ECO-198)

### DIFF
--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "231435"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "230903"
 }

--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "231126"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "231435"
 }

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -3,15 +3,15 @@ pragma solidity 0.8.26;
 
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
-import {ERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {ERC20 as SolmateERC20} from "solmate/src/tokens/ERC20.sol";
+import {ERC20 as OZERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
 import {SafeTransferLib} from "solmate/src/utils/SafeTransferLib.sol";
 import {IPermissionsAdapter} from "./interfaces/IPermissionsAdapter.sol";
 import {IAllowlistChecker} from "./interfaces/IAllowlistChecker.sol";
 import {PermissionFlag} from "./libraries/PermissionFlags.sol";
 
-contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
-    using SafeTransferLib for SolmateERC20;
+contract PermissionsAdapter is OZERC20, Ownable2Step, IPermissionsAdapter {
+    using SafeTransferLib for ERC20;
 
     /// @inheritdoc IPermissionsAdapter
     address public immutable POOL_MANAGER;
@@ -33,7 +33,7 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
         address poolManager,
         address initialOwner,
         IAllowlistChecker allowListChecker_
-    ) ERC20(_getName(permissionedToken), _getSymbol(permissionedToken)) Ownable(initialOwner) {
+    ) OZERC20(_getName(permissionedToken), _getSymbol(permissionedToken)) Ownable(initialOwner) {
         PERMISSIONED_TOKEN = permissionedToken;
         POOL_MANAGER = poolManager;
         _updateAllowListChecker(allowListChecker_);
@@ -112,7 +112,7 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
 
     function _unwrap(address account, uint256 amount) internal {
         _burn(account, amount);
-        SolmateERC20(address(PERMISSIONED_TOKEN)).safeTransfer(account, amount);
+        ERC20(address(PERMISSIONED_TOKEN)).safeTransfer(account, amount);
     }
 
     function _getName(IERC20 permissionedToken) private view returns (string memory) {

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -3,15 +3,15 @@ pragma solidity 0.8.26;
 
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
-import {ERC20 as OZERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {ERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20 as SafeERC20} from "solmate/src/tokens/ERC20.sol";
 import {SafeTransferLib} from "solmate/src/utils/SafeTransferLib.sol";
 import {IPermissionsAdapter} from "./interfaces/IPermissionsAdapter.sol";
 import {IAllowlistChecker} from "./interfaces/IAllowlistChecker.sol";
 import {PermissionFlag} from "./libraries/PermissionFlags.sol";
 
-contract PermissionsAdapter is OZERC20, Ownable2Step, IPermissionsAdapter {
-    using SafeTransferLib for ERC20;
+contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
+    using SafeTransferLib for SafeERC20;
 
     /// @inheritdoc IPermissionsAdapter
     address public immutable POOL_MANAGER;
@@ -33,7 +33,7 @@ contract PermissionsAdapter is OZERC20, Ownable2Step, IPermissionsAdapter {
         address poolManager,
         address initialOwner,
         IAllowlistChecker allowListChecker_
-    ) OZERC20(_getName(permissionedToken), _getSymbol(permissionedToken)) Ownable(initialOwner) {
+    ) ERC20(_getName(permissionedToken), _getSymbol(permissionedToken)) Ownable(initialOwner) {
         PERMISSIONED_TOKEN = permissionedToken;
         POOL_MANAGER = poolManager;
         _updateAllowListChecker(allowListChecker_);
@@ -112,7 +112,7 @@ contract PermissionsAdapter is OZERC20, Ownable2Step, IPermissionsAdapter {
 
     function _unwrap(address account, uint256 amount) internal {
         _burn(account, amount);
-        ERC20(address(PERMISSIONED_TOKEN)).safeTransfer(account, amount);
+        SafeERC20(address(PERMISSIONED_TOKEN)).safeTransfer(account, amount);
     }
 
     function _getName(IERC20 permissionedToken) private view returns (string memory) {

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IPermissionsAdapter} from "./interfaces/IPermissionsAdapter.sol";
 import {IAllowlistChecker} from "./interfaces/IAllowlistChecker.sol";
 import {PermissionFlag} from "./libraries/PermissionFlags.sol";
@@ -108,7 +109,7 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
 
     function _unwrap(address account, uint256 amount) internal {
         _burn(account, amount);
-        PERMISSIONED_TOKEN.transfer(account, amount);
+        SafeERC20.safeTransfer(PERMISSIONED_TOKEN, account, amount);
     }
 
     function _getName(IERC20 permissionedToken) private view returns (string memory) {

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -4,12 +4,15 @@ pragma solidity 0.8.26;
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC20 as SolmateERC20} from "solmate/src/tokens/ERC20.sol";
+import {SafeTransferLib} from "solmate/src/utils/SafeTransferLib.sol";
 import {IPermissionsAdapter} from "./interfaces/IPermissionsAdapter.sol";
 import {IAllowlistChecker} from "./interfaces/IAllowlistChecker.sol";
 import {PermissionFlag} from "./libraries/PermissionFlags.sol";
 
 contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
+    using SafeTransferLib for SolmateERC20;
+
     /// @inheritdoc IPermissionsAdapter
     address public immutable POOL_MANAGER;
 
@@ -109,7 +112,7 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
 
     function _unwrap(address account, uint256 amount) internal {
         _burn(account, amount);
-        SafeERC20.safeTransfer(PERMISSIONED_TOKEN, account, amount);
+        SolmateERC20(address(PERMISSIONED_TOKEN)).safeTransfer(account, amount);
     }
 
     function _getName(IERC20 permissionedToken) private view returns (string memory) {

--- a/test/hooks/permissionedPools/PermissionsAdapter.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapter.t.sol
@@ -6,7 +6,6 @@ import {
     IAllowlistChecker
 } from "../../../src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol";
 import {ERC20, IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {PermissionedPoolsBase, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {PermissionFlags, PermissionFlag} from "../../../src/hooks/permissionedPools/libraries/PermissionFlags.sol";
@@ -158,7 +157,7 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
 
         address recipient = makeAddr("recipient");
         vm.prank(mockPoolManager);
-        vm.expectRevert(abi.encodeWithSelector(SafeERC20.SafeERC20FailedOperation.selector, address(falseToken)));
+        vm.expectRevert("TRANSFER_FAILED");
         IERC20(address(adapter)).transfer(recipient, 50);
 
         // Burn and payout are atomic: nothing moved.
@@ -177,7 +176,7 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
 
         address recipient = makeAddr("recipient");
         vm.prank(mockPoolManager);
-        vm.expectRevert(abi.encodeWithSelector(SafeERC20.SafeERC20FailedOperation.selector, address(pausableToken)));
+        vm.expectRevert("TRANSFER_FAILED");
         IERC20(address(adapter)).transfer(recipient, 50);
 
         assertEq(adapter.totalSupply(), 100);

--- a/test/hooks/permissionedPools/PermissionsAdapter.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapter.t.sol
@@ -5,7 +5,8 @@ import {
     IPermissionsAdapter,
     IAllowlistChecker
 } from "../../../src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol";
-import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20, IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {PermissionedPoolsBase, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {PermissionFlags, PermissionFlag} from "../../../src/hooks/permissionedPools/libraries/PermissionFlags.sol";
@@ -146,6 +147,105 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         permissionsAdapter.transfer(recipient, transferAmount);
         assertEq(permissionsAdapter.balanceOf(mockPoolManager), mintAmount - transferAmount);
         assertEq(permissionedToken.balanceOf(recipient), transferAmount);
+    }
+
+    function testRevert_UnwrapWhenUnderlyingReturnsFalse() public {
+        FalseReturningToken falseToken = new FalseReturningToken();
+        IPermissionsAdapter adapter = _deployAdapterForToken(IERC20(address(falseToken)));
+
+        falseToken.mint(address(adapter), 100);
+        adapter.wrapToPoolManager(100);
+
+        address recipient = makeAddr("recipient");
+        vm.prank(mockPoolManager);
+        vm.expectRevert(abi.encodeWithSelector(SafeERC20.SafeERC20FailedOperation.selector, address(falseToken)));
+        IERC20(address(adapter)).transfer(recipient, 50);
+
+        // Burn and payout are atomic: nothing moved.
+        assertEq(adapter.totalSupply(), 100);
+        assertEq(adapter.balanceOf(mockPoolManager), 100);
+        assertEq(falseToken.balanceOf(recipient), 0);
+    }
+
+    function testRevert_UnwrapWhenUnderlyingPausedSilentFail() public {
+        PausableSilentFailToken pausableToken = new PausableSilentFailToken();
+        IPermissionsAdapter adapter = _deployAdapterForToken(IERC20(address(pausableToken)));
+
+        pausableToken.mint(address(adapter), 100);
+        adapter.wrapToPoolManager(100);
+        pausableToken.pause();
+
+        address recipient = makeAddr("recipient");
+        vm.prank(mockPoolManager);
+        vm.expectRevert(abi.encodeWithSelector(SafeERC20.SafeERC20FailedOperation.selector, address(pausableToken)));
+        IERC20(address(adapter)).transfer(recipient, 50);
+
+        assertEq(adapter.totalSupply(), 100);
+        assertEq(adapter.balanceOf(mockPoolManager), 100);
+        assertEq(pausableToken.balanceOf(recipient), 0);
+        assertEq(pausableToken.balanceOf(address(adapter)), 100);
+    }
+
+    function test_UnwrapSucceedsAfterUnpause() public {
+        PausableSilentFailToken pausableToken = new PausableSilentFailToken();
+        IPermissionsAdapter adapter = _deployAdapterForToken(IERC20(address(pausableToken)));
+
+        pausableToken.mint(address(adapter), 100);
+        adapter.wrapToPoolManager(100);
+
+        address recipient = makeAddr("recipient");
+        vm.prank(mockPoolManager);
+        IERC20(address(adapter)).transfer(recipient, 50);
+
+        assertEq(adapter.totalSupply(), 50);
+        assertEq(adapter.balanceOf(mockPoolManager), 50);
+        assertEq(pausableToken.balanceOf(recipient), 50);
+        assertEq(pausableToken.balanceOf(address(adapter)), 50);
+    }
+
+    function _deployAdapterForToken(IERC20 token) internal returns (IPermissionsAdapter adapter) {
+        bytes memory args = abi.encode(token, mockPoolManager, owner, allowlistChecker);
+        bytes memory initcode = abi.encodePacked(vm.getCode("PermissionsAdapter.sol:PermissionsAdapter"), args);
+        address deployed;
+        assembly {
+            deployed := create(0, add(initcode, 0x20), mload(initcode))
+        }
+        adapter = IPermissionsAdapter(deployed);
+        vm.prank(owner);
+        adapter.updateAllowedWrapper(address(this), true);
+    }
+}
+
+/// @dev ERC-20 that silently returns false from transfer without reverting or moving balances.
+contract FalseReturningToken is ERC20 {
+    constructor() ERC20("FalseToken", "FT") {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function transfer(address, uint256) public pure override returns (bool) {
+        return false;
+    }
+}
+
+/// @dev ERC-20 with pause logic that silently returns false on transfer when paused.
+contract PausableSilentFailToken is ERC20 {
+    bool public paused;
+
+    constructor() ERC20("PausableToken", "PT") {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function pause() public {
+        paused = true;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        if (paused) return false;
+        return super.transfer(to, amount);
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the bare `PERMISSIONED_TOKEN.transfer` call in `PermissionsAdapter._unwrap` with solmate's `SafeTransferLib.safeTransfer` so burn + payout stay atomic. Matches the pattern already used elsewhere in the repo (e.g. `WstETHHook`).
- Handles two edge cases that the prior code silently ignored:
  - ERC-20 tokens that return `false` on failed transfers instead of reverting.
  - Tokens with pause/freeze logic where `transfer` silently returns `false`.
- With `safeTransfer`, any such failure now reverts the whole transaction, preventing a scenario where adapter supply is burned but the underlying payout never lands.
- Because the contract already inherits from OpenZeppelin's `ERC20`, solmate's `ERC20` is imported as `SafeERC20` to avoid the name collision in the `using SafeTransferLib for SafeERC20` directive.

Fixes ECO-198.

## Test plan
- [x] `testRevert_UnwrapWhenUnderlyingReturnsFalse` — mock token that returns `false` on `transfer` causes unwrap to revert; adapter supply and PM balance are unchanged.
- [x] `testRevert_UnwrapWhenUnderlyingPausedSilentFail` — mock pausable token silently returning `false` when paused causes unwrap to revert; adapter supply and recipient balance are unchanged.
- [x] `test_UnwrapSucceedsAfterUnpause` — well-behaved ERC-20 still unwraps through the new `safeTransfer` path.
- [x] Existing `test_UnwrapOnPoolManagerTransfer` fuzz test continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)