### PR TITLE
fix(permissioned-position-manager): reject mints without verified-adapters

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -40,6 +40,7 @@ contract PermissionedPositionManager is PositionManager {
     error InvalidHook();
     error TransferDisabled();
     error NotPermissionsAdapterAdmin();
+    error NoVerifiedAdapter();
 
     /// @dev as this contract must know the hooks address in advance, it must be passed in as a constructor argument
     constructor(
@@ -137,6 +138,9 @@ contract PermissionedPositionManager is PositionManager {
     }
 
     /// @dev When minting a position, verify that the sender is allowed to mint the position. This prevents a disallowed user from minting one sided liquidity.
+    ///      Also rejects pools where neither side is a verified permissions adapter — those positions provide no
+    ///      permissioning value over the base PositionManager and would otherwise be permanently non-transferable
+    ///      (see `transferFrom`), so the manager refuses to mint them.
     function _mint(
         PoolKey calldata poolKey,
         int24 tickLower,
@@ -147,6 +151,11 @@ contract PermissionedPositionManager is PositionManager {
         address owner,
         bytes calldata hookData
     ) internal override {
+        // require at least one currency to be a verified permissions adapter
+        if (
+            _verifiedPermissionedTokenOf(poolKey.currency0) == address(0)
+                && _verifiedPermissionedTokenOf(poolKey.currency1) == address(0)
+        ) revert NoVerifiedAdapter();
         // allowlist is verified in the hook call
         if (!_checkAllowedHooks(poolKey)) revert InvalidHook();
         _checkRecipientAllowed(poolKey.currency0, owner);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -721,6 +721,38 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         vm.stopPrank();
     }
 
+    /// @dev A pool with no verified permissions adapter on either side has nothing for the
+    ///      PermissionedPositionManager to enforce; minting such a position would only produce
+    ///      a non-transferable NFT (see ECO-221 / `transferFrom`). Reject the mint outright.
+    function test_mint_reverts_when_no_verified_adapter() public {
+        // Two ordinary ERC-20s — neither is a verified permissions adapter.
+        Currency ordinary0 = deployMintAndApproveCurrency(false);
+        Currency ordinary1 = deployMintAndApproveCurrency(false);
+        if (Currency.unwrap(ordinary1) < Currency.unwrap(ordinary0)) {
+            (ordinary0, ordinary1) = (ordinary1, ordinary0);
+        }
+        approvePosmCurrency(ordinary0);
+        approvePosmCurrency(ordinary1);
+
+        // Initialize directly on the PoolManager with no hooks so initialization isn't gated.
+        PoolKey memory ordinaryKey = PoolKey({
+            currency0: ordinary0,
+            currency1: ordinary1,
+            fee: 3000,
+            tickSpacing: 60,
+            hooks: IHooks(address(0))
+        });
+        manager.initialize(ordinaryKey, SQRT_PRICE_1_1);
+
+        PositionConfig memory config = PositionConfig({poolKey: ordinaryKey, tickLower: -120, tickUpper: 120});
+        bytes memory calls = getMintEncoded(config, 1e18, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        // Use the literal selector to avoid pulling in PermissionedPositionManager imports here.
+        // bytes4(keccak256("NoVerifiedAdapter()")) = 0x36a01ad4
+        vm.expectRevert(bytes4(keccak256("NoVerifiedAdapter()")));
+        lpm.modifyLiquidities(calls, block.timestamp + 1);
+    }
+
     function test_permissioned_mint_increase_allowed_user() public {
         _test_permissioned_mint_increase_allowed_user(key0);
         _test_permissioned_mint_increase_allowed_user(key1);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -736,11 +736,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
         // Initialize directly on the PoolManager with no hooks so initialization isn't gated.
         PoolKey memory ordinaryKey = PoolKey({
-            currency0: ordinary0,
-            currency1: ordinary1,
-            fee: 3000,
-            tickSpacing: 60,
-            hooks: IHooks(address(0))
+            currency0: ordinary0, currency1: ordinary1, fee: 3000, tickSpacing: 60, hooks: IHooks(address(0))
         });
         manager.initialize(ordinaryKey, SQRT_PRICE_1_1);
 

--- a/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
+++ b/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
@@ -62,6 +62,10 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
     Plan public plan;
 
     address public positionManager;
+    /// @dev Plain (non-permissioned) PositionManager used to mint liquidity into ordinary
+    ///      ERC-20/ERC-20 pools (e.g. `key2`) for routing tests. The PermissionedPositionManager
+    ///      now rejects mints where neither side is a verified permissions adapter.
+    address public ordinaryPositionManager;
 
     mapping(Currency permissionsAdapter => Currency permissionedCurrency) public adapterToPermissioned;
 
@@ -185,9 +189,22 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
         }
         _key = PoolKey(currencyA, currencyB, 3000, 60, IHooks(hookAddr));
         manager.initialize(_key, SQRT_PRICE_1_1);
-        MockERC20(Currency.unwrap(currencyA)).approve(positionManager, type(uint256).max);
-        MockERC20(Currency.unwrap(currencyB)).approve(positionManager, type(uint256).max);
-        modifyLiquidity(_key, ModifyLiquidityParams(-887220, 887220, 200 ether, 0), "0x", 0);
+
+        // Pools where neither side is a verified permissions adapter must use the plain PositionManager —
+        // PermissionedPositionManager rejects mints into those pools (positions would be untransferable).
+        bool currency0Verified =
+            permissionsAdapterFactory.verifiedPermissionsAdapterOf(Currency.unwrap(currencyA)) != address(0);
+        bool currency1Verified =
+            permissionsAdapterFactory.verifiedPermissionsAdapterOf(Currency.unwrap(currencyB)) != address(0);
+        address posm = (currency0Verified || currency1Verified) ? positionManager : ordinaryPositionManager;
+
+        MockERC20(Currency.unwrap(currencyA)).approve(posm, type(uint256).max);
+        MockERC20(Currency.unwrap(currencyB)).approve(posm, type(uint256).max);
+        MockERC20(Currency.unwrap(currencyA)).approve(address(permit2), type(uint256).max);
+        MockERC20(Currency.unwrap(currencyB)).approve(address(permit2), type(uint256).max);
+        permit2.approve(Currency.unwrap(currencyA), posm, type(uint160).max, type(uint48).max);
+        permit2.approve(Currency.unwrap(currencyB), posm, type(uint160).max, type(uint48).max);
+        modifyLiquidityVia(posm, _key, ModifyLiquidityParams(-887220, 887220, 200 ether, 0), "0x", 0);
     }
 
     function createNativePoolWithLiquidity(Currency currency, address hookAddr) internal returns (PoolKey memory _key) {
@@ -298,6 +315,16 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
         bytes memory hookData,
         uint256 value
     ) public {
+        modifyLiquidityVia(positionManager, key, params, hookData, value);
+    }
+
+    function modifyLiquidityVia(
+        address posm,
+        PoolKey memory key,
+        ModifyLiquidityParams memory params,
+        bytes memory hookData,
+        uint256 value
+    ) public {
         // Create a plan with the mint position action
         plan = Planner.init();
         plan = plan.add(
@@ -310,7 +337,7 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
         uint256 deadline = block.timestamp + 3600;
 
         // Call modifyLiquidities with the properly encoded data
-        IPositionManager(positionManager).modifyLiquidities{value: value}(unlockData, deadline);
+        IPositionManager(posm).modifyLiquidities{value: value}(unlockData, deadline);
     }
 
     function _finalizeAndExecuteSwap(
@@ -405,6 +432,18 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
             abi.encode(manager, permit2, 1e18, address(tokenDescriptor), address(weth9), permissionsAdapterFactory)
         );
         positionManager = Deploy.create2(posmBytecode, keccak256("permissionedPosm"));
+
+        // Plain PositionManager — used to mint liquidity into ordinary pools (no verified adapter).
+        ordinaryPositionManager = address(
+            Deploy.positionManager(
+                address(manager),
+                address(permit2),
+                1e18,
+                address(tokenDescriptor),
+                address(weth9),
+                bytes.concat(keccak256("ordinaryPosm"))
+            )
+        );
     }
 
     function _deployAndSetupTokens(MockERC20[] memory tokens) private {


### PR DESCRIPTION
## Related Issue
[ECO-344](https://linear.app/uniswap/issue/ECO-344)

## Description of changes
- Adding a check into `PermissionedPositionManager._mint()` to ensure that at least one of the two currencies is a VerifiedAdapter. This prevents the minting of frozen positions for unrelated pools