### PR TITLE
feat(permissioned-posm): add seize and withdrawClaim; drop admin transfer recipient gate

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -15,13 +15,24 @@ import {IPermissionsAdapterFactory} from "./interfaces/IPermissionsAdapterFactor
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {PermissionFlags} from "./libraries/PermissionFlags.sol";
 import {ActionConstants} from "../../libraries/ActionConstants.sol";
+import {Actions} from "../../libraries/Actions.sol";
+import {CalldataDecoder} from "../../libraries/CalldataDecoder.sol";
 
 contract PermissionedPositionManager is PositionManager {
+    using CalldataDecoder for bytes;
+
     IPermissionsAdapterFactory public immutable PERMISSIONS_ADAPTER_FACTORY;
 
     mapping(Currency currency => mapping(IHooks hooks => bool)) public isAllowedHooks;
 
     event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
+    event PositionSeized(
+        uint256 indexed tokenId,
+        address indexed previousOwner,
+        address indexed seizingAdmin,
+        address recipient0,
+        address recipient1
+    );
 
     error InvalidHook();
     error SafeTransferDisabled();
@@ -59,18 +70,59 @@ contract PermissionedPositionManager is PositionManager {
         emit AllowedHooksUpdated(currency, hooks, allowed);
     }
 
+    /// @notice Atomically retire a position and convert each currency's proceeds into an ERC-6909 claim on the PoolManager
+    ///         held by the respective adapter admin.
+    /// @dev Either adapter admin may call. Non-permissioned currencies (no verified adapter) credit the caller instead,
+    ///      so single-PA pools route both legs to the sole admin. Claims are redeemable via `withdrawClaim`.
+    /// @param tokenId The id of the position to seize
+    function seize(uint256 tokenId) external isNotLocked {
+        (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
+        address admin0 = _getOwner(poolKey.currency0);
+        address admin1 = _getOwner(poolKey.currency1);
+        if (msg.sender != admin0 && msg.sender != admin1) revert Unauthorized();
+
+        address recipient0 = admin0 == address(0) ? msg.sender : admin0;
+        address recipient1 = admin1 == address(0) ? msg.sender : admin1;
+
+        // Pre-approve so the inner BURN_POSITION action passes `onlyIfApproved`.
+        getApproved[tokenId] = msg.sender;
+
+        emit PositionSeized(tokenId, ownerOf(tokenId), msg.sender, recipient0, recipient1);
+
+        bytes memory actions =
+            abi.encodePacked(uint8(Actions.BURN_POSITION), uint8(Actions.MINT_6909), uint8(Actions.MINT_6909));
+        bytes[] memory params = new bytes[](3);
+        params[0] = abi.encode(tokenId, uint128(0), uint128(0), bytes(""));
+        params[1] = abi.encode(poolKey.currency0, recipient0, ActionConstants.OPEN_DELTA);
+        params[2] = abi.encode(poolKey.currency1, recipient1, ActionConstants.OPEN_DELTA);
+
+        poolManager.unlock(abi.encode(actions, params));
+    }
+
+    /// @notice Burn an ERC-6909 claim held on the PoolManager and transfer the underlying currency to `to`.
+    /// @dev Caller must hold the claim or have granted this contract operator/allowance on PoolManager's ERC-6909.
+    ///      For permissioned currencies, `to` must clear the underlying token's issuer compliance on unwrap.
+    /// @param currency The currency whose claim is being withdrawn
+    /// @param amount   The amount of claim to burn (and underlying to transfer)
+    /// @param to       The recipient of the underlying
+    function withdrawClaim(Currency currency, uint256 amount, address to) external isNotLocked {
+        bytes memory actions = abi.encodePacked(uint8(Actions.BURN_6909), uint8(Actions.TAKE));
+        bytes[] memory params = new bytes[](2);
+        params[0] = abi.encode(currency, msg.sender, amount);
+        params[1] = abi.encode(currency, to, amount);
+        poolManager.unlock(abi.encode(actions, params));
+    }
+
     /// @inheritdoc PositionManager
-    /// @dev Only allow admins of permissioned tokens to transfer positions that contain their tokens,
-    /// and only to recipients that are allowlisted for each permissioned currency in the pool.
+    /// @dev Unilateral admin transfer: either currency admin may move the NFT without co-admin cooperation.
+    ///      No recipient allowlist gate — that would let one admin block the other. Use `seize` to unwind atomically.
     function transferFrom(address from, address to, uint256 id) public override onlyIfPoolManagerLocked {
         (PoolKey memory poolKey,) = getPoolAndPositionInfo(id);
-        address admin1 = _getOwner(poolKey.currency0);
-        address admin2 = _getOwner(poolKey.currency1);
-        if (msg.sender != admin1 && msg.sender != admin2) {
+        address admin0 = _getOwner(poolKey.currency0);
+        address admin1 = _getOwner(poolKey.currency1);
+        if (msg.sender != admin0 && msg.sender != admin1) {
             revert Unauthorized();
         }
-        _checkRecipientAllowed(poolKey.currency0, to);
-        _checkRecipientAllowed(poolKey.currency1, to);
         getApproved[id] = msg.sender;
         super.transferFrom(from, to, id);
     }
@@ -192,5 +244,22 @@ contract PermissionedPositionManager is PositionManager {
         address permissionedToken = _verifiedPermissionedTokenOf(currency);
         if (permissionedToken == address(0)) return address(0);
         return IPermissionsAdapter(permissionsAdapter).owner();
+    }
+
+    /// @dev Adds MINT_6909 / BURN_6909 to the action set so `seize` and `withdrawClaim` can convert
+    ///      open deltas into persistent ERC-6909 claims and back.
+    function _handleAction(uint256 action, bytes calldata params) internal override {
+        if (action == Actions.MINT_6909) {
+            (Currency currency, address to, uint256 amount) = params.decodeCurrencyAddressAndUint256();
+            if (amount == ActionConstants.OPEN_DELTA) amount = _getFullCredit(currency);
+            poolManager.mint(to, currency.toId(), amount);
+            return;
+        }
+        if (action == Actions.BURN_6909) {
+            (Currency currency, address from, uint256 amount) = params.decodeCurrencyAddressAndUint256();
+            poolManager.burn(from, currency.toId(), amount);
+            return;
+        }
+        super._handleAction(action, params);
     }
 }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1090,8 +1090,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         IERC721(address(lpm)).transferFrom(alice, address(this), tokenId3);
     }
 
-    function test_transferFrom_revert_recipient_not_allowlisted_mixed_pool() public {
-        // key0 is permissioned/normal, key1 is normal/permissioned
+    function test_transferFrom_success_recipient_not_allowlisted_mixed_pool() public {
+        // admin may transfer to any recipient; the co-admin must not be able to block via allowlist
         uint256 tokenId0 = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key0);
         uint256 tokenId1 = lpm.nextTokenId();
@@ -1099,40 +1099,21 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
         address notAllowed = makeAddr("NOT_ALLOWED");
 
-        // admin is address(this) for both adapters; recipient is not on either allowlist
-        vm.expectRevert(Unauthorized.selector);
         IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId0);
+        assertEq(IERC721(address(lpm)).ownerOf(tokenId0), notAllowed);
 
-        vm.expectRevert(Unauthorized.selector);
         IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId1);
