### PR TITLE
Socksnflops/eco 225 sc n 05 permission flag evaluation semantics diverge between

### DIFF
--- a/src/hooks/permissionedPools/libraries/PermissionFlags.sol
+++ b/src/hooks/permissionedPools/libraries/PermissionFlags.sol
@@ -24,8 +24,4 @@ library PermissionFlags {
     PermissionFlag constant SWAP_ALLOWED = PermissionFlag.wrap(0x0001);
     PermissionFlag constant LIQUIDITY_ALLOWED = PermissionFlag.wrap(0x0002);
     PermissionFlag constant ALL_ALLOWED = PermissionFlag.wrap(0xFFFF);
-
-    function hasFlag(PermissionFlag permissions, PermissionFlag flag) internal pure returns (bool) {
-        return PermissionFlag.unwrap(and(permissions, flag)) != 0;
-    }
 }


### PR DESCRIPTION
## Related Issue
[ECO-225](https://linear.app/uniswap/issue/ECO-225/sc-n-05-permission-flag-evaluation-semantics-diverge-between-helpers)

## Description of changes
Removes unused `hasFlags()` function from PermissionFlag library