### PR TITLE
refactor(PositionManager): rename ModifyLiquidity event to ModifyPosition

### DIFF
--- a/snapshots/PosMGasTest.json
+++ b/snapshots/PosMGasTest.json
@@ -34,10 +34,10 @@
   "PositionManager_mint_withSettlePair": "423838",
   "PositionManager_multicall_initialize_mint": "461136",
   "PositionManager_permit": "79175",
-  "PositionManager_permit_secondPosition": "62063",
+  "PositionManager_permit_secondPosition": "62075",
   "PositionManager_permit_twice": "44963",
   "PositionManager_subscribe": "87968",
   "PositionManager_unsubscribe": "62697",
-  "position manager initcode hash (without constructor params, as uint256)": "67582943578862820501218462243067479340757004968368407905126233562933492108999",
+  "position manager initcode hash (without constructor params, as uint256)": "39950173930130160046527526152179940231178202021933001972999459034999301007875",
   "positionManager bytecode size": "24172"
 }

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -432,7 +432,7 @@ contract PositionManager is
                 salt: bytes32(tokenId)
             });
             (liquidityDelta, feesAccrued) = poolManager.modifyLiquidity(poolKey, params, hookData);
-            emit ModifyLiquidity(
+            emit ModifyPosition(
                 poolKey.toId(), msgSender(), params.tickLower, params.tickUpper, params.liquidityDelta, params.salt
             );
             // Slippage checks should be done on the principal liquidityDelta which is the liquidityDelta - feesAccrued
@@ -507,7 +507,7 @@ contract PositionManager is
             hookData
         );
 
