### PR TITLE
feat(permissioned-position-manager): Adds `unwindPosition` and `withdrawClaim` functionality

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -243,7 +243,7 @@ contract PermissionedPositionManager is PositionManager {
     function _handleAction(uint256 action, bytes calldata params) internal override {
         if (action == _ACTION_TAKE_WITH_FALLBACK) {
             (Currency currency, address lp, address defaultRecipient) = abi.decode(params, (Currency, address, address));
-            _routeCredit(currency, lp, defaultRecipient);
+            _takeWithFallback(currency, lp, defaultRecipient);
             return;
         }
         if (action == Actions.BURN_6909) {
@@ -256,7 +256,7 @@ contract PermissionedPositionManager is PositionManager {
 
     /// @dev Cascade: try take to LP → take to defaultRecipient → mint 6909 claim to defaultRecipient.
     ///      Final mint never reverts.
-    function _routeCredit(Currency currency, address lp, address defaultRecipient) internal {
+    function _takeWithFallback(Currency currency, address lp, address defaultRecipient) internal {
         uint256 amount = _getFullCredit(currency);
         if (amount == 0) return;
 

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -105,6 +105,9 @@ contract PermissionedPositionManager is PositionManager {
     ///      currencies, `to` must clear the underlying token's issuer compliance on unwrap. `to` follows the
     ///      standard `Actions.TAKE` recipient sentinels: `address(1)` remaps to the caller, `address(2)` to this
     ///      contract.
+    /// @param currency The currency whose 6909 claim is being burned
+    /// @param amount The amount of claim to burn (and underlying to deliver)
+    /// @param to The recipient of the underlying currency
     function withdrawClaim(Currency currency, uint256 amount, address to) external isNotLocked {
         bytes memory actions = abi.encodePacked(uint8(Actions.BURN_6909), uint8(Actions.TAKE));
         bytes[] memory params = new bytes[](2);

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -15,13 +15,25 @@ import {IPermissionsAdapterFactory} from "./interfaces/IPermissionsAdapterFactor
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {PermissionFlags} from "./libraries/PermissionFlags.sol";
 import {ActionConstants} from "../../libraries/ActionConstants.sol";
+import {Actions} from "../../libraries/Actions.sol";
+import {CalldataDecoder} from "../../libraries/CalldataDecoder.sol";
 
 contract PermissionedPositionManager is PositionManager {
+    using CalldataDecoder for bytes;
+
+    /// @dev Takes a currency's positive delta with a fallback cascade: LP → defaultRecipient → 6909 mint to
+    ///      defaultRecipient. Picked above the standard Actions.sol range to avoid collision.
+    uint256 private constant _ACTION_TAKE_WITH_FALLBACK = 0x20;
+
     IPermissionsAdapterFactory public immutable PERMISSIONS_ADAPTER_FACTORY;
 
     mapping(Currency currency => mapping(IHooks hooks => bool)) public isAllowedHooks;
 
     event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
+    event PositionUnwound(
+        uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient
+    );
+    event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
 
     error InvalidHook();
     error TransferDisabled();
@@ -57,6 +69,50 @@ contract PermissionedPositionManager is PositionManager {
         if (oldAllowed == allowed) return;
         isAllowedHooks[currency][hooks] = allowed;
         emit AllowedHooksUpdated(currency, hooks, allowed);
+    }
+
+    /// @notice Force-exit the LP from a position. Burns the NFT, unwinds liquidity, and routes each currency.
+    /// @dev Either PA admin in the pool may call. For each currency the cascade is: try transfer to the original
+    ///      LP → on failure, try transfer to `defaultRecipient` → on failure, mint a persistent ERC-6909 claim on
+    ///      the PoolManager to `defaultRecipient`. The third step never reverts, so the call is atomic. Permissioned
+    ///      currencies unwrap to the underlying token; non-permissioned currencies transfer directly.
+    /// @param tokenId          The position to unwind
+    /// @param defaultRecipient The fallback address used if the LP cannot receive a currency
+    function unwindPosition(uint256 tokenId, address defaultRecipient) external isNotLocked {
+        (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
+        address admin0 = _getOwner(poolKey.currency0);
+        address admin1 = _getOwner(poolKey.currency1);
+        if (msg.sender != admin0 && msg.sender != admin1) revert Unauthorized();
+
+        address lp = ownerOf(tokenId);
+        emit PositionUnwound(tokenId, lp, msg.sender, defaultRecipient);
+
+        // Pre-approve so BURN_POSITION inside the unlock passes its onlyIfApproved check.
+        // ERC-721 _burn clears getApproved as part of its teardown, so the approval is self-cleaning.
+        getApproved[tokenId] = msg.sender;
+
+        bytes memory actions = abi.encodePacked(
+            uint8(Actions.BURN_POSITION), uint8(_ACTION_TAKE_WITH_FALLBACK), uint8(_ACTION_TAKE_WITH_FALLBACK)
+        );
+        bytes[] memory params = new bytes[](3);
+        params[0] = abi.encode(tokenId, uint128(0), uint128(0), bytes(""));
+        params[1] = abi.encode(poolKey.currency0, lp, defaultRecipient);
+        params[2] = abi.encode(poolKey.currency1, lp, defaultRecipient);
+        poolManager.unlock(abi.encode(actions, params));
+    }
+
+    /// @notice Burn an ERC-6909 claim on the PoolManager and transfer the underlying currency to `to`.
+    /// @dev Caller must hold the claim or have called PoolManager.setOperator(permPosm, true). For permissioned
+    ///      currencies, `to` must clear the underlying token's issuer compliance on unwrap. `to` follows the
+    ///      standard `Actions.TAKE` recipient sentinels: `address(1)` remaps to the caller, `address(2)` to this
+    ///      contract.
+    function withdrawClaim(Currency currency, uint256 amount, address to) external isNotLocked {
+        bytes memory actions = abi.encodePacked(uint8(Actions.BURN_6909), uint8(Actions.TAKE));
+        bytes[] memory params = new bytes[](2);
+        params[0] = abi.encode(currency, msg.sender, amount);
+        params[1] = abi.encode(currency, to, amount);
+        emit ClaimWithdrawn(currency, msg.sender, to, amount);
+        poolManager.unlock(abi.encode(actions, params));
     }
 
     /// @inheritdoc PositionManager
@@ -182,5 +238,39 @@ contract PermissionedPositionManager is PositionManager {
         address permissionedToken = _verifiedPermissionedTokenOf(currency);
         if (permissionedToken == address(0)) return address(0);
         return IPermissionsAdapter(permissionsAdapter).owner();
+    }
+
+    /// @dev Adds the cascade-routing action used by `unwindPosition` and the BURN_6909 primitive used by
+    ///      `withdrawClaim`. All other actions fall through to the base PositionManager dispatcher.
+    function _handleAction(uint256 action, bytes calldata params) internal override {
+        if (action == _ACTION_TAKE_WITH_FALLBACK) {
+            (Currency currency, address lp, address defaultRecipient) =
+                abi.decode(params, (Currency, address, address));
+            _routeCredit(currency, lp, defaultRecipient);
+            return;
+        }
+        if (action == Actions.BURN_6909) {
+            (Currency currency, address from, uint256 amount) = params.decodeCurrencyAddressAndUint256();
+            poolManager.burn(from, currency.toId(), amount);
+            return;
+        }
+        super._handleAction(action, params);
+    }
+
+    /// @dev Cascading routes: 1. Underlying -> LP, Underlying -> defaultRecipient, PA 6909 claim to defaultRecipient. Final mint never reverts.
+    function _routeCredit(Currency currency, address lp, address defaultRecipient) internal {
+        uint256 amount = _getFullCredit(currency);
+        if (amount == 0) return;
+
+        // Unwrap and transfer underlying to LP
+        try poolManager.take(currency, lp, amount) {
+            return;
+        } catch {}
+        // Unwrap and transfer underlying to defaultRecipient
+        try poolManager.take(currency, defaultRecipient, amount) {
+            return;
+        } catch {}
+        // Mint 6909 claim to defaultRecipient
+        poolManager.mint(defaultRecipient, currency.toId(), amount);
     }
 }

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -24,7 +24,7 @@ contract PermissionedPositionManager is PositionManager {
     event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
 
     error InvalidHook();
-    error SafeTransferDisabled();
+    error TransferDisabled();
     error NotPermissionsAdapterAdmin();
 
     /// @dev as this contract must know the hooks address in advance, it must be passed in as a constructor argument
@@ -60,27 +60,17 @@ contract PermissionedPositionManager is PositionManager {
     }
 
     /// @inheritdoc PositionManager
-    /// @dev Only allow admins of permissioned tokens to transfer positions that contain their tokens,
-    /// and only to recipients that are allowlisted for each permissioned currency in the pool.
+    /// @dev Positions of permissioned tokens are not transferable.
     function transferFrom(address from, address to, uint256 id) public override onlyIfPoolManagerLocked {
-        (PoolKey memory poolKey,) = getPoolAndPositionInfo(id);
-        address admin1 = _getOwner(poolKey.currency0);
-        address admin2 = _getOwner(poolKey.currency1);
-        if (msg.sender != admin1 && msg.sender != admin2) {
-            revert Unauthorized();
-        }
-        _checkRecipientAllowed(poolKey.currency0, to);
-        _checkRecipientAllowed(poolKey.currency1, to);
-        getApproved[id] = msg.sender;
-        super.transferFrom(from, to, id);
+        revert TransferDisabled();
     }
 
     function safeTransferFrom(address, address, uint256) public pure override {
-        revert SafeTransferDisabled();
+        revert TransferDisabled();
     }
 
     function safeTransferFrom(address, address, uint256, bytes calldata) public pure override {
-        revert SafeTransferDisabled();
+        revert TransferDisabled();
     }
 
     /// @dev When minting a position, verify that the sender is allowed to mint the position. This prevents a disallowed user from minting one sided liquidity.

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -21,16 +21,12 @@ import {CalldataDecoder} from "../../libraries/CalldataDecoder.sol";
 contract PermissionedPositionManager is PositionManager {
     using CalldataDecoder for bytes;
 
-    /// @dev Takes a currency's positive delta with a fallback cascade: LP → defaultRecipient → 6909 mint to
-    ///      defaultRecipient. Picked above the standard Actions.sol range to avoid collision.
-    uint256 private constant _ACTION_TAKE_WITH_FALLBACK = 0x20;
-
     IPermissionsAdapterFactory public immutable PERMISSIONS_ADAPTER_FACTORY;
 
     mapping(Currency currency => mapping(IHooks hooks => bool)) public isAllowedHooks;
 
     event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
-    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient);
+    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin);
     event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
 
     error InvalidHook();
@@ -70,11 +66,10 @@ contract PermissionedPositionManager is PositionManager {
     }
 
     /// @notice Force-exit the LP from a position. Burns the NFT, unwinds liquidity, and routes each currency.
-    /// @dev Either PA admin may call. Per-currency cascade: LP → `defaultRecipient` → 6909 mint to `defaultRecipient`.
-    ///      The 6909 fallback never reverts, so the call is atomic.
-    /// @param tokenId          The position to unwind
-    /// @param defaultRecipient The fallback address used if the LP cannot receive a currency
-    function unwindPosition(uint256 tokenId, address defaultRecipient) external isNotLocked {
+    /// @dev Either PA admin may call. Per-currency fallback is derived on-chain via `_getOwner` (see
+    ///      `_unwindWithFallback`). The 6909 fallback never reverts, so the call is atomic.
+    /// @param tokenId The position to unwind
+    function unwindPosition(uint256 tokenId) external isNotLocked {
         (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
         address admin0 = _getOwner(poolKey.currency0);
         address admin1 = _getOwner(poolKey.currency1);
@@ -87,15 +82,15 @@ contract PermissionedPositionManager is PositionManager {
         getApproved[tokenId] = msg.sender;
 
         bytes memory actions = abi.encodePacked(
-            uint8(Actions.BURN_POSITION), uint8(_ACTION_TAKE_WITH_FALLBACK), uint8(_ACTION_TAKE_WITH_FALLBACK)
+            uint8(Actions.BURN_POSITION), uint8(Actions.UNWIND_WITH_FALLBACK), uint8(Actions.UNWIND_WITH_FALLBACK)
         );
         bytes[] memory params = new bytes[](3);
         params[0] = abi.encode(tokenId, uint128(0), uint128(0), bytes(""));
-        params[1] = abi.encode(poolKey.currency0, lp, defaultRecipient);
-        params[2] = abi.encode(poolKey.currency1, lp, defaultRecipient);
+        params[1] = abi.encode(poolKey.currency0, lp);
+        params[2] = abi.encode(poolKey.currency1, lp);
         poolManager.unlock(abi.encode(actions, params));
 
-        emit PositionUnwound(tokenId, lp, msg.sender, defaultRecipient);
+        emit PositionUnwound(tokenId, lp, msg.sender);
     }
 
     /// @notice Burn an ERC-6909 claim on the PoolManager and transfer the underlying currency to `to`.
@@ -241,9 +236,9 @@ contract PermissionedPositionManager is PositionManager {
     /// @dev Adds the cascade-routing action used by `unwindPosition` and the BURN_6909 primitive used by
     ///      `withdrawClaim`. All other actions fall through to the base PositionManager dispatcher.
     function _handleAction(uint256 action, bytes calldata params) internal override {
-        if (action == _ACTION_TAKE_WITH_FALLBACK) {
-            (Currency currency, address lp, address defaultRecipient) = abi.decode(params, (Currency, address, address));
-            _takeWithFallback(currency, lp, defaultRecipient);
+        if (action == Actions.UNWIND_WITH_FALLBACK) {
+            (Currency currency, address lp) = abi.decode(params, (Currency, address));
+            _unwindWithFallback(currency, lp);
             return;
         }
         if (action == Actions.BURN_6909) {
@@ -254,18 +249,30 @@ contract PermissionedPositionManager is PositionManager {
         super._handleAction(action, params);
     }
 
-    /// @dev Cascade: try take to LP → take to defaultRecipient → mint 6909 claim to defaultRecipient.
-    ///      Final mint never reverts.
-    function _takeWithFallback(Currency currency, address lp, address defaultRecipient) internal {
+    /// @dev Permissioned currencies cascade `take → LP → admin → 6909 mint to admin`. Non-permissioned currencies
+    ///      cascade `take → LP → 6909 mint to LP` — admins cannot take regular ERC-20s, so the LP
+    ///      retains ownership as a transferable claim. Final mint never reverts.
+    function _unwindWithFallback(Currency currency, address lp) internal {
         uint256 amount = _getFullCredit(currency);
         if (amount == 0) return;
 
+        // Try to take to LP
         try poolManager.take(currency, lp, amount) {
             return;
         } catch {}
-        try poolManager.take(currency, defaultRecipient, amount) {
+
+        // If LP is not allowed to receive the currency, try to take to admin
+        address admin = _getOwner(currency);
+        // If no admin, LP retains ownership as a 6909 claim
+        if (admin == address(0)) {
+            poolManager.mint(lp, currency.toId(), amount);
+            return;
+        }
+        // Try to take to admin
+        try poolManager.take(currency, admin, amount) {
             return;
         } catch {}
-        poolManager.mint(defaultRecipient, currency.toId(), amount);
+        // If admin is not allowed to receive the currency, mint a 6909 claim to admin
+        poolManager.mint(admin, currency.toId(), amount);
     }
 }

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -26,7 +26,6 @@ contract PermissionedPositionManager is PositionManager {
     mapping(Currency currency => mapping(IHooks hooks => bool)) public isAllowedHooks;
 
     event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
-
     event CurrencyUnwound(
         uint256 indexed tokenId,
         Currency indexed currency,

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -26,7 +26,16 @@ contract PermissionedPositionManager is PositionManager {
     mapping(Currency currency => mapping(IHooks hooks => bool)) public isAllowedHooks;
 
     event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
-    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin);
+
+    event CurrencyUnwound(
+        uint256 indexed tokenId,
+        Currency indexed currency,
+        address indexed recipient,
+        address caller,
+        address lp,
+        uint256 amount,
+        bool asClaim
+    );
     event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
 
     error InvalidHook();
@@ -67,7 +76,8 @@ contract PermissionedPositionManager is PositionManager {
 
     /// @notice Force-exit the LP from a position. Burns the NFT, unwinds liquidity, and routes each currency.
     /// @dev Either PA admin may call. Per-currency fallback is derived on-chain via `_getOwner` (see
-    ///      `_unwindWithFallback`). The 6909 fallback never reverts, so the call is atomic.
+    ///      `_unwindWithFallback`). The 6909 fallback never reverts, so the call is atomic. Emits one
+    ///      `CurrencyUnwound` event per leg.
     /// @param tokenId The position to unwind
     function unwindPosition(uint256 tokenId) external isNotLocked {
         (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
@@ -86,11 +96,9 @@ contract PermissionedPositionManager is PositionManager {
         );
         bytes[] memory params = new bytes[](3);
         params[0] = abi.encode(tokenId, uint128(0), uint128(0), bytes(""));
-        params[1] = abi.encode(poolKey.currency0, lp);
-        params[2] = abi.encode(poolKey.currency1, lp);
+        params[1] = abi.encode(poolKey.currency0, lp, tokenId);
+        params[2] = abi.encode(poolKey.currency1, lp, tokenId);
         poolManager.unlock(abi.encode(actions, params));
-
-        emit PositionUnwound(tokenId, lp, msg.sender);
     }
 
     /// @notice Burn an ERC-6909 claim on the PoolManager and transfer the underlying currency to `to`.
@@ -237,8 +245,8 @@ contract PermissionedPositionManager is PositionManager {
     ///      `withdrawClaim`. All other actions fall through to the base PositionManager dispatcher.
     function _handleAction(uint256 action, bytes calldata params) internal override {
         if (action == Actions.UNWIND_WITH_FALLBACK) {
-            (Currency currency, address lp) = abi.decode(params, (Currency, address));
-            _unwindWithFallback(currency, lp);
+            (Currency currency, address lp, uint256 tokenId) = abi.decode(params, (Currency, address, uint256));
+            _unwindWithFallback(currency, lp, tokenId);
             return;
         }
         if (action == Actions.BURN_6909) {
@@ -251,13 +259,15 @@ contract PermissionedPositionManager is PositionManager {
 
     /// @dev Permissioned currencies cascade `take → LP → admin → 6909 mint to admin`. Non-permissioned currencies
     ///      cascade `take → LP → 6909 mint to LP` — admins cannot take regular ERC-20s, so the LP
-    ///      retains ownership as a transferable claim. Final mint never reverts.
-    function _unwindWithFallback(Currency currency, address lp) internal {
+    ///      retains ownership as a transferable claim. Final mint never reverts. Emits `CurrencyUnwound` on the
+    ///      terminal branch with `recipient`/`asClaim` reflecting the actual destination.
+    function _unwindWithFallback(Currency currency, address lp, uint256 tokenId) internal {
         uint256 amount = _getFullCredit(currency);
         if (amount == 0) return;
 
         // Try to take to LP
         try poolManager.take(currency, lp, amount) {
+            emit CurrencyUnwound(tokenId, currency, lp, msgSender(), lp, amount, false);
             return;
         } catch {}
 
@@ -266,13 +276,16 @@ contract PermissionedPositionManager is PositionManager {
         // If no admin, LP retains ownership as a 6909 claim
         if (admin == address(0)) {
             poolManager.mint(lp, currency.toId(), amount);
+            emit CurrencyUnwound(tokenId, currency, lp, msgSender(), lp, amount, true);
             return;
         }
         // Try to take to admin
         try poolManager.take(currency, admin, amount) {
+            emit CurrencyUnwound(tokenId, currency, admin, msgSender(), lp, amount, false);
             return;
         } catch {}
         // If admin is not allowed to receive the currency, mint a 6909 claim to admin
         poolManager.mint(admin, currency.toId(), amount);
+        emit CurrencyUnwound(tokenId, currency, admin, msgSender(), lp, amount, true);
     }
 }

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -30,9 +30,7 @@ contract PermissionedPositionManager is PositionManager {
     mapping(Currency currency => mapping(IHooks hooks => bool)) public isAllowedHooks;
 
     event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
-    event PositionUnwound(
-        uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient
-    );
+    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient);
     event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
 
     error InvalidHook();
@@ -72,10 +70,8 @@ contract PermissionedPositionManager is PositionManager {
     }
 
     /// @notice Force-exit the LP from a position. Burns the NFT, unwinds liquidity, and routes each currency.
-    /// @dev Either PA admin in the pool may call. For each currency the cascade is: try transfer to the original
-    ///      LP → on failure, try transfer to `defaultRecipient` → on failure, mint a persistent ERC-6909 claim on
-    ///      the PoolManager to `defaultRecipient`. The third step never reverts, so the call is atomic. Permissioned
-    ///      currencies unwrap to the underlying token; non-permissioned currencies transfer directly.
+    /// @dev Either PA admin may call. Per-currency cascade: LP → `defaultRecipient` → 6909 mint to `defaultRecipient`.
+    ///      The 6909 fallback never reverts, so the call is atomic.
     /// @param tokenId          The position to unwind
     /// @param defaultRecipient The fallback address used if the LP cannot receive a currency
     function unwindPosition(uint256 tokenId, address defaultRecipient) external isNotLocked {
@@ -85,7 +81,6 @@ contract PermissionedPositionManager is PositionManager {
         if (msg.sender != admin0 && msg.sender != admin1) revert Unauthorized();
 
         address lp = ownerOf(tokenId);
-        emit PositionUnwound(tokenId, lp, msg.sender, defaultRecipient);
 
         // Pre-approve so BURN_POSITION inside the unlock passes its onlyIfApproved check.
         // ERC-721 _burn clears getApproved as part of its teardown, so the approval is self-cleaning.
@@ -99,6 +94,8 @@ contract PermissionedPositionManager is PositionManager {
         params[1] = abi.encode(poolKey.currency0, lp, defaultRecipient);
         params[2] = abi.encode(poolKey.currency1, lp, defaultRecipient);
         poolManager.unlock(abi.encode(actions, params));
+
+        emit PositionUnwound(tokenId, lp, msg.sender, defaultRecipient);
     }
 
     /// @notice Burn an ERC-6909 claim on the PoolManager and transfer the underlying currency to `to`.
@@ -111,8 +108,9 @@ contract PermissionedPositionManager is PositionManager {
         bytes[] memory params = new bytes[](2);
         params[0] = abi.encode(currency, msg.sender, amount);
         params[1] = abi.encode(currency, to, amount);
-        emit ClaimWithdrawn(currency, msg.sender, to, amount);
         poolManager.unlock(abi.encode(actions, params));
+
+        emit ClaimWithdrawn(currency, msg.sender, to, amount);
     }
 
     /// @inheritdoc PositionManager
@@ -244,8 +242,7 @@ contract PermissionedPositionManager is PositionManager {
     ///      `withdrawClaim`. All other actions fall through to the base PositionManager dispatcher.
     function _handleAction(uint256 action, bytes calldata params) internal override {
         if (action == _ACTION_TAKE_WITH_FALLBACK) {
-            (Currency currency, address lp, address defaultRecipient) =
-                abi.decode(params, (Currency, address, address));
+            (Currency currency, address lp, address defaultRecipient) = abi.decode(params, (Currency, address, address));
             _routeCredit(currency, lp, defaultRecipient);
             return;
         }
@@ -257,20 +254,18 @@ contract PermissionedPositionManager is PositionManager {
         super._handleAction(action, params);
     }
 
-    /// @dev Cascading routes: 1. Underlying -> LP, Underlying -> defaultRecipient, PA 6909 claim to defaultRecipient. Final mint never reverts.
+    /// @dev Cascade: try take to LP → take to defaultRecipient → mint 6909 claim to defaultRecipient.
+    ///      Final mint never reverts.
     function _routeCredit(Currency currency, address lp, address defaultRecipient) internal {
         uint256 amount = _getFullCredit(currency);
         if (amount == 0) return;
 
-        // Unwrap and transfer underlying to LP
         try poolManager.take(currency, lp, amount) {
             return;
         } catch {}
-        // Unwrap and transfer underlying to defaultRecipient
         try poolManager.take(currency, defaultRecipient, amount) {
             return;
         } catch {}
-        // Mint 6909 claim to defaultRecipient
         poolManager.mint(defaultRecipient, currency.toId(), amount);
     }
 }

--- a/src/libraries/Actions.sol
+++ b/src/libraries/Actions.sol
@@ -46,4 +46,8 @@ library Actions {
     // note this is not supported in the position manager or router
     uint256 internal constant MINT_6909 = 0x17;
     uint256 internal constant BURN_6909 = 0x18;
+
+    // permissioned-pools specific actions
+    // routes a currency's positive delta with a fallback cascade: LP → defaultRecipient → 6909 mint to defaultRecipient
+    uint256 internal constant UNWIND_WITH_FALLBACK = 0x19;
 }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1011,24 +1011,9 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         assertEq(lpFee, fee);
     }
 
-    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    error TransferDisabled();
 
-    function test_transferFrom_success_seize_by_admin() public {
-        _testRevert_transferFrom_success_seize_by_admin(key0);
-        _testRevert_transferFrom_success_seize_by_admin(key1);
-    }
-
-    function _testRevert_transferFrom_success_seize_by_admin(PoolKey memory poolKey) internal {
-        uint256 tokenId = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(poolKey);
-
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(alice, address(this), tokenId);
-        // address(this) is admin
-        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId);
-    }
-
-    function test_transferFrom_success_seize_by_either_admin() public {
+    function test_transferFrom_reverts_transfer_disabled_either_admin() public {
         uint256 tokenId0 = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key2);
         uint256 tokenId1 = lpm.nextTokenId();
@@ -1036,9 +1021,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 tokenId2 = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key2);
 
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(alice, address(this), tokenId0);
         // address(this) is admin of both permissioned tokens
+        vm.expectRevert(TransferDisabled.selector);
         IERC721(address(lpm)).transferFrom(alice, address(this), tokenId0);
 
         address owner0 = makeAddr("owner0");
@@ -1050,94 +1034,32 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         vm.prank(owner1);
         permissionsAdapter2.acceptOwnership();
 
-        vm.prank(owner0);
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(alice, address(this), tokenId1);
-        // owner0 is admin of permissionsAdapter0
+        vm.startPrank(owner0);
+        vm.expectRevert(TransferDisabled.selector);
         IERC721(address(lpm)).transferFrom(alice, address(this), tokenId1);
+        vm.stopPrank();
 
-        vm.prank(owner1);
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(alice, address(this), tokenId2);
-        // owner1 is admin of permissionsAdapter2
+        vm.startPrank(owner1);
+        vm.expectRevert(TransferDisabled.selector);
         IERC721(address(lpm)).transferFrom(alice, address(this), tokenId2);
+        vm.stopPrank();
     }
 
-    function test_transferFrom_revert_not_admin(address notAdmin) public {
-        vm.assume(notAdmin != address(this) && notAdmin != address(0));
-        uint256 tokenId0 = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key0);
-        uint256 tokenId1 = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key1);
-        uint256 tokenId2 = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key2);
-        uint256 tokenId3 = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key2);
-
-        vm.prank(notAdmin);
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId0);
-
-        vm.prank(notAdmin);
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId1);
-
-        vm.prank(notAdmin);
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId2);
-
-        vm.prank(notAdmin);
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId3);
+    function test_transferFrom_reverts_transfer_disabled(address caller) public {
+        _testRevert_transferFrom_reverts_transfer_disabled(key0, caller);
+        _testRevert_transferFrom_reverts_transfer_disabled(key1, caller);
+        _testRevert_transferFrom_reverts_transfer_disabled(key2, caller);
     }
 
-    function test_transferFrom_revert_recipient_not_allowlisted_mixed_pool() public {
-        // key0 is permissioned/normal, key1 is normal/permissioned
-        uint256 tokenId0 = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key0);
-        uint256 tokenId1 = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key1);
-
-        address notAllowed = makeAddr("NOT_ALLOWED");
-
-        // admin is address(this) for both adapters; recipient is not on either allowlist
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId0);
-
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId1);
-    }
-
-    function test_transferFrom_revert_recipient_not_allowlisted_both_permissioned() public {
-        // key2 has two permissioned currencies
+    function _testRevert_transferFrom_reverts_transfer_disabled(PoolKey memory poolKey, address caller) internal {
         uint256 tokenId = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key2);
+        _test_permissioned_mint_allowed_user(poolKey);
 
-        address notAllowed = makeAddr("NOT_ALLOWED");
-
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, notAllowed, tokenId);
+        vm.startPrank(caller);
+        vm.expectRevert(TransferDisabled.selector);
+        IERC721(address(lpm)).transferFrom(alice, address(this), tokenId);
+        vm.stopPrank();
     }
-
-    function test_transferFrom_success_recipient_allowlisted_after_seize() public {
-        // admin can seize a key2 position to a fresh recipient after allowlisting them
-        uint256 tokenId = lpm.nextTokenId();
-        _test_permissioned_mint_allowed_user(key2);
-
-        address recipient = makeAddr("NEW_HOLDER");
-
-        vm.expectRevert(Unauthorized.selector);
-        IERC721(address(lpm)).transferFrom(alice, recipient, tokenId);
-
-        // admin allowlists the recipient on each permissioned token in the pool
-        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(recipient, PermissionFlags.ALL_ALLOWED);
-        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(recipient, PermissionFlags.ALL_ALLOWED);
-
-        IERC721(address(lpm)).transferFrom(alice, recipient, tokenId);
-        assertEq(IERC721(address(lpm)).ownerOf(tokenId), recipient);
-    }
-
-    error SafeTransferDisabled();
 
     function test_safe_transfer_from_reverts() public {
         bytes memory encodedCall =
@@ -1149,7 +1071,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         (bool success, bytes memory data) = address(target).call(encodedCall);
 
         assertEq(success, false);
-        assertEq(bytes4(data), SafeTransferDisabled.selector);
+        assertEq(bytes4(data), TransferDisabled.selector);
         vm.stopPrank();
     }
 
@@ -1162,7 +1084,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         (bool success, bytes memory data) = address(target).call(encodedCall);
 
         assertEq(success, false);
-        assertEq(bytes4(data), SafeTransferDisabled.selector);
+        assertEq(bytes4(data), TransferDisabled.selector);
         vm.stopPrank();
     }
 

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1613,13 +1613,19 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         require(success, "setAllowedHook failed");
     }
 
-    event PositionUnwound(
-        uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient
-    );
-    event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
+    // ===== unwindPosition / withdrawClaim helpers =====
 
+    /// @dev V4 rounds in favor of the pool: a mint+burn roundtrip loses up to 1 wei per side.
+    uint256 private constant _ROUNDTRIP_TOLERANCE = 1;
     bytes4 private constant _UNWIND_SELECTOR = 0x3aa505cc;
     bytes4 private constant _WITHDRAW_CLAIM_SELECTOR = 0xf77de3fc;
+
+    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient);
+    event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
+
+    function _balanceOf(Currency c, address who) internal view returns (uint256) {
+        return IERC20(Currency.unwrap(c)).balanceOf(who);
+    }
 
     function _unwind(uint256 tokenId, address defaultRecipient) internal {
         (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, defaultRecipient));
@@ -1631,15 +1637,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         require(ok, "withdrawClaim failed");
     }
 
-    /// @dev V4 rounds in favor of the pool: a mint+burn roundtrip loses up to 1 wei per side.
-    uint256 private constant _ROUNDTRIP_TOLERANCE = 1;
-
-    function _balanceOf(Currency c, address who) internal view returns (uint256) {
-        return IERC20(Currency.unwrap(c)).balanceOf(who);
-    }
-
-    /// @dev Sets up unwindPosition tests by handing pa0 ownership to `admin1`, pa2 ownership to `admin2`, and
-    ///      filtering fuzz inputs so the cascade test premise holds. Pass `admin1 == admin2` for the same-admin case.
+    /// @dev Hands pa0 ownership to `admin1`, pa2 ownership to `admin2`, and filters fuzz inputs so the cascade
+    ///      premise holds. Pass `admin1 == admin2` for the same-admin case.
     function _setupUnwindPositionTests(address admin1, address admin2, address defaultRecipient) internal {
         // admins must be valid Ownable2Step recipients and distinct from protocol contracts
         vm.assume(admin1 != address(0) && admin2 != address(0));
@@ -1735,9 +1734,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
         // defaultRecipient receives ~exactly what alice deposited on pa0; regular currency goes back to alice
         assertApproxEqAbs(
-            _balanceOf(currency0, defaultRecipient) - recipientCurrency0BeforeMint,
-            deposited0,
-            _ROUNDTRIP_TOLERANCE
+            _balanceOf(currency0, defaultRecipient) - recipientCurrency0BeforeMint, deposited0, _ROUNDTRIP_TOLERANCE
         );
         assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
     }
@@ -1765,9 +1762,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _unwind(tokenId, defaultRecipient);
 
         // 6909 claim to defaultRecipient ≈ alice's pa0 deposit; regular currency goes back to alice
-        assertApproxEqAbs(
-            manager.balanceOf(defaultRecipient, key0.currency0.toId()), deposited0, _ROUNDTRIP_TOLERANCE
-        );
+        assertApproxEqAbs(manager.balanceOf(defaultRecipient, key0.currency0.toId()), deposited0, _ROUNDTRIP_TOLERANCE);
         assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
     }
 
@@ -1796,7 +1791,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     }
 
     /// @dev Case 3b: LP delisted on currency2 → pa0 → LP, pa2 → defaultRecipient.
-    function test_unwindPosition_two_pas_different_admins_routes_pa1_to_default_when_lp_blocked(
+    function test_unwindPosition_two_pas_different_admins_routes_pa2_to_default_when_lp_blocked(
         address admin1,
         address admin2,
         address defaultRecipient
@@ -1820,14 +1815,12 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
         assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
         assertApproxEqAbs(
-            _balanceOf(currency2, defaultRecipient) - recipientCurrency2BeforeMint,
-            deposited2,
-            _ROUNDTRIP_TOLERANCE
+            _balanceOf(currency2, defaultRecipient) - recipientCurrency2BeforeMint, deposited2, _ROUNDTRIP_TOLERANCE
         );
     }
 
     /// @dev Case 3c: LP and defaultRecipient delisted on currency2 → pa0 → LP, pa2 → 6909 claim to defaultRecipient.
-    function test_unwindPosition_two_pas_different_admins_credits_6909_when_lp_and_default_blocked_on_pa1(
+    function test_unwindPosition_two_pas_different_admins_credits_6909_when_lp_and_default_blocked_on_pa2(
         address admin1,
         address admin2,
         address defaultRecipient
@@ -1849,32 +1842,37 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _unwind(tokenId, defaultRecipient);
 
         assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
-        assertApproxEqAbs(
-            manager.balanceOf(defaultRecipient, key2.currency1.toId()), deposited2, _ROUNDTRIP_TOLERANCE
-        );
+        assertApproxEqAbs(manager.balanceOf(defaultRecipient, key2.currency1.toId()), deposited2, _ROUNDTRIP_TOLERANCE);
     }
 
-    function test_unwindPosition_reverts_when_caller_is_not_admin(address notAdmin) public {
-        vm.assume(notAdmin != address(this) && notAdmin != address(0));
+    // ===== Auth / either-admin =====
+
+    function test_unwindPosition_reverts_when_caller_is_not_admin(
+        address admin1,
+        address admin2,
+        address defaultRecipient,
+        address notAdmin
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+        vm.assume(notAdmin != admin1 && notAdmin != admin2);
+
         uint256 tokenId = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key2);
 
         vm.prank(notAdmin);
         (bool ok, bytes memory data) =
-            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, notAdmin));
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, defaultRecipient));
         assertEq(ok, false);
         assertEq(bytes4(data), Unauthorized.selector);
     }
 
-    /// @dev Either PA admin in the pool can call `unwindPosition`. With split ownership (admin1 ≠ admin2), exercise
-    ///      both: admin1 unwinds one position, admin2 unwinds another.
+    /// @dev Either PA admin can call `unwindPosition`. With distinct admins, exercise both.
     function test_unwindPosition_either_admin_acts_independently(
         address admin1,
         address admin2,
         address defaultRecipient
     ) public {
         _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
-        // need distinct admins to actually exercise "either"
         vm.assume(admin1 != admin2);
 
         uint256 tokenId0 = lpm.nextTokenId();
@@ -1893,18 +1891,15 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         IERC721(address(lpm)).ownerOf(tokenId1);
     }
 
-    /// @dev Roundtrip: force the cascade to step 3 (6909 mint to defaultRecipient), then redeem the claim through
-    ///      `withdrawClaim` to a fresh `to` address. Verifies the claim is fully consumed and the underlying
-    ///      lands at `to` exactly.
-    function test_withdrawClaim_round_trip(
-        address admin1,
-        address admin2,
-        address defaultRecipient,
-        address to
-    ) public {
+    // ===== withdrawClaim =====
+
+    /// @dev Forces the cascade to the 6909 fallback, then redeems via `withdrawClaim` to a fresh `to`.
+    function test_withdrawClaim_round_trip(address admin1, address admin2, address defaultRecipient, address to)
+        public
+    {
         _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
-        // to must be a clean recipient distinct from existing actors and from the action-handler sentinels
-        // (MSG_SENDER = 0x1 / ADDRESS_THIS = 0x2 would get remapped by _mapRecipient inside the TAKE action)
+        // `to` must be distinct from existing actors and from action-handler sentinels (MSG_SENDER = 0x1 /
+        // ADDRESS_THIS = 0x2 would get remapped by _mapRecipient inside the TAKE action)
         vm.assume(to != address(0));
         vm.assume(to != ActionConstants.MSG_SENDER);
         vm.assume(to != ActionConstants.ADDRESS_THIS);
@@ -1927,7 +1922,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 claim = manager.balanceOf(defaultRecipient, key0.currency0.toId());
         assertGt(claim, 0);
 
-        // to needs to be on the underlying compliance list to receive the secToken on unwrap
+        // `to` needs to be on the underlying compliance list to receive the secToken on unwrap
         MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(to, PermissionFlags.ALL_ALLOWED);
 
         // defaultRecipient authorizes permPosm to burn its 6909 claims
@@ -1945,9 +1940,20 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         assertEq(_balanceOf(currency0, to) - toBefore, claim);
     }
 
-    /// @dev Caller has no 6909 balance and has not authorized permPosm via `setOperator` or `approve` →
-    ///      `PoolManager.burn` underflows on the allowance check and the whole unlock reverts.
-    function test_withdrawClaim_reverts_without_operator_or_balance() public {
+    /// @dev Caller has not authorized permPosm via `setOperator` → BURN_6909 underflows on the allowance check.
+    function test_withdrawClaim_reverts_without_operator() public {
+        vm.startPrank(alice);
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_WITHDRAW_CLAIM_SELECTOR, key2.currency0, 1, alice));
+        vm.stopPrank();
+        assertEq(ok, false);
+    }
+
+    /// @dev Caller has authorized permPosm but holds no 6909 balance → BURN_6909 passes auth and underflows on
+    ///      the balance subtraction.
+    function test_withdrawClaim_reverts_without_balance() public {
+        vm.prank(alice);
+        manager.setOperator(address(lpm), true);
+
         vm.startPrank(alice);
         (bool ok,) = address(lpm).call(abi.encodeWithSelector(_WITHDRAW_CLAIM_SELECTOR, key2.currency0, 1, alice));
         vm.stopPrank();

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1612,4 +1612,345 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         (bool success,) = address(lpm).call(abi.encodeWithSelector(selector, currency, hooks_, allowed));
         require(success, "setAllowedHook failed");
     }
+
+    event PositionUnwound(
+        uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient
+    );
+    event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
+
+    bytes4 private constant _UNWIND_SELECTOR = 0x3aa505cc;
+    bytes4 private constant _WITHDRAW_CLAIM_SELECTOR = 0xf77de3fc;
+
+    function _unwind(uint256 tokenId, address defaultRecipient) internal {
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, defaultRecipient));
+        require(ok, "unwindPosition failed");
+    }
+
+    function _withdrawClaim(Currency currency, uint256 amount, address to) internal {
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_WITHDRAW_CLAIM_SELECTOR, currency, amount, to));
+        require(ok, "withdrawClaim failed");
+    }
+
+    /// @dev V4 rounds in favor of the pool: a mint+burn roundtrip loses up to 1 wei per side.
+    uint256 private constant _ROUNDTRIP_TOLERANCE = 1;
+
+    function _balanceOf(Currency c, address who) internal view returns (uint256) {
+        return IERC20(Currency.unwrap(c)).balanceOf(who);
+    }
+
+    /// @dev Sets up unwindPosition tests by handing pa0 ownership to `admin1`, pa2 ownership to `admin2`, and
+    ///      filtering fuzz inputs so the cascade test premise holds. Pass `admin1 == admin2` for the same-admin case.
+    function _setupUnwindPositionTests(address admin1, address admin2, address defaultRecipient) internal {
+        // admins must be valid Ownable2Step recipients and distinct from protocol contracts
+        vm.assume(admin1 != address(0) && admin2 != address(0));
+        vm.assume(admin1 != alice && admin2 != alice);
+        vm.assume(admin1 != address(manager) && admin2 != address(manager));
+        vm.assume(admin1 != address(lpm) && admin2 != address(lpm));
+
+        permissionsAdapter0.transferOwnership(admin1);
+        vm.prank(admin1);
+        permissionsAdapter0.acceptOwnership();
+
+        permissionsAdapter2.transferOwnership(admin2);
+        vm.prank(admin2);
+        permissionsAdapter2.acceptOwnership();
+
+        // defaultRecipient must not collide with the LP or with any protocol contract whose receipt semantics
+        // would distort the cascade balance assertions
+        vm.assume(defaultRecipient != address(0));
+        vm.assume(defaultRecipient != alice);
+        vm.assume(defaultRecipient != address(manager));
+        vm.assume(defaultRecipient != address(lpm));
+        vm.assume(defaultRecipient != address(permissionsAdapter0));
+        vm.assume(defaultRecipient != address(permissionsAdapter2));
+    }
+
+    // ===== Case 1: both currencies are PAs owned by the same admin (admin1 == admin2) =====
+
+    function test_unwindPosition_two_pas_same_admin_routes_both_to_lp(address admin, address defaultRecipient) public {
+        _setupUnwindPositionTests(admin, admin, defaultRecipient);
+
+        uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
+        uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        vm.expectEmit(true, true, true, true);
+        emit PositionUnwound(tokenId, alice, admin, defaultRecipient);
+        vm.prank(admin);
+        _unwind(tokenId, defaultRecipient);
+
+        // alice should be roughly whole on both currencies
+        assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
+        assertApproxEqAbs(_balanceOf(currency2, alice), aliceCurrency2BeforeMint, _ROUNDTRIP_TOLERANCE);
+    }
+
+    // ===== Case 2: one PA + one regular ERC-20; admin1 (= owner of pa0) calls =====
+
+    /// @dev Case 2a: LP compliant on pa0's underlying → both cascade to LP.
+    function test_unwindPosition_pa_and_regular_routes_both_to_lp_when_compliant(
+        address admin1,
+        address admin2,
+        address defaultRecipient
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+
+        uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
+        uint256 aliceCurrency1BeforeMint = _balanceOf(key0.currency1, alice);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+
+        vm.prank(admin1);
+        _unwind(tokenId, defaultRecipient);
+
+        assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
+        assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
+    }
+
+    /// @dev Case 2b: LP delisted on pa0's underlying → pa0 cascades to defaultRecipient; regular still goes to LP.
+    function test_unwindPosition_pa_and_regular_routes_pa_to_default_when_lp_blocked(
+        address admin1,
+        address admin2,
+        address defaultRecipient
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+
+        uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
+        uint256 aliceCurrency1BeforeMint = _balanceOf(key0.currency1, alice);
+        uint256 recipientCurrency0BeforeMint = _balanceOf(currency0, defaultRecipient);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+
+        // capture how much pa0 underlying alice deposited at mint time
+        uint256 deposited0 = aliceCurrency0BeforeMint - _balanceOf(currency0, alice);
+
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(defaultRecipient, true);
+
+        vm.prank(admin1);
+        _unwind(tokenId, defaultRecipient);
+
+        // defaultRecipient receives ~exactly what alice deposited on pa0; regular currency goes back to alice
+        assertApproxEqAbs(
+            _balanceOf(currency0, defaultRecipient) - recipientCurrency0BeforeMint,
+            deposited0,
+            _ROUNDTRIP_TOLERANCE
+        );
+        assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
+    }
+
+    /// @dev Case 2c: neither LP nor defaultRecipient on pa0's underlying → pa0 lands as 6909 claim to defaultRecipient.
+    function test_unwindPosition_pa_and_regular_credits_6909_when_lp_and_default_blocked(
+        address admin1,
+        address admin2,
+        address defaultRecipient
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+
+        uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
+        uint256 aliceCurrency1BeforeMint = _balanceOf(key0.currency1, alice);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+
+        uint256 deposited0 = aliceCurrency0BeforeMint - _balanceOf(currency0, alice);
+
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(defaultRecipient, false);
+
+        vm.prank(admin1);
+        _unwind(tokenId, defaultRecipient);
+
+        // 6909 claim to defaultRecipient ≈ alice's pa0 deposit; regular currency goes back to alice
+        assertApproxEqAbs(
+            manager.balanceOf(defaultRecipient, key0.currency0.toId()), deposited0, _ROUNDTRIP_TOLERANCE
+        );
+        assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
+    }
+
+    // ===== Case 3: both currencies are PAs owned by different admins; admin1 (= owner of pa0) calls =====
+    // pa0 always cascades happy-path because admin1 controls currency0's compliance list. pa2 is the variable.
+
+    /// @dev Case 3a: LP on both underlyings → both cascade to LP.
+    function test_unwindPosition_two_pas_different_admins_routes_both_to_lp(
+        address admin1,
+        address admin2,
+        address defaultRecipient
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+
+        uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
+        uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        vm.prank(admin1);
+        _unwind(tokenId, defaultRecipient);
+
+        assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
+        assertApproxEqAbs(_balanceOf(currency2, alice), aliceCurrency2BeforeMint, _ROUNDTRIP_TOLERANCE);
+    }
+
+    /// @dev Case 3b: LP delisted on currency2 → pa0 → LP, pa2 → defaultRecipient.
+    function test_unwindPosition_two_pas_different_admins_routes_pa1_to_default_when_lp_blocked(
+        address admin1,
+        address admin2,
+        address defaultRecipient
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+
+        uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
+        uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
+        uint256 recipientCurrency2BeforeMint = _balanceOf(currency2, defaultRecipient);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        uint256 deposited2 = aliceCurrency2BeforeMint - _balanceOf(currency2, alice);
+
+        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(alice, false);
+        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(defaultRecipient, true);
+
+        vm.prank(admin1);
+        _unwind(tokenId, defaultRecipient);
+
+        assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
+        assertApproxEqAbs(
+            _balanceOf(currency2, defaultRecipient) - recipientCurrency2BeforeMint,
+            deposited2,
+            _ROUNDTRIP_TOLERANCE
+        );
+    }
+
+    /// @dev Case 3c: LP and defaultRecipient delisted on currency2 → pa0 → LP, pa2 → 6909 claim to defaultRecipient.
+    function test_unwindPosition_two_pas_different_admins_credits_6909_when_lp_and_default_blocked_on_pa1(
+        address admin1,
+        address admin2,
+        address defaultRecipient
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+
+        uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
+        uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        uint256 deposited2 = aliceCurrency2BeforeMint - _balanceOf(currency2, alice);
+
+        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(alice, false);
+        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(defaultRecipient, false);
+
+        vm.prank(admin1);
+        _unwind(tokenId, defaultRecipient);
+
+        assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
+        assertApproxEqAbs(
+            manager.balanceOf(defaultRecipient, key2.currency1.toId()), deposited2, _ROUNDTRIP_TOLERANCE
+        );
+    }
+
+    function test_unwindPosition_reverts_when_caller_is_not_admin(address notAdmin) public {
+        vm.assume(notAdmin != address(this) && notAdmin != address(0));
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        vm.prank(notAdmin);
+        (bool ok, bytes memory data) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, notAdmin));
+        assertEq(ok, false);
+        assertEq(bytes4(data), Unauthorized.selector);
+    }
+
+    /// @dev Either PA admin in the pool can call `unwindPosition`. With split ownership (admin1 ≠ admin2), exercise
+    ///      both: admin1 unwinds one position, admin2 unwinds another.
+    function test_unwindPosition_either_admin_acts_independently(
+        address admin1,
+        address admin2,
+        address defaultRecipient
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+        // need distinct admins to actually exercise "either"
+        vm.assume(admin1 != admin2);
+
+        uint256 tokenId0 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+        uint256 tokenId1 = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        vm.prank(admin1);
+        _unwind(tokenId0, defaultRecipient);
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId0);
+
+        vm.prank(admin2);
+        _unwind(tokenId1, defaultRecipient);
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId1);
+    }
+
+    /// @dev Roundtrip: force the cascade to step 3 (6909 mint to defaultRecipient), then redeem the claim through
+    ///      `withdrawClaim` to a fresh `to` address. Verifies the claim is fully consumed and the underlying
+    ///      lands at `to` exactly.
+    function test_withdrawClaim_round_trip(
+        address admin1,
+        address admin2,
+        address defaultRecipient,
+        address to
+    ) public {
+        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+        // to must be a clean recipient distinct from existing actors and from the action-handler sentinels
+        // (MSG_SENDER = 0x1 / ADDRESS_THIS = 0x2 would get remapped by _mapRecipient inside the TAKE action)
+        vm.assume(to != address(0));
+        vm.assume(to != ActionConstants.MSG_SENDER);
+        vm.assume(to != ActionConstants.ADDRESS_THIS);
+        vm.assume(to != alice);
+        vm.assume(to != defaultRecipient);
+        vm.assume(to != address(manager));
+        vm.assume(to != address(lpm));
+        vm.assume(to != address(permissionsAdapter0));
+        vm.assume(to != address(permissionsAdapter2));
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(defaultRecipient, false);
+
+        vm.prank(admin1);
+        _unwind(tokenId, defaultRecipient);
+
+        uint256 claim = manager.balanceOf(defaultRecipient, key0.currency0.toId());
+        assertGt(claim, 0);
+
+        // to needs to be on the underlying compliance list to receive the secToken on unwrap
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(to, PermissionFlags.ALL_ALLOWED);
+
+        // defaultRecipient authorizes permPosm to burn its 6909 claims
+        vm.prank(defaultRecipient);
+        manager.setOperator(address(lpm), true);
+
+        uint256 toBefore = _balanceOf(currency0, to);
+        vm.expectEmit(true, true, true, true);
+        emit ClaimWithdrawn(key0.currency0, defaultRecipient, to, claim);
+        vm.prank(defaultRecipient);
+        _withdrawClaim(key0.currency0, claim, to);
+
+        // claim fully consumed; to received exactly `claim` of the underlying
+        assertEq(manager.balanceOf(defaultRecipient, key0.currency0.toId()), 0);
+        assertEq(_balanceOf(currency0, to) - toBefore, claim);
+    }
+
+    /// @dev Caller has no 6909 balance and has not authorized permPosm via `setOperator` or `approve` →
+    ///      `PoolManager.burn` underflows on the allowance check and the whole unlock reverts.
+    function test_withdrawClaim_reverts_without_operator_or_balance() public {
+        vm.startPrank(alice);
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_WITHDRAW_CLAIM_SELECTOR, key2.currency0, 1, alice));
+        vm.stopPrank();
+        assertEq(ok, false);
+    }
 }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1617,18 +1617,18 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
     /// @dev V4 rounds in favor of the pool: a mint+burn roundtrip loses up to 1 wei per side.
     uint256 private constant _ROUNDTRIP_TOLERANCE = 1;
