### PR TITLE
fix(permissioned-posm): enforce hook allowlist on liquidity increases

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -499,10 +499,7 @@ contract PositionManager is
         (liquidityDelta, feesAccrued) = poolManager.modifyLiquidity(
             poolKey,
             ModifyLiquidityParams({
-                tickLower: info.tickLower(),
-                tickUpper: info.tickUpper(),
-                liquidityDelta: liquidityChange,
-                salt: salt
+                tickLower: info.tickLower(), tickUpper: info.tickUpper(), liquidityDelta: liquidityChange, salt: salt
             }),
             hookData
         );

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -290,7 +290,7 @@ contract PositionManager is
         uint128 amount0Max,
         uint128 amount1Max,
         bytes calldata hookData
-    ) internal onlyIfApproved(msgSender(), tokenId) {
+    ) internal virtual onlyIfApproved(msgSender(), tokenId) {
         (PoolKey memory poolKey, PositionInfo info) = getPoolAndPositionInfo(tokenId);
 
         // Note: The tokenId is used as the salt for this position, so every minted position has unique storage in the pool manager.
@@ -303,6 +303,7 @@ contract PositionManager is
     /// @dev The liquidity delta is derived from open deltas in the pool manager.
     function _increaseFromDeltas(uint256 tokenId, uint128 amount0Max, uint128 amount1Max, bytes calldata hookData)
         internal
+        virtual
         onlyIfApproved(msgSender(), tokenId)
     {
         (PoolKey memory poolKey, PositionInfo info) = getPoolAndPositionInfo(tokenId);
@@ -498,7 +499,10 @@ contract PositionManager is
         (liquidityDelta, feesAccrued) = poolManager.modifyLiquidity(
             poolKey,
             ModifyLiquidityParams({
-                tickLower: info.tickLower(), tickUpper: info.tickUpper(), liquidityDelta: liquidityChange, salt: salt
+                tickLower: info.tickLower(),
+                tickUpper: info.tickUpper(),
+                liquidityDelta: liquidityChange,
+                salt: salt
             }),
             hookData
         );

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -43,7 +43,9 @@ contract PermissionedPositionManager is PositionManager {
     }
 
     /// @notice Sets the allowed hook for a given permissions adapter
-    /// @dev Sets which hooks are allowed to be used with a permissions adapter. Only callable by the owner of the permissions adapter
+    /// @dev Sets which hooks are allowed to be used with a permissions adapter. Only callable by the owner of the permissions adapter.
+    ///      Revoking a hook (setting `allowed` to false) blocks future mints and liquidity increases on existing positions that use
+    ///      that hook; existing liquidity can still be decreased or burned so that holders can always exit.
     /// @param currency The currency of the permissions adapter
     /// @param hooks The hook to set the allowance for
     /// @param allowed Whether the hook is allowed to be used with the permissions adapter
@@ -99,6 +101,32 @@ contract PermissionedPositionManager is PositionManager {
         super._mint(poolKey, tickLower, tickUpper, liquidity, amount0Max, amount1Max, owner, hookData);
     }
 
+    /// @dev Re-validate the hook allowlist on every liquidity increase so that a revoked hook cannot
+    ///      continue to accept new inflows on existing positions. Decrease and burn paths are intentionally
+    ///      left unchecked so that holders can always exit positions even after a hook has been removed
+    ///      from the allowlist.
+    function _increase(
+        uint256 tokenId,
+        uint256 liquidity,
+        uint128 amount0Max,
+        uint128 amount1Max,
+        bytes calldata hookData
+    ) internal override {
+        (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
+        if (!_checkAllowedHooks(poolKey)) revert InvalidHook();
+        super._increase(tokenId, liquidity, amount0Max, amount1Max, hookData);
+    }
+
+    /// @dev See `_increase` — same rationale for the from-deltas variant.
+    function _increaseFromDeltas(uint256 tokenId, uint128 amount0Max, uint128 amount1Max, bytes calldata hookData)
+        internal
+        override
+    {
+        (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
+        if (!_checkAllowedHooks(poolKey)) revert InvalidHook();
+        super._increaseFromDeltas(tokenId, amount0Max, amount1Max, hookData);
+    }
+
     function _checkRecipientAllowed(Currency currency, address recipient) internal view {
         address permissionedToken = _verifiedPermissionedTokenOf(currency);
         if (permissionedToken == address(0)) return;
@@ -107,7 +135,7 @@ contract PermissionedPositionManager is PositionManager {
         }
     }
 
-    function _checkAllowedHooks(PoolKey calldata poolKey) internal view returns (bool) {
+    function _checkAllowedHooks(PoolKey memory poolKey) internal view returns (bool) {
         return
             _checkAllowedHook(poolKey.currency0, poolKey.hooks) && _checkAllowedHook(poolKey.currency1, poolKey.hooks);
     }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -183,24 +183,29 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(this), PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(alice, PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(lpm), PermissionFlags.ALL_ALLOWED);
-        MockPermissionedToken(Currency.unwrap(currency))
-            .setAllowlist(address(secondaryPosm), PermissionFlags.ALL_ALLOWED);
-        MockPermissionedToken(Currency.unwrap(currency))
-            .setAllowlist(address(permissionsAdapterFactory), PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
+            address(secondaryPosm), PermissionFlags.ALL_ALLOWED
+        );
+        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
+            address(permissionsAdapterFactory), PermissionFlags.ALL_ALLOWED
+        );
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(lpm), PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(manager), PermissionFlags.ALL_ALLOWED);
-        MockPermissionedToken(Currency.unwrap(currency))
-            .setAllowlist(address(permissionedSwapRouter), PermissionFlags.ALL_ALLOWED);
-        MockPermissionedToken(Currency.unwrap(currency2))
-            .setAllowlist(address(permissionedHooks), PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
+            address(permissionedSwapRouter), PermissionFlags.ALL_ALLOWED
+        );
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(
+            address(permissionedHooks), PermissionFlags.ALL_ALLOWED
+        );
     }
 
     function setUpPermissionsAdapter(PermissionsAdapter permissionsAdapter, Currency currency) internal {
         adapterToPermissioned[Currency.wrap(address(permissionsAdapter))] = currency;
 
         MockPermissionedToken(Currency.unwrap(currency)).mint(address(this), 1000 ether);
-        MockPermissionedToken(Currency.unwrap(currency))
-            .setAllowlist(address(permissionsAdapter), PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
+            address(permissionsAdapter), PermissionFlags.ALL_ALLOWED
+        );
 
         // permissions adapter contract must have a non-zero balance of the permissioned token
         currency.transfer(address(permissionsAdapter), 1);
@@ -866,11 +871,13 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         }
 
         // Add some tokens to unauthorized user
-        MockPermissionedToken(Currency.unwrap(currencyPermissioned))
-            .setAllowlist(unauthorizedUser, PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currencyPermissioned)).setAllowlist(
+            unauthorizedUser, PermissionFlags.ALL_ALLOWED
+        );
         MockPermissionedToken(Currency.unwrap(currencyPermissioned)).mint(unauthorizedUser, 1000e18);
-        MockPermissionedToken(Currency.unwrap(currencyPermissioned))
-            .setAllowlist(unauthorizedUser, PermissionFlags.NONE);
+        MockPermissionedToken(Currency.unwrap(currencyPermissioned)).setAllowlist(
+            unauthorizedUser, PermissionFlags.NONE
+        );
 
         vm.startPrank(unauthorizedUser);
 
@@ -969,9 +976,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
     function _test_initialize(Currency currency0_, Currency currency1_) internal {
         // initialize a new pool
-        PoolKey memory key = PoolKey({
-            currency0: currency0_, currency1: currency1_, fee: 0, tickSpacing: 100, hooks: IHooks(address(0))
-        });
+        PoolKey memory key =
+            PoolKey({currency0: currency0_, currency1: currency1_, fee: 0, tickSpacing: 100, hooks: IHooks(address(0))});
 
         lpm.initializePool(key, SQRT_PRICE_1_1);
 
@@ -997,7 +1003,11 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             uint160(bound(sqrtPrice, TickMath.MIN_SQRT_PRICE, TickMath.MAX_SQRT_PRICE_MINUS_MIN_SQRT_PRICE_MINUS_ONE));
         fee = uint24(bound(fee, 0, LPFeeLibrary.MAX_LP_FEE));
         PoolKey memory key = PoolKey({
-            currency0: currency0_, currency1: currency1_, fee: fee, tickSpacing: 10, hooks: IHooks(address(0))
+            currency0: currency0_,
+            currency1: currency1_,
+            fee: fee,
+            tickSpacing: 10,
+            hooks: IHooks(address(0))
         });
 
         lpm.initializePool(key, sqrtPrice);
@@ -1376,10 +1386,12 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 liquidity = 1e18;
 
         // Test SWAP_ALLOWED + LIQUIDITY_ALLOWED (should work like ALL_ALLOWED)
-        MockPermissionedToken(Currency.unwrap(currency0))
-            .setAllowlist(alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED));
-        MockPermissionedToken(Currency.unwrap(currency2))
-            .setAllowlist(alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED));
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(
+            alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED)
+        );
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(
+            alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED)
+        );
 
         uint256 tokenId = lpm.nextTokenId();
         vm.prank(alice);
