### PR TITLE
fix(permissions-adapter): tolerate tokens without standard ERC20 meta…

### DIFF
--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {ERC20 as SafeERC20} from "solmate/src/tokens/ERC20.sol";
 import {SafeTransferLib} from "solmate/src/utils/SafeTransferLib.sol";
 import {IPermissionsAdapter} from "./interfaces/IPermissionsAdapter.sol";
@@ -115,16 +116,37 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
         SafeERC20(address(PERMISSIONED_TOKEN)).safeTransfer(account, amount);
     }
 
+    /// @dev Low-level staticcall + ABI-layout validation. try/catch doesn't catch return-data decode failures,
+    /// so tokens returning bytes32 (MKR-style) or other non-string shapes must be checked explicitly.
+    function _readString(address token, bytes4 selector, string memory fallback_) private view returns (string memory) {
+        (bool ok, bytes memory data) = token.staticcall(abi.encodeWithSelector(selector));
+        if (!ok || data.length < 64) return fallback_;
+        uint256 offset;
+        uint256 length;
+        assembly ("memory-safe") {
+            offset := mload(add(data, 0x20))
+            length := mload(add(data, 0x40))
+        }
+        if (offset != 0x20 || length == 0 || length > data.length - 64) return fallback_;
+        return abi.decode(data, (string));
+    }
+
     function _getName(IERC20 permissionedToken) private view returns (string memory) {
-        return string.concat("Uniswap v4 ", ERC20(address(permissionedToken)).name());
+        return string.concat(
+            "Uniswap v4 ", _readString(address(permissionedToken), IERC20Metadata.name.selector, "Permissioned Token")
+        );
     }
 
     function _getSymbol(IERC20 permissionedToken) private view returns (string memory) {
-        return string.concat("v4", ERC20(address(permissionedToken)).symbol());
+        return string.concat("v4", _readString(address(permissionedToken), IERC20Metadata.symbol.selector, "PT"));
     }
 
     function decimals() public view override returns (uint8) {
-        return ERC20(address(PERMISSIONED_TOKEN)).decimals();
+        (bool ok, bytes memory data) =
+            address(PERMISSIONED_TOKEN).staticcall(abi.encodeWithSelector(IERC20Metadata.decimals.selector));
+        if (!ok || data.length < 32) return 18;
+        uint256 value = abi.decode(data, (uint256));
+        return value > type(uint8).max ? 18 : uint8(value);
     }
 
     function owner() public view override(Ownable, IPermissionsAdapter) returns (address) {

--- a/test/hooks/permissionedPools/PermissionsAdapter.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapter.t.sol
@@ -202,6 +202,40 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         assertEq(pausableToken.balanceOf(address(adapter)), 50);
     }
 