+        assertEq(IERC721(address(lpm)).ownerOf(tokenId1), notAllowed);
     }
 
-    function test_transferFrom_revert_recipient_not_allowlisted_both_permissioned() public {
-        // key2 has two permissioned currencies
+    function test_transferFrom_success_recipient_not_allowlisted_both_permissioned() public {
         uint256 tokenId = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key2);
 
         address notAllowed = makeAddr("NOT_ALLOWED");
 
-        vm.expectRevert(Unauthorized.selector);
         IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId);
-    }
-
-    function test_transferFrom_success_recipient_allowlisted_after_seize() public {
-        // admin can seize a key2 position to a fresh recipient after allowlisting them
-        uint256 tokenId = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key2);
-
-        address recipient = makeAddr("NEW_HOLDER");
-
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, recipient, tokenId);
-
-        // admin allowlists the recipient on the permissioned token backing the shared checker
-        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(recipient, PermissionFlags.ALL_ALLOWED);
-
-        IERC721(address(lpm)).transferFrom(alice, recipient, tokenId);
-        assertEq(IERC721(address(lpm)).ownerOf(tokenId), recipient);
+        assertEq(IERC721(address(lpm)).ownerOf(tokenId), notAllowed);
     }
 
     error SafeTransferDisabled();
@@ -1686,5 +1667,145 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         bytes4 selector = 0xb5cdc484;
         (bool success,) = address(lpm).call(abi.encodeWithSelector(selector, currency, hooks_, allowed));
         require(success, "setAllowedHook failed");
