### PR TITLE
fix(permissioned-pools): use OZ ERC165Checker for IAllowlistCheck validation

### DIFF
--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "240524"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "241550"
 }

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -5,6 +5,7 @@ import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {ERC20 as SafeERC20} from "solmate/src/tokens/ERC20.sol";
 import {SafeTransferLib} from "solmate/src/utils/SafeTransferLib.sol";
 import {IPermissionsAdapter} from "./interfaces/IPermissionsAdapter.sol";
@@ -75,7 +76,7 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
     }
 
     function _updateAllowListChecker(IAllowlistChecker newAllowListChecker) internal {
-        if (!newAllowListChecker.supportsInterface(type(IAllowlistChecker).interfaceId)) {
+        if (!ERC165Checker.supportsInterface(address(newAllowListChecker), type(IAllowlistChecker).interfaceId)) {
             revert InvalidAllowListChecker(newAllowListChecker);
         }
         allowListChecker = newAllowListChecker;

--- a/test/hooks/permissionedPools/PermissionsAdapter.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapter.t.sol
@@ -106,6 +106,16 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         permissionsAdapter.updateAllowListChecker(newAllowListCheckerContract);
     }
 
+    /// @dev ERC-165 compliant contracts must return `false` for `0xffffffff`. A checker that returns
+    ///      `true` for any interfaceId would bypass a direct `supportsInterface` check. The new
+    ///      `ERC165Checker.supportsInterface` pre-check catches this.
+    function testRevert_WhenBypassFakeSupportsInterface() public {
+        IAllowlistChecker bypassChecker = new BypassAllowlistChecker();
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IPermissionsAdapter.InvalidAllowListChecker.selector, bypassChecker));
+        permissionsAdapter.updateAllowListChecker(bypassChecker);
+    }
+
     function test_UpdateAllowListChecker() public {
         IAllowlistChecker newAllowListChecker = new MockAllowlistChecker();
         vm.prank(owner);
@@ -376,5 +386,17 @@ contract ImproperAllowlistChecker is IAllowlistChecker {
 
     function supportsInterface(bytes4) external pure returns (bool) {
         return false;
+    }
+}
+
+/// @dev Returns `true` for every interfaceId, including `0xffffffff`. Defeats a naive direct
+///      `supportsInterface` check; rejected by ERC-165's required pre-checks.
+contract BypassAllowlistChecker is IAllowlistChecker {
+    function checkAllowlist(address, address) public pure returns (PermissionFlag) {
+        return PermissionFlags.ALL_ALLOWED;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
     }
 }


### PR DESCRIPTION
## Related Issue
- [ECO-352](https://linear.app/uniswap/issue/ECO-352)

## Description of changes
- `PermissionsAdapter._updateAllowListChecker` was calling `newAllowListChecker.supportsInterface(...)` directly. Per ERC-165, callers must first verify the contract returns `true` for `0x01ffc9a7` and `false` for `0xffffffff` before trusting any interface-id response — otherwise a contract returning `true` for every `bytes4` argument can bypass the check.
- Switched to `ERC165Checker.supportsInterface(address, interfaceId)` from OpenZeppelin, which performs both pre-checks.
- Added unit tests confirming behavior with BypassAllowlistChecker contract