@@ -1511,5 +1523,180 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
         mint(config, liquidity, alice, ZERO_BYTES);
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), alice);
+    }
+
+    // =============================================================================
+    // Hook allowlist revocation enforcement on liquidity increases (ECO-218 / SC-L-07)
+    // =============================================================================
+
+    function test_permissioned_increase_disallowed_hook_reverts() public {
+        _test_permissioned_increase_disallowed_hook_reverts(key0);
+        _test_permissioned_increase_disallowed_hook_reverts(key1);
+        _test_permissioned_increase_disallowed_hook_reverts(key2);
+    }
+
+    function _test_permissioned_increase_disallowed_hook_reverts(PoolKey memory key) internal {
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+        uint256 liquidity = 1e18;
+        uint256 tokenId = lpm.nextTokenId();
+
+        vm.prank(alice);
+        mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        uint128 liquidityBefore = lpm.getPositionLiquidity(tokenId);
+
+        // Revoke the hook as the adapter admin (address(this) owns both permissionsAdapter0 and permissionsAdapter2)
+        _setHookAllowedForKey(key, false);
+
+        vm.prank(alice);
+        vm.expectRevert(InvalidHook.selector);
+        increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
+
+        assertEq(lpm.getPositionLiquidity(tokenId), liquidityBefore);
+
+        // restore so the fan-out across keys is independent
+        _setHookAllowedForKey(key, true);
+    }
+
+    function test_permissioned_increaseFromDeltas_disallowed_hook_reverts() public {
+        _test_permissioned_increaseFromDeltas_disallowed_hook_reverts(key0);
+        _test_permissioned_increaseFromDeltas_disallowed_hook_reverts(key1);
+        _test_permissioned_increaseFromDeltas_disallowed_hook_reverts(key2);
+    }
+
+    function _test_permissioned_increaseFromDeltas_disallowed_hook_reverts(PoolKey memory key) internal {
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+        uint256 initialLiquidity = 1e18;
+        uint256 tokenId = lpm.nextTokenId();
+
+        vm.prank(alice);
+        mint(config, initialLiquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        uint128 liquidityBefore = lpm.getPositionLiquidity(tokenId);
+
+        _setHookAllowedForKey(key, false);
+
+        // Build a plan that pre-settles both currencies then drives INCREASE_LIQUIDITY_FROM_DELTAS.
+        // The hook-allowlist check runs at the top of the override, so the whole batch reverts
+        // atomically and no funds move.
+        Plan memory planner = Planner.init();
+        planner.add(Actions.SETTLE, abi.encode(key.currency0, uint256(10e18), true));
+        planner.add(Actions.SETTLE, abi.encode(key.currency1, uint256(10e18), true));
+        planner.add(
+            Actions.INCREASE_LIQUIDITY_FROM_DELTAS,
+            abi.encode(tokenId, MAX_SLIPPAGE_INCREASE, MAX_SLIPPAGE_INCREASE, ZERO_BYTES)
+        );
+        bytes memory calls = planner.encode();
+
+        vm.prank(alice);
+        vm.expectRevert(InvalidHook.selector);
+        lpm.modifyLiquidities(calls, _deadline);
+
+        assertEq(lpm.getPositionLiquidity(tokenId), liquidityBefore);
+
+        _setHookAllowedForKey(key, true);
+    }
+
+    function test_permissioned_increase_succeeds_when_hook_still_allowed() public {
+        _test_permissioned_increase_succeeds_when_hook_still_allowed(key0);
+        _test_permissioned_increase_succeeds_when_hook_still_allowed(key1);
+        _test_permissioned_increase_succeeds_when_hook_still_allowed(key2);
+    }
+
+    function _test_permissioned_increase_succeeds_when_hook_still_allowed(PoolKey memory key) internal {
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+        uint256 liquidity = 1e18;
+        uint256 tokenId = lpm.nextTokenId();
+
+        vm.prank(alice);
+        mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        uint128 liquidityBefore = lpm.getPositionLiquidity(tokenId);
+
+        vm.prank(alice);
+        increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
+
+        assertEq(lpm.getPositionLiquidity(tokenId), liquidityBefore + uint128(liquidity));
+    }
+
+    function test_permissioned_increase_succeeds_then_reverts_after_revocation() public {
+        _test_permissioned_increase_succeeds_then_reverts_after_revocation(key0);
+        _test_permissioned_increase_succeeds_then_reverts_after_revocation(key1);
+        _test_permissioned_increase_succeeds_then_reverts_after_revocation(key2);
+    }
+
+    function _test_permissioned_increase_succeeds_then_reverts_after_revocation(PoolKey memory key) internal {
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+        uint256 liquidity = 1e18;
+        uint256 tokenId = lpm.nextTokenId();
+
+        vm.prank(alice);
+        mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        // While the hook is still allowed, increase succeeds.
+        vm.prank(alice);
+        increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
+        uint128 liquidityAfterFirstIncrease = lpm.getPositionLiquidity(tokenId);
+
+        // Revoke the hook — the next increase must revert.
+        _setHookAllowedForKey(key, false);
+
+        vm.prank(alice);
+        vm.expectRevert(InvalidHook.selector);
+        increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
+
+        assertEq(lpm.getPositionLiquidity(tokenId), liquidityAfterFirstIncrease);
+
+        _setHookAllowedForKey(key, true);
+    }
+
+    function test_permissioned_increase_reverts_when_only_one_currency_hook_revoked() public {
+        // Use key2 (permissioned/permissioned) to exercise the `&&` short-circuit in _checkAllowedHooks.
+        // Each side's mapping entry must independently block an increase.
+        _test_permissioned_increase_reverts_when_only_one_currency_hook_revoked(key2, true);
+        _test_permissioned_increase_reverts_when_only_one_currency_hook_revoked(key2, false);
+    }
+
+    function _test_permissioned_increase_reverts_when_only_one_currency_hook_revoked(
+        PoolKey memory key,
+        bool revokeCurrency0
+    ) internal {
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+        uint256 liquidity = 1e18;
+        uint256 tokenId = lpm.nextTokenId();
+
+        vm.prank(alice);
+        mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        Currency revoked = revokeCurrency0 ? key.currency0 : key.currency1;
+        _setHookAllowed(revoked, key.hooks, false);
+
+        vm.prank(alice);
+        vm.expectRevert(InvalidHook.selector);
+        increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
+
+        // Restore for the next iteration so the tests are independent.
+        _setHookAllowed(revoked, key.hooks, true);
+    }
+
+    // Helpers for toggling the hook allowlist in tests. Uses a raw selector call to mirror the
+    // pattern established by `setAllowedHooks` (line 227).
+    function _setHookAllowedForKey(PoolKey memory key, bool allowed) internal {
+        _maybeSetHookAllowed(key.currency0, key.hooks, allowed);
+        _maybeSetHookAllowed(key.currency1, key.hooks, allowed);
+    }
+
+    function _maybeSetHookAllowed(Currency currency, IHooks hooks_, bool allowed) internal {
+        // setAllowedHook requires the currency to have a verified permissions adapter;
+        // skip unpermissioned currencies so mixed-pool keys (key0, key1) work with this helper.
+        if (permissionsAdapterFactory.verifiedPermissionsAdapterOf(Currency.unwrap(currency)) == address(0)) return;
+        _setHookAllowed(currency, hooks_, allowed);
+    }
+
+    function _setHookAllowed(Currency currency, IHooks hooks_, bool allowed) internal {
+        // setAllowedHook(Currency,IHooks,bool) selector
+        bytes4 selector = 0xb5cdc484;
+        (bool success,) = address(lpm).call(abi.encodeWithSelector(selector, currency, hooks_, allowed));
+        require(success, "setAllowedHook failed");
     }
 }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -183,29 +183,24 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(this), PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(alice, PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(lpm), PermissionFlags.ALL_ALLOWED);