+    }
+
+    event PositionSeized(
+        uint256 indexed tokenId,
+        address indexed previousOwner,
+        address indexed seizingAdmin,
+        address recipient0,
+        address recipient1
+    );
+
+    // seize(uint256) selector
+    bytes4 private constant _SEIZE_SELECTOR = 0x2ac05311;
+    // withdrawClaim(Currency,uint256,address) selector
+    bytes4 private constant _WITHDRAW_CLAIM_SELECTOR = 0xf77de3fc;
+
+    function _seize(uint256 tokenId) internal {
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_SEIZE_SELECTOR, tokenId));
+        require(ok, "seize failed");
+    }
+
+    function _seizeExpectRevert(uint256 tokenId, bytes4 expectedSelector) internal {
+        (bool ok, bytes memory data) = address(lpm).call(abi.encodeWithSelector(_SEIZE_SELECTOR, tokenId));
+        assertEq(ok, false);
+        assertEq(bytes4(data), expectedSelector);
+    }
+
+    function _withdrawClaim(Currency currency, uint256 amount, address to) internal {
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_WITHDRAW_CLAIM_SELECTOR, currency, amount, to));
+        require(ok, "withdrawClaim failed");
+    }
+
+    function test_seize_credits_admins_with_6909_claims() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        address admin0 = permissionsAdapter0.owner();
+        address admin1 = permissionsAdapter2.owner();
+        uint256 admin0ClaimBefore = manager.balanceOf(admin0, key2.currency0.toId());
+        uint256 admin1ClaimBefore = manager.balanceOf(admin1, key2.currency1.toId());
+
+        vm.expectEmit(true, true, true, true);
+        emit PositionSeized(tokenId, alice, address(this), admin0, admin1);
+        _seize(tokenId);
+
+        // NFT is gone
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId);
+
+        // Each admin received a positive claim for their side
+        assertGt(manager.balanceOf(admin0, key2.currency0.toId()), admin0ClaimBefore);
+        assertGt(manager.balanceOf(admin1, key2.currency1.toId()), admin1ClaimBefore);
+    }
+
+    function test_seize_single_pa_pool_credits_caller_for_nonpermissioned_side() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0); // [pa0, currency1=normal]
+
+        address admin0 = permissionsAdapter0.owner();
+        uint256 paClaimBefore = manager.balanceOf(admin0, key0.currency0.toId());
+        uint256 normalClaimBefore = manager.balanceOf(admin0, key0.currency1.toId());
+
+        _seize(tokenId);
+
+        // Both claims routed to the sole admin (caller)
+        assertGt(manager.balanceOf(admin0, key0.currency0.toId()), paClaimBefore);
+        assertGt(manager.balanceOf(admin0, key0.currency1.toId()), normalClaimBefore);
+    }
+
+    function test_seize_reverts_when_caller_is_not_admin(address notAdmin) public {
+        vm.assume(notAdmin != address(this) && notAdmin != address(0));
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        vm.prank(notAdmin);
+        _seizeExpectRevert(tokenId, Unauthorized.selector);
+    }
+
+    function test_seize_either_admin_cannot_be_blocked_by_the_other() public {
+        // Split adapter ownership so each side has a distinct admin
+        address admin0 = makeAddr("ADMIN0");
+        address admin1 = makeAddr("ADMIN1");
+        permissionsAdapter0.transferOwnership(admin0);
+        vm.prank(admin0);
+        permissionsAdapter0.acceptOwnership();
+        permissionsAdapter2.transferOwnership(admin1);
+        vm.prank(admin1);
+        permissionsAdapter2.acceptOwnership();
+
+        uint256 tokenId0 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+        uint256 tokenId1 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        // admin0 seizes independently — admin1 has no lever to block
+        vm.prank(admin0);
+        _seize(tokenId0);
+        assertGt(manager.balanceOf(admin0, key2.currency0.toId()), 0);
+
+        // admin1 does the same, independently
+        vm.prank(admin1);
+        _seize(tokenId1);
+        assertGt(manager.balanceOf(admin1, key2.currency1.toId()), 0);
+    }
+
+    function test_withdrawClaim_round_trip() public {
+        // Seize a key2 position, then withdraw each side to the admin
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+        _seize(tokenId);
+
+        uint256 claim0 = manager.balanceOf(address(this), key2.currency0.toId());
+        uint256 claim1 = manager.balanceOf(address(this), key2.currency1.toId());
+        assertGt(claim0, 0);
+        assertGt(claim1, 0);
+
+        // Allow PermPosm to burn our 6909 claim
+        manager.setOperator(address(lpm), true);
+
+        address payout = makeAddr("PAYOUT");
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(payout, PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(payout, PermissionFlags.ALL_ALLOWED);
+
+        uint256 under0Before = IERC20(Currency.unwrap(currency0)).balanceOf(payout);
+        uint256 under1Before = IERC20(Currency.unwrap(currency2)).balanceOf(payout);
+
+        _withdrawClaim(key2.currency0, claim0, payout);
+        _withdrawClaim(key2.currency1, claim1, payout);
+
+        assertEq(manager.balanceOf(address(this), key2.currency0.toId()), 0);
+        assertEq(manager.balanceOf(address(this), key2.currency1.toId()), 0);
+        assertEq(IERC20(Currency.unwrap(currency0)).balanceOf(payout) - under0Before, claim0);
+        assertEq(IERC20(Currency.unwrap(currency2)).balanceOf(payout) - under1Before, claim1);
+    }
+
+    function test_withdrawClaim_reverts_without_operator_or_balance() public {
+        // Caller has no claim and has not approved — PoolManager's burn reverts
+        vm.startPrank(alice);
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_WITHDRAW_CLAIM_SELECTOR, key2.currency0, 1, alice));
+        vm.stopPrank();
+        assertEq(ok, false);
     }
 }


### PR DESCRIPTION
## Related Issue
Fixes [ECO-221](https://linear.app/uniswap/issue/ECO-223/sc-n-03-permissionsadapter-constructor-reverts-for-tokens-without)

## Description of changes
- Reverts https://github.com/Uniswap/v4-periphery/pull/532 (since this enables admins to block each other)
- Add `seize` function to PermissionedPositionManager, allowing admins to unwind a position but leave the PAs inside of PoolManager to be withdrawn by respective admins
  - If only one token is permissioned, both are seized by the single admin
- Adds `withdrawClaim` function to enable admins to withdraw ERC6909 claims created from `seize`