+    // --- ERC20 metadata fallbacks ---
+
+    function _assertMetadataFallbacks(IPermissionsAdapter adapter) internal view {
+        assertEq(IERC20Metadata(address(adapter)).name(), "Uniswap v4 Permissioned Token");
+        assertEq(IERC20Metadata(address(adapter)).symbol(), "v4PT");
+        assertEq(IERC20Metadata(address(adapter)).decimals(), 18);
+    }
+
+    function test_Constructor_FallsBackWhenMetadataIsMissing() public {
+        _assertMetadataFallbacks(_deployAdapterForToken(IERC20(address(new NoMetadataToken()))));
+    }
+
+    function test_Constructor_FallsBackWhenMetadataReverts() public {
+        _assertMetadataFallbacks(_deployAdapterForToken(IERC20(address(new RevertingMetadataToken()))));
+    }
+
+    /// @dev bytes32 returns aren't standard ABI-encoded strings, so decode fails and we fall back.
+    function test_Constructor_FallsBackOnBytes32Metadata() public {
+        IPermissionsAdapter adapter = _deployAdapterForToken(IERC20(address(new Bytes32MetadataToken())));
+        assertEq(IERC20Metadata(address(adapter)).name(), "Uniswap v4 Permissioned Token");
+        assertEq(IERC20Metadata(address(adapter)).symbol(), "v4PT");
+        // decimals() is a valid uint8 here, so it does NOT fall back.
+        assertEq(IERC20Metadata(address(adapter)).decimals(), 18);
+    }
+
+    function test_Constructor_FallsBackWhenDecimalsDoesNotFitInUint8() public {
+        IPermissionsAdapter adapter = _deployAdapterForToken(IERC20(address(new OversizedDecimalsToken())));
+        // name/symbol decode cleanly.
+        assertEq(IERC20Metadata(address(adapter)).name(), "Uniswap v4 Big");
+        assertEq(IERC20Metadata(address(adapter)).symbol(), "v4BIG");
+        // decimals decode as uint8 fails on the oversized value -> fallback.
+        assertEq(IERC20Metadata(address(adapter)).decimals(), 18);
+    }
+
     function _deployAdapterForToken(IERC20 token) internal returns (IPermissionsAdapter adapter) {
         bytes memory args = abi.encode(token, mockPoolManager, owner, allowlistChecker);
         bytes memory initcode = abi.encodePacked(vm.getCode("PermissionsAdapter.sol:PermissionsAdapter"), args);
@@ -209,6 +243,7 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         assembly {
             deployed := create(0, add(initcode, 0x20), mload(initcode))
         }
+        require(deployed != address(0), "deployment failed");
         adapter = IPermissionsAdapter(deployed);
         vm.prank(owner);
         adapter.updateAllowedWrapper(address(this), true);
@@ -245,6 +280,79 @@ contract PausableSilentFailToken is ERC20 {
     function transfer(address to, uint256 amount) public override returns (bool) {
         if (paused) return false;
         return super.transfer(to, amount);
+    }
+}
+
+/// @dev Bare-minimum IERC20 so the mocks below do not inherit OZ ERC20 (which would auto-provide metadata).
+abstract contract StubIERC20 is IERC20 {
+    function totalSupply() external pure override returns (uint256) {
+        return 0;
+    }
+
+    function balanceOf(address) external pure override returns (uint256) {
+        return 0;
+    }
+
+    function transfer(address, uint256) external pure override returns (bool) {
+        return true;
+    }
+
+    function allowance(address, address) external pure override returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256) external pure override returns (bool) {
+        return true;
+    }
+
+    function transferFrom(address, address, uint256) external pure override returns (bool) {
+        return true;
+    }
+}
+
+contract NoMetadataToken is StubIERC20 {}
+
+contract RevertingMetadataToken is StubIERC20 {
+    function name() external pure returns (string memory) {
+        revert("no name");
+    }
+
+    function symbol() external pure returns (string memory) {
+        revert("no symbol");
+    }
+
+    function decimals() external pure returns (uint8) {
+        revert("no decimals");
+    }
+}
+
+/// @dev Legacy MKR-style token that returns `bytes32` instead of `string` for name/symbol.
+contract Bytes32MetadataToken is StubIERC20 {
+    function name() external pure returns (bytes32) {
+        return bytes32("MakerDAO");
+    }
+
+    function symbol() external pure returns (bytes32) {
+        return bytes32("MKR");
+    }
+
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+}
+
+/// @dev `decimals()` returns a uint256 that does not fit in uint8 — ABI decode as uint8 must fail.
+contract OversizedDecimalsToken is StubIERC20 {
+    function name() external pure returns (string memory) {
+        return "Big";
+    }
+
+    function symbol() external pure returns (string memory) {
+        return "BIG";
+    }
+
+    function decimals() external pure returns (uint256) {
+        return 999;
     }
 }
 


### PR DESCRIPTION
## Related Issue
Fixes [ECO-223](https://linear.app/uniswap/issue/ECO-223/sc-n-03-permissionsadapter-constructor-reverts-for-tokens-without)

## Description of changes
- Adds error-handling for situations when underlying secToken doesn't implement `name()`, `symbol()`, nor `decimals()` metadata functions
- Not using try/catch because it's insufficient for abi-decoding failures (expected types don't match)