### PR TITLE
fix(Permissioned-position-manager): unsubscribing on unwind

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -91,12 +91,16 @@ contract PermissionedPositionManager is PositionManager {
         getApproved[tokenId] = msg.sender;
 
         bytes memory actions = abi.encodePacked(
-            uint8(Actions.BURN_POSITION), uint8(Actions.UNWIND_WITH_FALLBACK), uint8(Actions.UNWIND_WITH_FALLBACK)
+            uint8(Actions.UNSUBSCRIBE),
+            uint8(Actions.BURN_POSITION),
+            uint8(Actions.UNWIND_WITH_FALLBACK),
+            uint8(Actions.UNWIND_WITH_FALLBACK)
         );
-        bytes[] memory params = new bytes[](3);
-        params[0] = abi.encode(tokenId, uint128(0), uint128(0), bytes(""));
-        params[1] = abi.encode(poolKey.currency0, lp, tokenId);
-        params[2] = abi.encode(poolKey.currency1, lp, tokenId);
+        bytes[] memory params = new bytes[](4);
+        params[0] = abi.encode(tokenId);
+        params[1] = abi.encode(tokenId, uint128(0), uint128(0), bytes(""));
+        params[2] = abi.encode(poolKey.currency0, lp, tokenId);
+        params[3] = abi.encode(poolKey.currency1, lp, tokenId);
         poolManager.unlock(abi.encode(actions, params));
     }
 
@@ -264,6 +268,11 @@ contract PermissionedPositionManager is PositionManager {
         if (action == Actions.UNWIND_WITH_FALLBACK) {
             (Currency currency, address lp, uint256 tokenId) = abi.decode(params, (Currency, address, uint256));
             _unwindWithFallback(currency, lp, tokenId);
+            return;
+        }
+        if (action == Actions.UNSUBSCRIBE) {
+            uint256 tokenId = abi.decode(params, (uint256));
+            if (positionInfo[tokenId].hasSubscriber()) _unsubscribe(tokenId);
             return;
         }
         if (action == Actions.BURN_6909) {

--- a/src/libraries/Actions.sol
+++ b/src/libraries/Actions.sol
@@ -50,4 +50,6 @@ library Actions {
     // permissioned-pools specific actions
     // routes a currency's positive delta with a fallback cascade: LP → defaultRecipient → 6909 mint to defaultRecipient
     uint256 internal constant UNWIND_WITH_FALLBACK = 0x19;
+    // detaches a position's subscriber via the gas-capped + revert-swallowed unsubscribe path
+    uint256 internal constant UNSUBSCRIBE = 0x1a;
 }

--- a/src/libraries/Actions.sol
+++ b/src/libraries/Actions.sol
@@ -50,6 +50,7 @@ library Actions {
     // permissioned-pools specific actions
     // routes a currency's positive delta with a fallback cascade: LP → defaultRecipient → 6909 mint to defaultRecipient
     uint256 internal constant UNWIND_WITH_FALLBACK = 0x19;
-    // detaches a position's subscriber via the gas-capped + revert-swallowed unsubscribe path
-    uint256 internal constant UNSUBSCRIBE = 0x1a;
+    // subscribing/unsubscribing via position manager
+    uint256 internal constant SUBSCRIBE = 0x1a;
+    uint256 internal constant UNSUBSCRIBE = 0x1b;
 }

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -33,6 +33,10 @@ import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.so
 import {MockAllowlistChecker, MockPermissionedToken} from "./PermissionedPoolsBase.sol";
 import {PermissionsAdapter, IERC20} from "../../../src/hooks/permissionedPools/PermissionsAdapter.sol";
 import {PermissionFlags, PermissionFlag} from "../../../src/hooks/permissionedPools/libraries/PermissionFlags.sol";
+import {INotifier} from "../../../src/interfaces/INotifier.sol";
+import {MockUnsubscribeRevertingSubscriber} from "../../mocks/MockUnsubscribeRevertingSubscriber.sol";
+import {MockBurnRevertingSubscriber} from "../../mocks/MockBurnRevertingSubscriber.sol";
+import {MockReentrantSubscriber} from "../../mocks/MockReentrantSubscriber.sol";
 
 contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
@@ -2072,5 +2076,79 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
         assertEq(nonPermissioned.balanceOf(recipient) - recipientBefore, amount);
         assertEq(nonPermissioned.balanceOf(address(lpm)), 0);
+    }
+
+    // ===== Subscriber DoS protection on unwindPosition =====
+
+    /// @dev Admin force-exit succeeds even when the LP attached a subscriber that reverts on
+    ///      `notifyUnsubscribe`. The revert is gas-capped + try/catch'd inside `_unsubscribe`.
+    function test_unwindPosition_with_unsubscribe_reverting_subscriber_succeeds() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        MockUnsubscribeRevertingSubscriber sub = new MockUnsubscribeRevertingSubscriber();
+        vm.prank(alice);
+        INotifier(address(lpm)).subscribe(tokenId, address(sub), "");
+        assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(sub));
+
+        // address(this) is admin of both adapters (default setUp)
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
+        assertEq(ok, true);
+
+        // subscriber detached, NFT burned
+        assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(0));
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId);
+    }
+
+    /// @dev Admin force-exit succeeds even when the LP grants operator approval to a malicious
+    ///      reentrant subscriber that tries to re-attach a fresh subscriber during
+    ///      `notifyUnsubscribe`. The re-entry is blocked by `subscribe`'s `onlyIfPoolManagerLocked`
+    ///      modifier (we're inside an active unlock callback when `_unsubscribe` runs).
+    function test_unwindPosition_with_reentrant_subscriber_blocks_reentry() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        // The would-be replacement subscriber. If reentry succeeded, this would be attached
+        // and its `notifyBurn` revert would brick the burn.
+        MockBurnRevertingSubscriber replacement = new MockBurnRevertingSubscriber();
+
+        // The malicious subscriber that the LP attaches. On notifyUnsubscribe it tries to
+        // re-attach `replacement` via posm.subscribe.
+        MockReentrantSubscriber sub = new MockReentrantSubscriber(INotifier(address(lpm)), address(replacement));
+
+        vm.prank(alice);
+        INotifier(address(lpm)).subscribe(tokenId, address(sub), "");
+        assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(sub));
+
+        // The reentry path requires the subscriber to be authorized to call posm.subscribe.
+        // LP grants operator approval — this is the setup we're testing the defense against.
+        vm.prank(alice);
+        IERC721(address(lpm)).setApprovalForAll(address(sub), true);
+
+        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
+        assertEq(ok, true);
+
+        // Subscriber fully detached — no re-attach happened, despite the reentry attempt.
+        assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(0));
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId);
+    }
+
+    /// @dev LP-initiated burn semantics are preserved: a subscriber that reverts on `notifyBurn`
+    ///      still propagates the revert when the LP burns their own position via BURN_POSITION.
+    function test_burn_lp_with_burn_reverting_subscriber_still_reverts() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        MockBurnRevertingSubscriber sub = new MockBurnRevertingSubscriber();
+        vm.prank(alice);
+        INotifier(address(lpm)).subscribe(tokenId, address(sub), "");
+
+        PositionConfig memory config = PositionConfig({poolKey: key2, tickLower: -120, tickUpper: 120});
+
+        vm.prank(alice);
+        vm.expectRevert();
+        burn(tokenId, config, ZERO_BYTES);
     }
 }