-        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
-            address(secondaryPosm), PermissionFlags.ALL_ALLOWED
-        );
-        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
-            address(permissionsAdapterFactory), PermissionFlags.ALL_ALLOWED
-        );
+        MockPermissionedToken(Currency.unwrap(currency))
+            .setAllowlist(address(secondaryPosm), PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency))
+            .setAllowlist(address(permissionsAdapterFactory), PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(lpm), PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(address(manager), PermissionFlags.ALL_ALLOWED);
-        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
-            address(permissionedSwapRouter), PermissionFlags.ALL_ALLOWED
-        );
-        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(
-            address(permissionedHooks), PermissionFlags.ALL_ALLOWED
-        );
+        MockPermissionedToken(Currency.unwrap(currency))
+            .setAllowlist(address(permissionedSwapRouter), PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency2))
+            .setAllowlist(address(permissionedHooks), PermissionFlags.ALL_ALLOWED);
     }
 
     function setUpPermissionsAdapter(PermissionsAdapter permissionsAdapter, Currency currency) internal {
         adapterToPermissioned[Currency.wrap(address(permissionsAdapter))] = currency;
 
         MockPermissionedToken(Currency.unwrap(currency)).mint(address(this), 1000 ether);
-        MockPermissionedToken(Currency.unwrap(currency)).setAllowlist(
-            address(permissionsAdapter), PermissionFlags.ALL_ALLOWED
-        );
+        MockPermissionedToken(Currency.unwrap(currency))
+            .setAllowlist(address(permissionsAdapter), PermissionFlags.ALL_ALLOWED);
 
         // permissions adapter contract must have a non-zero balance of the permissioned token
         currency.transfer(address(permissionsAdapter), 1);
@@ -871,13 +866,11 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         }
 
         // Add some tokens to unauthorized user
