### PR TITLE
docs(permissioned-v4-router): adding natspec to execute() to clarify allow-revert behavior

### DIFF
--- a/src/hooks/permissionedPools/PermissionedV4Router.sol
+++ b/src/hooks/permissionedPools/PermissionedV4Router.sol
@@ -67,6 +67,8 @@ contract PermissionedV4Router is V4Router, ReentrancyLock {
     /// @notice Executes encoded commands along with provided inputs.
     /// @param commands A set of concatenated commands, each 1 byte in length
     /// @param inputs An array of byte strings containing abi encoded inputs for each command
+    /// @dev COMMAND_FLAG_ALLOW_REVERT is only honored for COMMAND_PERMIT2_PERMIT. Swap commands
+    /// always revert on failure to avoid leaving the router in an inconsistent state mid-batch.
     function execute(bytes calldata commands, bytes[] calldata inputs) public payable isNotLocked {
         bool success;
         bytes memory output;

--- a/src/hooks/permissionedPools/PermissionedV4Router.sol
+++ b/src/hooks/permissionedPools/PermissionedV4Router.sol
@@ -67,7 +67,7 @@ contract PermissionedV4Router is V4Router, ReentrancyLock {
     /// @notice Executes encoded commands along with provided inputs.
     /// @param commands A set of concatenated commands, each 1 byte in length
     /// @param inputs An array of byte strings containing abi encoded inputs for each command
-    /// @dev COMMAND_FLAG_ALLOW_REVERT is only honored for COMMAND_PERMIT2_PERMIT. Swap commands
+    /// @dev COMMAND_FLAG_ALLOW_REVERT is currently only honored for COMMAND_PERMIT2_PERMIT. Swap commands
     /// always revert on failure to avoid leaving the router in an inconsistent state mid-batch.
     function execute(bytes calldata commands, bytes[] calldata inputs) public payable isNotLocked {
         bool success;


### PR DESCRIPTION
## Related Issue
Fixes [ECO-228](https://linear.app/uniswap/issue/ECO-228/sc-n-08-command-flag-allow-revert-is-ineffective-for-command-v4-swap)

## Description of changes
`FLAG_ALLOW_REVERT` is unsupported for `swap` and `payment` commands in universal-router. This is to prevent partial execution of swap batches, which could leave the system in an inconsistent state.

This behavior is mirrored in PermissionedV4Router. This PR adds natspec explaining that `COMMAND_FLAG_ALLOW_REVERT` does not apply to `COMMAND_V4_SWAP` and similar commands, so integrators understand this behaviour.