--- a/test/mocks/MockBurnRevertingSubscriber.sol
+++ b/test/mocks/MockBurnRevertingSubscriber.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+
+/// @notice Subscriber that reverts only on `notifyBurn`. Used to verify that LP-initiated
+///         burns still propagate the revert (base behavior is preserved).
+contract MockBurnRevertingSubscriber is ISubscriber {
+    error TestRevert(string);
+
+    function notifySubscribe(uint256, bytes memory) external pure {}
+
+    function notifyUnsubscribe(uint256) external pure {}
+
+    function notifyModifyLiquidity(uint256, int256, BalanceDelta) external pure {}
+
+    function notifyBurn(uint256, address, PositionInfo, uint256, BalanceDelta) external pure {
+        revert TestRevert("notifyBurn");
+    }
+}

--- a/test/mocks/MockReentrantSubscriber.sol
+++ b/test/mocks/MockReentrantSubscriber.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {INotifier} from "../../src/interfaces/INotifier.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+
+/// @notice On `notifyUnsubscribe`, attempts to re-attach a fresh subscriber via
+///         `posm.subscribe(...)`. Used to verify that the re-entry is blocked by the
+///         existing `onlyIfPoolManagerLocked` guard on `subscribe` when `unsubscribe`
+///         runs from inside an unlock callback.
+contract MockReentrantSubscriber is ISubscriber {
+    INotifier public immutable posm;
+    address public immutable reentrantTarget;
+
+    constructor(INotifier _posm, address _reentrantTarget) {
+        posm = _posm;
+        reentrantTarget = _reentrantTarget;
+    }
+
+    function notifySubscribe(uint256, bytes memory) external pure {}
+
+    function notifyUnsubscribe(uint256 tokenId) external {
+        // Should revert with PoolManagerMustBeLocked when called from inside an active
+        // unlock callback — that's the protection we're testing.
+        posm.subscribe(tokenId, reentrantTarget, "");
+    }
+
+    function notifyModifyLiquidity(uint256, int256, BalanceDelta) external pure {}
+
+    function notifyBurn(uint256, address, PositionInfo, uint256, BalanceDelta) external pure {}
+}

--- a/test/mocks/MockUnsubscribeRevertingSubscriber.sol
+++ b/test/mocks/MockUnsubscribeRevertingSubscriber.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+
+/// @notice Subscriber that reverts only on `notifyUnsubscribe`. Used to verify that
+///         admin force-exit (`unwindPosition`) swallows the revert via the existing
+///         gas-capped + try/catch path on `_unsubscribe`.
+contract MockUnsubscribeRevertingSubscriber is ISubscriber {
+    error TestRevert(string);
+
+    function notifySubscribe(uint256, bytes memory) external pure {}
+
+    function notifyUnsubscribe(uint256) external pure {
+        revert TestRevert("notifyUnsubscribe");
+    }
+
+    function notifyModifyLiquidity(uint256, int256, BalanceDelta) external pure {}
+
+    function notifyBurn(uint256, address, PositionInfo, uint256, BalanceDelta) external pure {}
+}


### PR DESCRIPTION
## Related Issue
[ECO-371](https://linear.app/uniswap/issue/ECO-371/fixing-subscribe-griefing-in-unwindposition)

## Description of changes
- Auto-unsubscribes during `unwindPosition()` flows to prevent reverting subscriptions from blocking unwinds.