### PR TITLE
docs(permissions-adapter)[eco-343]: document allowedWrappers trust requirement

### DIFF
--- a/src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol
@@ -69,7 +69,7 @@ interface IPermissionsAdapter is IERC20 {
     function allowListChecker() external view returns (IAllowlistChecker);
 
     /// @notice Returns the allowed wrappers that can wrap the permissioned token
-    /// @dev e.g., the permissioned pool manager, quoters or the swap router
+    /// @dev Wrappers must honestly report `msgSender()` to maintain permission guarantees.
     function allowedWrappers(address wrapper) external view returns (bool);
 
     /// @notice Returns the swapping enabled status

--- a/src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol
@@ -69,6 +69,7 @@ interface IPermissionsAdapter is IERC20 {
     function allowListChecker() external view returns (IAllowlistChecker);
 
     /// @notice Returns the allowed wrappers that can wrap the permissioned token
+    /// @dev e.g., the permissioned pool manager, quoters or the swap router
     /// @dev Wrappers must honestly report `msgSender()` to maintain permission guarantees.
     function allowedWrappers(address wrapper) external view returns (bool);
 


### PR DESCRIPTION
## Related Issue
[ECO-343](https://linear.app/uniswap/issue/ECO-343)

## Description of changes
NatSpec on `IPermissionsAdapter.allowedWrappers` calling out that wrappers must honestly report `msgSender()` to maintain permission guarantees.