-    bytes4 private constant _UNWIND_SELECTOR = 0x3aa505cc;
+    bytes4 private constant _UNWIND_SELECTOR = 0x37058749;
     bytes4 private constant _WITHDRAW_CLAIM_SELECTOR = 0xf77de3fc;
 
-    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin, address defaultRecipient);
+    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin);
     event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
 
     function _balanceOf(Currency c, address who) internal view returns (uint256) {
         return IERC20(Currency.unwrap(c)).balanceOf(who);
     }
 
-    function _unwind(uint256 tokenId, address defaultRecipient) internal {
-        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, defaultRecipient));
+    function _unwind(uint256 tokenId) internal {
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
         require(ok, "unwindPosition failed");
     }
 
@@ -1637,9 +1637,9 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         require(ok, "withdrawClaim failed");
     }
 
-    /// @dev Hands pa0 ownership to `admin1`, pa2 ownership to `admin2`, and filters fuzz inputs so the cascade
-    ///      premise holds. Pass `admin1 == admin2` for the same-admin case.
-    function _setupUnwindPositionTests(address admin1, address admin2, address defaultRecipient) internal {
+    /// @dev Hands pa0 ownership to `admin1`, pa2 ownership to `admin2`, and filters fuzz inputs to keep the
+    ///      cascade premise sane. Pass `admin1 == admin2` for the same-admin case.
+    function _setupUnwindPositionTests(address admin1, address admin2) internal {
         // admins must be valid Ownable2Step recipients and distinct from protocol contracts
         vm.assume(admin1 != address(0) && admin2 != address(0));
         vm.assume(admin1 != alice && admin2 != alice);
@@ -1653,21 +1653,12 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         permissionsAdapter2.transferOwnership(admin2);
         vm.prank(admin2);
         permissionsAdapter2.acceptOwnership();
-
-        // defaultRecipient must not collide with the LP or with any protocol contract whose receipt semantics
-        // would distort the cascade balance assertions
-        vm.assume(defaultRecipient != address(0));
-        vm.assume(defaultRecipient != alice);
-        vm.assume(defaultRecipient != address(manager));
-        vm.assume(defaultRecipient != address(lpm));
-        vm.assume(defaultRecipient != address(permissionsAdapter0));
-        vm.assume(defaultRecipient != address(permissionsAdapter2));
     }
 
     // ===== Case 1: both currencies are PAs owned by the same admin (admin1 == admin2) =====
 
-    function test_unwindPosition_two_pas_same_admin_routes_both_to_lp(address admin, address defaultRecipient) public {
-        _setupUnwindPositionTests(admin, admin, defaultRecipient);
+    function test_unwindPosition_two_pas_same_admin_routes_both_to_lp(address admin) public {
+        _setupUnwindPositionTests(admin, admin);
 
         uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
         uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
@@ -1676,9 +1667,9 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _test_permissioned_mint_allowed_user(key2);
 
         vm.expectEmit(true, true, true, true);
-        emit PositionUnwound(tokenId, alice, admin, defaultRecipient);
+        emit PositionUnwound(tokenId, alice, admin);
         vm.prank(admin);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
         // alice should be roughly whole on both currencies
         assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
@@ -1688,12 +1679,10 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     // ===== Case 2: one PA + one regular ERC-20; admin1 (= owner of pa0) calls =====
 
     /// @dev Case 2a: LP compliant on pa0's underlying → both cascade to LP.
-    function test_unwindPosition_pa_and_regular_routes_both_to_lp_when_compliant(
-        address admin1,
-        address admin2,
-        address defaultRecipient
-    ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+    function test_unwindPosition_pa_and_regular_routes_both_to_lp_when_compliant(address admin1, address admin2)
+        public
+    {
+        _setupUnwindPositionTests(admin1, admin2);
 
         uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
         uint256 aliceCurrency1BeforeMint = _balanceOf(key0.currency1, alice);
@@ -1702,23 +1691,21 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _test_permissioned_mint_allowed_user(key0);
 
         vm.prank(admin1);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
         assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
         assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
     }
 
-    /// @dev Case 2b: LP delisted on pa0's underlying → pa0 cascades to defaultRecipient; regular still goes to LP.
-    function test_unwindPosition_pa_and_regular_routes_pa_to_default_when_lp_blocked(
-        address admin1,
-        address admin2,
-        address defaultRecipient
-    ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+    /// @dev Case 2b: LP delisted on pa0's underlying → pa0 cascades to admin1; regular still goes to LP.
+    function test_unwindPosition_pa_and_regular_routes_pa_to_admin_when_lp_blocked(address admin1, address admin2)
+        public
+    {
+        _setupUnwindPositionTests(admin1, admin2);
 
         uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
         uint256 aliceCurrency1BeforeMint = _balanceOf(key0.currency1, alice);
-        uint256 recipientCurrency0BeforeMint = _balanceOf(currency0, defaultRecipient);
+        uint256 adminCurrency0BeforeMint = _balanceOf(currency0, admin1);
 
         uint256 tokenId = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key0);
@@ -1727,25 +1714,21 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 deposited0 = aliceCurrency0BeforeMint - _balanceOf(currency0, alice);
 
         MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
-        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(defaultRecipient, true);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(admin1, true);
 
         vm.prank(admin1);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
-        // defaultRecipient receives ~exactly what alice deposited on pa0; regular currency goes back to alice
-        assertApproxEqAbs(
-            _balanceOf(currency0, defaultRecipient) - recipientCurrency0BeforeMint, deposited0, _ROUNDTRIP_TOLERANCE
-        );
+        // admin1 receives ~exactly what alice deposited on pa0; regular currency goes back to alice
+        assertApproxEqAbs(_balanceOf(currency0, admin1) - adminCurrency0BeforeMint, deposited0, _ROUNDTRIP_TOLERANCE);
         assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
     }
 
-    /// @dev Case 2c: neither LP nor defaultRecipient on pa0's underlying → pa0 lands as 6909 claim to defaultRecipient.
-    function test_unwindPosition_pa_and_regular_credits_6909_when_lp_and_default_blocked(
-        address admin1,
-        address admin2,
-        address defaultRecipient
-    ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+    /// @dev Case 2c: neither LP nor admin1 on pa0's underlying → pa0 lands as 6909 claim to admin1.
+    function test_unwindPosition_pa_and_regular_credits_6909_when_lp_and_admin_blocked(address admin1, address admin2)
+        public
+    {
+        _setupUnwindPositionTests(admin1, admin2);
 
         uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
         uint256 aliceCurrency1BeforeMint = _balanceOf(key0.currency1, alice);
@@ -1756,13 +1739,13 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 deposited0 = aliceCurrency0BeforeMint - _balanceOf(currency0, alice);
 
         MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
-        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(defaultRecipient, false);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(admin1, false);
 
         vm.prank(admin1);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
-        // 6909 claim to defaultRecipient ≈ alice's pa0 deposit; regular currency goes back to alice
-        assertApproxEqAbs(manager.balanceOf(defaultRecipient, key0.currency0.toId()), deposited0, _ROUNDTRIP_TOLERANCE);
+        // 6909 claim to admin1 ≈ alice's pa0 deposit; regular currency goes back to alice
+        assertApproxEqAbs(manager.balanceOf(admin1, key0.currency0.toId()), deposited0, _ROUNDTRIP_TOLERANCE);
         assertApproxEqAbs(_balanceOf(key0.currency1, alice), aliceCurrency1BeforeMint, _ROUNDTRIP_TOLERANCE);
     }
 
@@ -1770,12 +1753,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     // pa0 always cascades happy-path because admin1 controls currency0's compliance list. pa2 is the variable.
 
     /// @dev Case 3a: LP on both underlyings → both cascade to LP.
-    function test_unwindPosition_two_pas_different_admins_routes_both_to_lp(
-        address admin1,
-        address admin2,
-        address defaultRecipient
-    ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+    function test_unwindPosition_two_pas_different_admins_routes_both_to_lp(address admin1, address admin2) public {
+        _setupUnwindPositionTests(admin1, admin2);
 
         uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
         uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
@@ -1784,23 +1763,22 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _test_permissioned_mint_allowed_user(key2);
 
         vm.prank(admin1);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
         assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
         assertApproxEqAbs(_balanceOf(currency2, alice), aliceCurrency2BeforeMint, _ROUNDTRIP_TOLERANCE);
     }
 
-    /// @dev Case 3b: LP delisted on currency2 → pa0 → LP, pa2 → defaultRecipient.
-    function test_unwindPosition_two_pas_different_admins_routes_pa2_to_default_when_lp_blocked(
+    /// @dev Case 3b: LP delisted on currency2 → pa0 → LP, pa2 → admin2 (pa2's admin).
+    function test_unwindPosition_two_pas_different_admins_routes_pa2_to_admin2_when_lp_blocked(
         address admin1,
-        address admin2,
-        address defaultRecipient
+        address admin2
     ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+        _setupUnwindPositionTests(admin1, admin2);
 
         uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
         uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
-        uint256 recipientCurrency2BeforeMint = _balanceOf(currency2, defaultRecipient);
+        uint256 admin2Currency2BeforeMint = _balanceOf(currency2, admin2);
 
         uint256 tokenId = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key2);
@@ -1808,24 +1786,21 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 deposited2 = aliceCurrency2BeforeMint - _balanceOf(currency2, alice);
 
         MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(alice, false);
-        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(defaultRecipient, true);
+        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(admin2, true);
 
         vm.prank(admin1);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
         assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
-        assertApproxEqAbs(
-            _balanceOf(currency2, defaultRecipient) - recipientCurrency2BeforeMint, deposited2, _ROUNDTRIP_TOLERANCE
-        );
+        assertApproxEqAbs(_balanceOf(currency2, admin2) - admin2Currency2BeforeMint, deposited2, _ROUNDTRIP_TOLERANCE);
     }
 
-    /// @dev Case 3c: LP and defaultRecipient delisted on currency2 → pa0 → LP, pa2 → 6909 claim to defaultRecipient.
-    function test_unwindPosition_two_pas_different_admins_credits_6909_when_lp_and_default_blocked_on_pa2(
+    /// @dev Case 3c: LP and admin2 delisted on currency2 → pa0 → LP, pa2 → 6909 claim to admin2.
+    function test_unwindPosition_two_pas_different_admins_credits_6909_when_lp_and_admin2_blocked(
         address admin1,
-        address admin2,
-        address defaultRecipient
+        address admin2
     ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+        _setupUnwindPositionTests(admin1, admin2);
 
         uint256 aliceCurrency0BeforeMint = _balanceOf(currency0, alice);
         uint256 aliceCurrency2BeforeMint = _balanceOf(currency2, alice);
@@ -1836,43 +1811,62 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 deposited2 = aliceCurrency2BeforeMint - _balanceOf(currency2, alice);
 
         MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(alice, false);
-        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(defaultRecipient, false);
+        MockPermissionedToken(Currency.unwrap(currency2)).setTokenAllowlist(admin2, false);
 
         vm.prank(admin1);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
         assertApproxEqAbs(_balanceOf(currency0, alice), aliceCurrency0BeforeMint, _ROUNDTRIP_TOLERANCE);
-        assertApproxEqAbs(manager.balanceOf(defaultRecipient, key2.currency1.toId()), deposited2, _ROUNDTRIP_TOLERANCE);
+        assertApproxEqAbs(manager.balanceOf(admin2, key2.currency1.toId()), deposited2, _ROUNDTRIP_TOLERANCE);
+    }
+
+    /// @dev Non-PA edge case: regular ERC-20 transfer to LP reverts (e.g., LP is blocklisted by the token).
+    ///      Cascade falls back to minting a 6909 claim to LP — not to any admin.
+    function test_unwindPosition_non_pa_credits_6909_to_lp_when_lp_rejects(address admin1, address admin2) public {
+        _setupUnwindPositionTests(admin1, admin2);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0); // [pa0, regular]
+
+        uint256 aliceRegularPostMint = _balanceOf(key0.currency1, alice);
+
+        // Force the regular ERC-20's transfer to alice to revert (simulating a blocklist or compliance hook)
+        vm.mockCallRevert(
+            Currency.unwrap(key0.currency1),
+            abi.encodeWithSelector(IERC20.transfer.selector, alice),
+            bytes("LP rejects")
+        );
+
+        vm.prank(admin1);
+        _unwind(tokenId);
+
+        // alice's regular balance unchanged (transfer was rejected) but she received a 6909 claim instead
+        assertEq(_balanceOf(key0.currency1, alice), aliceRegularPostMint);
+        assertGt(manager.balanceOf(alice, key0.currency1.toId()), 0);
+        // admin1 has no 6909 claim for the regular currency — admins don't custody non-PA value
+        assertEq(manager.balanceOf(admin1, key0.currency1.toId()), 0);
     }
 
     // ===== Auth / either-admin =====
 
-    function test_unwindPosition_reverts_when_caller_is_not_admin(
-        address admin1,
-        address admin2,
-        address defaultRecipient,
-        address notAdmin
-    ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+    function test_unwindPosition_reverts_when_caller_is_not_admin(address admin1, address admin2, address notAdmin)
+        public
+    {
+        _setupUnwindPositionTests(admin1, admin2);
         vm.assume(notAdmin != admin1 && notAdmin != admin2);
 
         uint256 tokenId = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key2);
 
         vm.prank(notAdmin);
-        (bool ok, bytes memory data) =
-            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, defaultRecipient));
+        (bool ok, bytes memory data) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
         assertEq(ok, false);
         assertEq(bytes4(data), Unauthorized.selector);
     }
 
     /// @dev Either PA admin can call `unwindPosition`. With distinct admins, exercise both.
-    function test_unwindPosition_either_admin_acts_independently(
-        address admin1,
-        address admin2,
-        address defaultRecipient
-    ) public {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+    function test_unwindPosition_either_admin_acts_independently(address admin1, address admin2) public {
+        _setupUnwindPositionTests(admin1, admin2);
         vm.assume(admin1 != admin2);
 
         uint256 tokenId0 = lpm.nextTokenId();
@@ -1881,30 +1875,29 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _test_permissioned_mint_allowed_user(key2);
 
         vm.prank(admin1);
-        _unwind(tokenId0, defaultRecipient);
+        _unwind(tokenId0);
         vm.expectRevert();
         IERC721(address(lpm)).ownerOf(tokenId0);
 
         vm.prank(admin2);
-        _unwind(tokenId1, defaultRecipient);
+        _unwind(tokenId1);
         vm.expectRevert();
         IERC721(address(lpm)).ownerOf(tokenId1);
     }
 
     // ===== withdrawClaim =====
 
-    /// @dev Forces the cascade to the 6909 fallback, then redeems via `withdrawClaim` to a fresh `to`.
-    function test_withdrawClaim_round_trip(address admin1, address admin2, address defaultRecipient, address to)
-        public
-    {
-        _setupUnwindPositionTests(admin1, admin2, defaultRecipient);
+    /// @dev Forces the cascade to the 6909 fallback (LP and admin1 both delisted on currency0), then redeems
+    ///      the admin1-held claim via `withdrawClaim` to a fresh `to`.
+    function test_withdrawClaim_round_trip(address admin1, address admin2, address to) public {
+        _setupUnwindPositionTests(admin1, admin2);
         // `to` must be distinct from existing actors and from action-handler sentinels (MSG_SENDER = 0x1 /
         // ADDRESS_THIS = 0x2 would get remapped by _mapRecipient inside the TAKE action)
         vm.assume(to != address(0));
         vm.assume(to != ActionConstants.MSG_SENDER);
         vm.assume(to != ActionConstants.ADDRESS_THIS);
         vm.assume(to != alice);
-        vm.assume(to != defaultRecipient);
+        vm.assume(to != admin1);
         vm.assume(to != address(manager));
         vm.assume(to != address(lpm));
         vm.assume(to != address(permissionsAdapter0));
@@ -1914,29 +1907,29 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _test_permissioned_mint_allowed_user(key0);
 
         MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
-        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(defaultRecipient, false);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(admin1, false);
 
         vm.prank(admin1);
-        _unwind(tokenId, defaultRecipient);
+        _unwind(tokenId);
 
-        uint256 claim = manager.balanceOf(defaultRecipient, key0.currency0.toId());
+        uint256 claim = manager.balanceOf(admin1, key0.currency0.toId());
         assertGt(claim, 0);
 
         // `to` needs to be on the underlying compliance list to receive the secToken on unwrap
         MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(to, PermissionFlags.ALL_ALLOWED);
 
-        // defaultRecipient authorizes permPosm to burn its 6909 claims
-        vm.prank(defaultRecipient);
+        // admin1 authorizes permPosm to burn its 6909 claims
+        vm.prank(admin1);
         manager.setOperator(address(lpm), true);
 
         uint256 toBefore = _balanceOf(currency0, to);
         vm.expectEmit(true, true, true, true);
-        emit ClaimWithdrawn(key0.currency0, defaultRecipient, to, claim);
-        vm.prank(defaultRecipient);
+        emit ClaimWithdrawn(key0.currency0, admin1, to, claim);
+        vm.prank(admin1);
         _withdrawClaim(key0.currency0, claim, to);
 
         // claim fully consumed; to received exactly `claim` of the underlying
-        assertEq(manager.balanceOf(defaultRecipient, key0.currency0.toId()), 0);
+        assertEq(manager.balanceOf(admin1, key0.currency0.toId()), 0);
         assertEq(_balanceOf(currency0, to) - toBefore, claim);
     }
 

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1624,7 +1624,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 indexed tokenId,
         Currency indexed currency,
         address indexed recipient,
-        address admin,
+        address caller,
         address lp,
         uint256 amount,
         bool asClaim
@@ -1665,6 +1665,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
     // ===== Case 1: both currencies are PAs owned by the same admin (admin1 == admin2) =====
 
+    /// @dev Case 1: same admin owns both PAs, LP compliant on both → both legs cascade to LP.
     function test_unwindPosition_two_pas_same_admin_routes_both_to_lp(address admin) public {
         _setupUnwindPositionTests(admin, admin);
 
@@ -1678,8 +1679,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 deposited0 = aliceCurrency0BeforeMint - _balanceOf(currency0, alice);
         uint256 deposited2 = aliceCurrency2BeforeMint - _balanceOf(currency2, alice);
 
-        // Full-data check on both events. Notably verifies `caller == admin` (i.e., msgSender() returns the
-        // original unwindPosition caller, not the PoolManager). _ROUNDTRIP_TOLERANCE absorbed via deposited - 1.
+        // Full-data check verifies caller == admin (msgSender() returns the unwindPosition caller, not PoolManager).
         vm.expectEmit(true, true, true, true);
         emit CurrencyUnwound(tokenId, key2.currency0, alice, admin, alice, deposited0 - 1, false);
         vm.expectEmit(true, true, true, true);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1620,7 +1620,15 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     bytes4 private constant _UNWIND_SELECTOR = 0x37058749;
     bytes4 private constant _WITHDRAW_CLAIM_SELECTOR = 0xf77de3fc;
 
-    event PositionUnwound(uint256 indexed tokenId, address indexed lp, address indexed admin);
+    event CurrencyUnwound(
+        uint256 indexed tokenId,
+        Currency indexed currency,
+        address indexed recipient,
+        address admin,
+        address lp,
+        uint256 amount,
+        bool asClaim
+    );
     event ClaimWithdrawn(Currency indexed currency, address indexed from, address indexed to, uint256 amount);
 
     function _balanceOf(Currency c, address who) internal view returns (uint256) {
@@ -1666,8 +1674,16 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         uint256 tokenId = lpm.nextTokenId();
         _test_permissioned_mint_allowed_user(key2);
 
+        // capture the exact deposit amounts so we can do a full-data event check
+        uint256 deposited0 = aliceCurrency0BeforeMint - _balanceOf(currency0, alice);
+        uint256 deposited2 = aliceCurrency2BeforeMint - _balanceOf(currency2, alice);
+
+        // Full-data check on both events. Notably verifies `caller == admin` (i.e., msgSender() returns the
+        // original unwindPosition caller, not the PoolManager). _ROUNDTRIP_TOLERANCE absorbed via deposited - 1.
         vm.expectEmit(true, true, true, true);
-        emit PositionUnwound(tokenId, alice, admin);
+        emit CurrencyUnwound(tokenId, key2.currency0, alice, admin, alice, deposited0 - 1, false);
+        vm.expectEmit(true, true, true, true);
+        emit CurrencyUnwound(tokenId, key2.currency1, alice, admin, alice, deposited2 - 1, false);
         vm.prank(admin);
         _unwind(tokenId);
 
@@ -1716,6 +1732,11 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
         MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(admin1, true);
 
+        // pa0 leg lands at admin1 as underlying; regular leg lands at alice as underlying
+        vm.expectEmit(true, true, true, false);
+        emit CurrencyUnwound(tokenId, key0.currency0, admin1, address(0), address(0), 0, false);
+        vm.expectEmit(true, true, true, false);
+        emit CurrencyUnwound(tokenId, key0.currency1, alice, address(0), address(0), 0, false);
         vm.prank(admin1);
         _unwind(tokenId);
 
@@ -1741,6 +1762,11 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
         MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(admin1, false);
 
+        // pa0 leg lands at admin1 as 6909 (asClaim=true); regular leg lands at alice as underlying
+        vm.expectEmit(true, true, true, false);
+        emit CurrencyUnwound(tokenId, key0.currency0, admin1, address(0), address(0), 0, true);
+        vm.expectEmit(true, true, true, false);
+        emit CurrencyUnwound(tokenId, key0.currency1, alice, address(0), address(0), 0, false);
         vm.prank(admin1);
         _unwind(tokenId);
 
@@ -1837,6 +1863,11 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             bytes("LP rejects")
         );
 
+        // pa0 leg lands at alice as underlying; regular leg falls back to 6909 mint to alice (asClaim=true)
+        vm.expectEmit(true, true, true, false);
+        emit CurrencyUnwound(tokenId, key0.currency0, alice, address(0), address(0), 0, false);
+        vm.expectEmit(true, true, true, false);
+        emit CurrencyUnwound(tokenId, key0.currency1, alice, address(0), address(0), 0, true);
         vm.prank(admin1);
         _unwind(tokenId);
 


### PR DESCRIPTION
## Related Issue
- [ECO-173](https://linear.app/uniswap/issue/ECO-221/sc-l-10-unilateral-admin-transfer-authority-in)

## Description of changes
- Reverting https://github.com/Uniswap/v4-periphery/pull/532
- Removing all transferability of PermissionedPositionManager positions
- Introducing `unwindPosition` + `withdrawClaim` functions

## Tests
Unwinding Tests:
| # | Test | Spec | What it verifies |                                                                                                                                                                                                         
  |---|---|---|---|                      
  | 1 | `test_unwindPosition_two_pas_same_admin_routes_both_to_lp(admin, defaultRecipient)` | Same admin owns both PAs, happy path | Helper called with `(admin, admin, defaultRecipient)` so both PAs end up owned by one address. LP compliant on both underlyings (default setUp), so cascade lands at step 1 for both → asserted via "alice ≈ whole on currency0 and currency2." Also checks `PositionUnwound(tokenId, alice, admin, defaultRecipient)` emission. |                         
  | 2a | `test_unwindPosition_pa_and_regular_routes_both_to_lp_when_compliant(admin1, admin2, defaultRecipient)` | PA + regular, LP compliant | key0 = `[pa0, regular]`. LP on currency0 allowlist (default). Cascade hits step 1 for both legs. Asserts alice is whole on currency0 + key0.currency1. |                                                                                                                                                                                        
  | 2b | `test_unwindPosition_pa_and_regular_routes_pa_to_default_when_lp_blocked(admin1, admin2, defaultRecipient)` | PA + regular, LP blocked, goes to defaultRecipient | LP delisted on currency0; defaultRecipient force-allowlisted. Captures `deposited0` at mint. After unwind: defaultRecipient delta on currency0 ≈ `deposited0` (step 2). Regular currency goes to alice (step 1, no compliance gate). |                                                                       
  | 2c | `test_unwindPosition_pa_and_regular_credits_6909_when_lp_and_default_blocked(admin1, admin2, defaultRecipient)` | PA + regular, both blocked, 6909 to defaultRecipient | LP and defaultRecipient both delisted on currency0. Asserts `manager.balanceOf(defaultRecipient, currency0.toId()) ≈ deposited0` (step 3). Regular still goes to alice. |                                                                                                                                  
  | 3a | `test_unwindPosition_two_pas_different_admins_routes_both_to_lp(admin1, admin2, defaultRecipient)` | Two PAs, different admins, both compliant | Helper splits ownership (pa0→admin1, pa2→admin2). admin1 calls. Both legs hit step 1. Asserts alice whole on both. |                                                                                                                                                                                                                 
  | 3b | `test_unwindPosition_two_pas_different_admins_routes_pa1_to_default_when_lp_blocked(admin1, admin2, defaultRecipient)` | admin1 calls; pa0 happy, pa2 → defaultRecipient | LP delisted on currency2; defaultRecipient force-allowlisted on currency2. pa0 leg: step 1 (alice). pa2 leg: step 2 (defaultRecipient). |                                                                                                                                                                   
  | 3c | `test_unwindPosition_two_pas_different_admins_credits_6909_when_lp_and_default_blocked_on_pa1(admin1, admin2, defaultRecipient)` | admin1 calls; pa0 happy, pa2 → 6909 | LP and defaultRecipient both delisted on currency2. pa0 leg: step 1. pa2 leg: step 3 (6909 mint to defaultRecipient). |  