### PR TITLE
fix(permissions-adapter): reject pool-manager self-transfer/unwrap

### DIFF
--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242570"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242599"
 }

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -112,6 +112,8 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
             // if the pool manager is the sender, the permissioned token is automatically released, skip the checks
             revert InvalidTransfer(from, to);
         }
+        // reject self-transfer: would unwrap raw underlying into PoolManager
+        if (to == POOL_MANAGER) revert InvalidTransfer(from, to);
         super._update(from, to, amount);
         _unwrap(to, amount);
         // the pool manager must always be the only holder of the permissions adapter

--- a/test/hooks/permissionedPools/PermissionsAdapter.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapter.t.sol
@@ -154,6 +154,25 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         permissionsAdapter.transfer(to, 0);
     }
 
+    function testRevert_PoolManagerSelfTransfer(uint256 mintAmount, uint256 transferAmount) public {
+        // Cantina ECO-340: a TAKE(adapter, poolManager, ...) would otherwise unwrap raw underlying
+        // back into the pool manager, breaking the adapter accounting boundary.
+        transferAmount = bound(transferAmount, 0, mintAmount);
+        permissionedToken.mint(address(permissionsAdapter), mintAmount);
+        permissionsAdapter.wrapToPoolManager(mintAmount);
+
+        vm.prank(mockPoolManager);
+        vm.expectRevert(
+            abi.encodeWithSelector(IPermissionsAdapter.InvalidTransfer.selector, mockPoolManager, mockPoolManager)
+        );
+        permissionsAdapter.transfer(mockPoolManager, transferAmount);
+
+        // adapter and underlying state are unchanged
+        assertEq(permissionsAdapter.balanceOf(mockPoolManager), mintAmount);
+        assertEq(permissionedToken.balanceOf(mockPoolManager), 0);
+        assertEq(permissionedToken.balanceOf(address(permissionsAdapter)), mintAmount);
+    }
+
     function test_UnwrapOnPoolManagerTransfer(uint256 mintAmount, uint256 transferAmount, address recipient) public {
         vm.assume(recipient != address(0) && recipient != mockPoolManager && recipient != address(permissionsAdapter));
         assertEq(permissionedToken.balanceOf(recipient), 0);


### PR DESCRIPTION
## Related Issue
[ECO-340](https://linear.app/uniswap/issue/ECO-340)

## Description of changes
- `PermissionsAdapter._update` auto-unwraps when `from == POOL_MANAGER`. A `TAKE(adapter, address(poolManager), amount)` triggers `_update(POOL_MANAGER, POOL_MANAGER, amount)`, burns the adapter shares, and transfers the raw underlying back into PoolManager — leaving an orphan balance with no associated delta.
- Adds an explicit revert when both `from` and `to` are `POOL_MANAGER`, reusing the existing `InvalidTransfer` error. The legitimate `wrapToPoolManager` mint path is untouched (it goes through `from == address(0)` and returns before reaching the new check).
- In well-configured deployments, the underlying secToken's own allowlist already rejects this transfer (PoolManager would not normally be on the issuer allowlist). The new check protects users from accidentally routing a TAKE to PoolManager in misconfigured-allowlist environments — a clean revert instead of a stuck-funds scenario.