-        MockPermissionedToken(Currency.unwrap(currencyPermissioned)).setAllowlist(
-            unauthorizedUser, PermissionFlags.ALL_ALLOWED
-        );
+        MockPermissionedToken(Currency.unwrap(currencyPermissioned))
+            .setAllowlist(unauthorizedUser, PermissionFlags.ALL_ALLOWED);
         MockPermissionedToken(Currency.unwrap(currencyPermissioned)).mint(unauthorizedUser, 1000e18);
-        MockPermissionedToken(Currency.unwrap(currencyPermissioned)).setAllowlist(
-            unauthorizedUser, PermissionFlags.NONE
-        );
+        MockPermissionedToken(Currency.unwrap(currencyPermissioned))
+            .setAllowlist(unauthorizedUser, PermissionFlags.NONE);
 
         vm.startPrank(unauthorizedUser);
 
@@ -976,8 +969,9 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
     function _test_initialize(Currency currency0_, Currency currency1_) internal {
         // initialize a new pool
-        PoolKey memory key =
-            PoolKey({currency0: currency0_, currency1: currency1_, fee: 0, tickSpacing: 100, hooks: IHooks(address(0))});
+        PoolKey memory key = PoolKey({
+            currency0: currency0_, currency1: currency1_, fee: 0, tickSpacing: 100, hooks: IHooks(address(0))
+        });
 
         lpm.initializePool(key, SQRT_PRICE_1_1);
 
@@ -1003,11 +997,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             uint160(bound(sqrtPrice, TickMath.MIN_SQRT_PRICE, TickMath.MAX_SQRT_PRICE_MINUS_MIN_SQRT_PRICE_MINUS_ONE));
         fee = uint24(bound(fee, 0, LPFeeLibrary.MAX_LP_FEE));
         PoolKey memory key = PoolKey({
-            currency0: currency0_,
-            currency1: currency1_,
-            fee: fee,
-            tickSpacing: 10,
-            hooks: IHooks(address(0))
+            currency0: currency0_, currency1: currency1_, fee: fee, tickSpacing: 10, hooks: IHooks(address(0))
         });
 
         lpm.initializePool(key, sqrtPrice);
@@ -1386,12 +1376,10 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 liquidity = 1e18;
 
         // Test SWAP_ALLOWED + LIQUIDITY_ALLOWED (should work like ALL_ALLOWED)
-        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(
-            alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED)
-        );
-        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(
-            alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED)
-        );
+        MockPermissionedToken(Currency.unwrap(currency0))
+            .setAllowlist(alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED));
+        MockPermissionedToken(Currency.unwrap(currency2))
+            .setAllowlist(alice, (PermissionFlags.SWAP_ALLOWED | PermissionFlags.LIQUIDITY_ALLOWED));
 
         uint256 tokenId = lpm.nextTokenId();
         vm.prank(alice);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1670,11 +1670,11 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     // Helpers for toggling the hook allowlist in tests. Uses a raw selector call to mirror the
     // pattern established by `setAllowedHooks` (line 227).
     function _setHookAllowedForKey(PoolKey memory key, bool allowed) internal {
-        _maybeSetHookAllowed(key.currency0, key.hooks, allowed);
-        _maybeSetHookAllowed(key.currency1, key.hooks, allowed);
+        _setHookAllowedIfPermissioned(key.currency0, key.hooks, allowed);
+        _setHookAllowedIfPermissioned(key.currency1, key.hooks, allowed);
     }
 
-    function _maybeSetHookAllowed(Currency currency, IHooks hooks_, bool allowed) internal {
+    function _setHookAllowedIfPermissioned(Currency currency, IHooks hooks_, bool allowed) internal {
         // setAllowedHook requires the currency to have a verified permissions adapter;
         // skip unpermissioned currencies so mixed-pool keys (key0, key1) work with this helper.
         if (permissionsAdapterFactory.verifiedPermissionsAdapterOf(Currency.unwrap(currency)) == address(0)) return;


### PR DESCRIPTION
## Related Issue
[ECO-218](https://linear.app/uniswap/issue/ECO-218/sc-l-07-hook-allowlist-revocation-is-not-enforced-on-liquidity)

## Description of changes
- Checks `allowedHooks` on liquidity increases to prevent users from increasing their liquidity on hooks that have already been removed by the admin. Does not check on decreases to allow them to exit.