-        emit ModifyLiquidity(poolKey.toId(), msgSender(), info.tickLower(), info.tickUpper(), liquidityChange, salt);
+        emit ModifyPosition(poolKey.toId(), msgSender(), info.tickLower(), info.tickUpper(), liquidityChange, salt);
 
         if (info.hasSubscriber()) {
             _notifyModifyLiquidity(uint256(salt), liquidityChange, feesAccrued);

--- a/src/interfaces/IPositionManager.sol
+++ b/src/interfaces/IPositionManager.sol
@@ -26,8 +26,9 @@ interface IPositionManager is
     IUnorderedNonce,
     IPermit2Forwarder
 {
-    /// @notice Emitted by the position manager for each modifyLiquidity call, mirroring PoolManager ModifyLiquidity except `sender` is the unlock locker (end user), not the position manager
-    event ModifyLiquidity(
+    /// @notice Emitted by the position manager for each modifyLiquidity call, mirroring PoolManager
+    ///         ModifyLiquidity except `sender` is the unlock locker (end user), not the position manager.
+    event ModifyPosition(
         PoolId indexed id, address indexed sender, int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt
     );
 

--- a/test/position-managers/PositionManager.t.sol
+++ b/test/position-managers/PositionManager.t.sol
@@ -978,22 +978,22 @@ contract PositionManagerTest is Test, PosmTestSetup, LiquidityFuzzers {
     function test_mint_slippageRevert() public {}
 
     /*//////////////////////////////////////////////////////////////
-                       MODIFY LIQUIDITY EVENT TESTS
+                       MODIFY POSITION EVENT TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function test_mint_emitsModifyLiquidityEvent() public {
+    function test_mint_emitsModifyPositionEvent() public {
         PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
         uint256 liquidity = 1e18;
         uint256 tokenId = lpm.nextTokenId();
 
         vm.expectEmit(true, true, true, true, address(lpm));
-        emit IPositionManager.ModifyLiquidity(
+        emit IPositionManager.ModifyPosition(
             key.toId(), address(this), config.tickLower, config.tickUpper, int256(liquidity), bytes32(tokenId)
         );
         mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
     }
 
-    function test_increase_emitsModifyLiquidityEvent() public {
+    function test_increase_emitsModifyPositionEvent() public {
         PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
         uint256 tokenId = lpm.nextTokenId();
         mint(config, 1e18, ActionConstants.MSG_SENDER, ZERO_BYTES);
@@ -1001,13 +1001,13 @@ contract PositionManagerTest is Test, PosmTestSetup, LiquidityFuzzers {
         uint256 liquidityToAdd = 1e18;
 
         vm.expectEmit(true, true, true, true, address(lpm));
-        emit IPositionManager.ModifyLiquidity(
+        emit IPositionManager.ModifyPosition(
             key.toId(), address(this), config.tickLower, config.tickUpper, int256(liquidityToAdd), bytes32(tokenId)
         );
         increaseLiquidity(tokenId, config, liquidityToAdd, ZERO_BYTES);
     }
 
-    function test_decrease_emitsModifyLiquidityEvent() public {
+    function test_decrease_emitsModifyPositionEvent() public {
         PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
         uint256 tokenId = lpm.nextTokenId();
         mint(config, 1e18, ActionConstants.MSG_SENDER, ZERO_BYTES);
@@ -1015,78 +1015,78 @@ contract PositionManagerTest is Test, PosmTestSetup, LiquidityFuzzers {
         uint256 liquidityToRemove = 1e18;
 
         vm.expectEmit(true, true, true, true, address(lpm));
-        emit IPositionManager.ModifyLiquidity(
+        emit IPositionManager.ModifyPosition(
             key.toId(), address(this), config.tickLower, config.tickUpper, -int256(liquidityToRemove), bytes32(tokenId)
         );
         decreaseLiquidity(tokenId, config, liquidityToRemove, ZERO_BYTES);
     }
 
-    function test_burn_emitsModifyLiquidityEvent() public {
+    function test_burn_emitsModifyPositionEvent() public {
         PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
         uint256 liquidity = 1e18;
         uint256 tokenId = lpm.nextTokenId();
         mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
 
         vm.expectEmit(true, true, true, true, address(lpm));
-        emit IPositionManager.ModifyLiquidity(
+        emit IPositionManager.ModifyPosition(
             key.toId(), address(this), config.tickLower, config.tickUpper, -int256(liquidity), bytes32(tokenId)
         );
         burn(tokenId, config, ZERO_BYTES);
     }
 
     /// @dev Guards against a future refactor that might route mint through `_modifyLiquidity` (or vice versa) and cause
-    /// a duplicate `ModifyLiquidity` emission. Each lifecycle action must emit exactly one event from `address(lpm)`.
-    function test_modifyLiquidityEvent_emitsOncePerAction() public {
+    /// a duplicate `ModifyPosition` emission. Each lifecycle action must emit exactly one event from `address(lpm)`.
+    function test_modifyPositionEvent_emitsOncePerAction() public {
         PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
         uint256 liquidity = 1e18;
         uint256 tokenId = lpm.nextTokenId();
 
-        assertEq(_countModifyLiquidityEventsDuring_mint(config, liquidity), 1, "mint should emit once");
-        assertEq(_countModifyLiquidityEventsDuring_increase(tokenId, config, liquidity), 1, "increase should emit once");
-        assertEq(_countModifyLiquidityEventsDuring_decrease(tokenId, config, liquidity), 1, "decrease should emit once");
-        assertEq(_countModifyLiquidityEventsDuring_burn(tokenId, config), 1, "burn should emit once");
+        assertEq(_countModifyPositionEventsDuring_mint(config, liquidity), 1, "mint should emit once");
+        assertEq(_countModifyPositionEventsDuring_increase(tokenId, config, liquidity), 1, "increase should emit once");
+        assertEq(_countModifyPositionEventsDuring_decrease(tokenId, config, liquidity), 1, "decrease should emit once");
+        assertEq(_countModifyPositionEventsDuring_burn(tokenId, config), 1, "burn should emit once");
     }
 
-    function _countModifyLiquidityEventsDuring_mint(PositionConfig memory config, uint256 liquidity)
+    function _countModifyPositionEventsDuring_mint(PositionConfig memory config, uint256 liquidity)
         private
         returns (uint256)
     {
         vm.recordLogs();
         mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
-        return _countModifyLiquidityEvents(vm.getRecordedLogs());
+        return _countModifyPositionEvents(vm.getRecordedLogs());
     }
 
-    function _countModifyLiquidityEventsDuring_increase(
+    function _countModifyPositionEventsDuring_increase(
         uint256 tokenId,
         PositionConfig memory config,
         uint256 liquidity
     ) private returns (uint256) {
         vm.recordLogs();
         increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
-        return _countModifyLiquidityEvents(vm.getRecordedLogs());
+        return _countModifyPositionEvents(vm.getRecordedLogs());
     }
 
-    function _countModifyLiquidityEventsDuring_decrease(
+    function _countModifyPositionEventsDuring_decrease(
         uint256 tokenId,
         PositionConfig memory config,
         uint256 liquidity
     ) private returns (uint256) {
         vm.recordLogs();
         decreaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
-        return _countModifyLiquidityEvents(vm.getRecordedLogs());
+        return _countModifyPositionEvents(vm.getRecordedLogs());
     }
 
-    function _countModifyLiquidityEventsDuring_burn(uint256 tokenId, PositionConfig memory config)
+    function _countModifyPositionEventsDuring_burn(uint256 tokenId, PositionConfig memory config)
         private
         returns (uint256)
     {
         vm.recordLogs();
         burn(tokenId, config, ZERO_BYTES);
-        return _countModifyLiquidityEvents(vm.getRecordedLogs());
+        return _countModifyPositionEvents(vm.getRecordedLogs());
     }
 
-    function _countModifyLiquidityEvents(VmSafe.Log[] memory logs) private view returns (uint256 count) {
-        bytes32 topic = IPositionManager.ModifyLiquidity.selector;
+    function _countModifyPositionEvents(VmSafe.Log[] memory logs) private view returns (uint256 count) {
+        bytes32 topic = IPositionManager.ModifyPosition.selector;
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == topic && logs[i].emitter == address(lpm)) count++;
         }


### PR DESCRIPTION
## Summary

PR #528 added an `event ModifyLiquidity(PoolId, address, int24, int24, int256, bytes32)` to `IPositionManager` with the same parameter types as PoolManager's `ModifyLiquidity` event. Any downstream contract that inherits from both — e.g. [universal-router's `ImportsForTypechain.sol`](https://github.com/Uniswap/universal-router/blob/5a5336a2aa69faea5407ad610feabed6d5a1c4fa/contracts/test/ImportsForTypechain.sol#L11) shim that pulls both into the hardhat build for typechain artifact generation — now fails with:

```
DeclarationError: Event with same name and parameter types defined twice.
  --> v4-core/src/interfaces/IPoolManager.sol:78
  --> v4-periphery/src/interfaces/IPositionManager.sol:30
```

This blocks anyone bumping their v4-periphery dependency past PR #528.

## Fix

Rename the periphery event to `ModifyPosition` so downstream consumers don't have to work around the collision. Same parameters, same emit sites, same semantics — `sender` is still the end user (not the position manager).

## Test plan

- [x] All 672 tests pass under `FOUNDRY_PROFILE=ci FORGE_SNAPSHOT_CHECK=true forge test --isolate` (forge v1.3.6, matching CI)
- [x] Renamed-event tests verify emission from `address(lpm)` for mint / increase / decrease / burn, plus the once-per-action guard
- [x] Verified universal-router compiles past the previous `ModifyLiquidity` collision when this v4-periphery is dropped into its `lib/v4-periphery` submodule
- [x] Gas snapshot regenerated; only `permit_secondPosition` (+12 gas, bytecode layout drift) and `posm initcode hash` (event topic embedded in bytecode) changed — both expected from a pure rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)