### PR TITLE
fix(permissioned-pools): block permissioned _pay when swapping disabled

### DIFF
--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "241550"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242570"
 }

--- a/src/hooks/permissionedPools/PermissionedV4Router.sol
+++ b/src/hooks/permissionedPools/PermissionedV4Router.sol
@@ -14,6 +14,7 @@ abstract contract PermissionedV4Router is V4Router {
     IPermissionsAdapterFactory public immutable PERMISSIONS_ADAPTER_FACTORY;
 
     error Unauthorized();
+    error SwappingDisabled();
 
     constructor(IPoolManager poolManager_, IPermissionsAdapterFactory permissionsAdapterFactory)
         V4Router(poolManager_)
@@ -31,6 +32,7 @@ abstract contract PermissionedV4Router is V4Router {
         }
         // token is permissioned, wrap the token and transfer it to the pool manager
         IPermissionsAdapter permissionsAdapter = IPermissionsAdapter(Currency.unwrap(currency));
+        if (!permissionsAdapter.swappingEnabled()) revert SwappingDisabled();
         if (!permissionsAdapter.isAllowed(msgSender(), PermissionFlags.SWAP_ALLOWED)) {
             revert Unauthorized();
         }

--- a/test/hooks/permissionedPools/PermissionedV4Router.t.sol
+++ b/test/hooks/permissionedPools/PermissionedV4Router.t.sol
@@ -216,6 +216,22 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
         permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
     }
 
+    /// @notice Standalone SETTLE+TAKE bypasses the hook's swap pause. Router-side check must catch it.
+    function test_settle_revert_when_swapping_disabled_on_input_adapter() public {
+        IERC20(Currency.unwrap(currency0)).transfer(alice, 2 ether);
+        IERC20(Currency.unwrap(currency1)).transfer(alice, 2 ether);
+
+        plan = plan.add(Actions.SETTLE, abi.encode(permissionsAdapter0Currency, uint256(100), true));
+        plan = plan.add(Actions.TAKE, abi.encode(permissionsAdapter0Currency, alice, uint256(100)));
+        bytes memory data = plan.encode();
+
+        permissionsAdapter0.updateSwappingEnabled(false);
+
+        vm.prank(alice);
+        vm.expectRevert(SwappingDisabled.selector);
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+    }
+
     function test_swap_succeeds_authorized_user() public {
         IERC20(Currency.unwrap(currency0)).transfer(alice, 2 ether);
         IERC20(Currency.unwrap(currency1)).transfer(alice, 2 ether);


### PR DESCRIPTION
## Related Issue
[ECO-339](https://linear.app/uniswap/issue/ECO-339)

## Description of changes
- When `swappingEnabled = false`, the hook will revert on `beforeSwap()` for all swap-related actions. However, it's currently possible to submit action-plans without swaps, e.g. `[SETTLE, TAKE]`.
- These would reach `PermissionedV4Router._pay()` without the hook running, using the router as a generic wrap/unwrap surface despite the admin pause.
- Adds a `swappingEnabled()` check on the permissioned branch of `_pay()` plus a new `SwappingDisabled` error.