### PR TITLE
fix(permissioned-position-manager): enforce owner LIQUIDITY_ALLOWED on liquidity increase"

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -164,9 +164,10 @@ contract PermissionedPositionManager is PositionManager {
     }
 
     /// @dev Re-validate the hook allowlist on every liquidity increase so that a revoked hook cannot
-    ///      continue to accept new inflows on existing positions. Decrease and burn paths are intentionally
-    ///      left unchecked so that holders can always exit positions even after a hook has been removed
-    ///      from the allowlist.
+    ///      continue to accept new inflows on existing positions. Also re-check that the position owner
+    ///      still clears `LIQUIDITY_ALLOWED` for each permissioned currency. Decrease and burn paths are
+    ///      intentionally left unchecked so that holders can always exit positions even after their
+    ///      permissions or the hook have been revoked.
     function _increase(
         uint256 tokenId,
         uint256 liquidity,
@@ -176,6 +177,9 @@ contract PermissionedPositionManager is PositionManager {
     ) internal override {
         (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
         if (!_checkAllowedHooks(poolKey)) revert InvalidHook();
+        address owner = ownerOf(tokenId);
+        _checkRecipientAllowed(poolKey.currency0, owner);
+        _checkRecipientAllowed(poolKey.currency1, owner);
         super._increase(tokenId, liquidity, amount0Max, amount1Max, hookData);
     }
 
@@ -186,6 +190,9 @@ contract PermissionedPositionManager is PositionManager {
     {
         (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
         if (!_checkAllowedHooks(poolKey)) revert InvalidHook();
+        address owner = ownerOf(tokenId);
+        _checkRecipientAllowed(poolKey.currency0, owner);
+        _checkRecipientAllowed(poolKey.currency1, owner);
         super._increaseFromDeltas(tokenId, amount0Max, amount1Max, hookData);
     }
 

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -1624,6 +1624,113 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _setHookAllowed(revoked, key.hooks, true);
     }
 
+    // =============================================================================
+    // Owner LIQUIDITY_ALLOWED enforcement on liquidity increases (ECO-347 / Cantina #17)
+    // =============================================================================
+    //
+    // An ERC-721-approved operator that retains LIQUIDITY_ALLOWED must not be able to grow
+    // a delisted owner's position by paying with their own funds. `_increase` and
+    // `_increaseFromDeltas` re-check `_checkRecipientAllowed(currency, ownerOf(tokenId))`.
+
+    function test_permissioned_increase_reverts_when_owner_liquidity_revoked_via_operator() public {
+        _test_permissioned_increase_reverts_when_owner_liquidity_revoked_via_operator(key0);
+        _test_permissioned_increase_reverts_when_owner_liquidity_revoked_via_operator(key1);
+        _test_permissioned_increase_reverts_when_owner_liquidity_revoked_via_operator(key2);
+    }
+
+    function _test_permissioned_increase_reverts_when_owner_liquidity_revoked_via_operator(PoolKey memory key)
+        internal
+    {
+        address bob = makeAddr("BOB");
+        // Bob holds LIQUIDITY_ALLOWED on every permissioned underlying and is funded so he can
+        // pay for the increase from his own balance.
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(bob, PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(bob, PermissionFlags.ALL_ALLOWED);
+        seedBalance(bob);
+        approvePosmFor(bob);
+
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+        uint256 liquidity = 1e18;
+        uint256 tokenId = lpm.nextTokenId();
+
+        // Alice mints a position while she still has LIQUIDITY_ALLOWED.
+        vm.prank(alice);
+        mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+        uint128 liquidityBefore = lpm.getPositionLiquidity(tokenId);
+
+        // Alice approves Bob via ERC-721 so he can operate on her tokenId.
+        vm.prank(alice);
+        IERC721(address(lpm)).approve(bob, tokenId);
+
+        // Alice's adapter revokes her permissions on every permissioned underlying.
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(alice, PermissionFlags.NONE);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(alice, PermissionFlags.NONE);
+
+        // Bob — still allowlisted, still ERC-721-approved — must not be able to grow Alice's
+        // position by paying with his own funds.
+        vm.prank(bob);
+        vm.expectRevert(Unauthorized.selector);
+        increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
+
+        // Position size unchanged.
+        assertEq(lpm.getPositionLiquidity(tokenId), liquidityBefore);
+
+        // Restore so the fan-out across keys is independent.
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(alice, PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(alice, PermissionFlags.ALL_ALLOWED);
+    }
+
+    function test_permissioned_increaseFromDeltas_reverts_when_owner_liquidity_revoked_via_operator() public {
+        _test_permissioned_increaseFromDeltas_reverts_when_owner_liquidity_revoked_via_operator(key0);
+        _test_permissioned_increaseFromDeltas_reverts_when_owner_liquidity_revoked_via_operator(key1);
+        _test_permissioned_increaseFromDeltas_reverts_when_owner_liquidity_revoked_via_operator(key2);
+    }
+
+    function _test_permissioned_increaseFromDeltas_reverts_when_owner_liquidity_revoked_via_operator(PoolKey memory key)
+        internal
+    {
+        address bob = makeAddr("BOB_DELTAS");
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(bob, PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(bob, PermissionFlags.ALL_ALLOWED);
+        seedBalance(bob);
+        approvePosmFor(bob);
+
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+        uint256 initialLiquidity = 1e18;
+        uint256 tokenId = lpm.nextTokenId();
+
+        vm.prank(alice);
+        mint(config, initialLiquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+        uint128 liquidityBefore = lpm.getPositionLiquidity(tokenId);
+
+        vm.prank(alice);
+        IERC721(address(lpm)).approve(bob, tokenId);
+
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(alice, PermissionFlags.NONE);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(alice, PermissionFlags.NONE);
+
+        // Build a plan that pre-settles both currencies then drives INCREASE_LIQUIDITY_FROM_DELTAS.
+        // The owner-allowlist check runs at the top of the override, so the whole batch reverts
+        // atomically and no funds move.
+        Plan memory planner = Planner.init();
+        planner.add(Actions.SETTLE, abi.encode(key.currency0, uint256(10e18), true));
+        planner.add(Actions.SETTLE, abi.encode(key.currency1, uint256(10e18), true));
+        planner.add(
+            Actions.INCREASE_LIQUIDITY_FROM_DELTAS,
+            abi.encode(tokenId, MAX_SLIPPAGE_INCREASE, MAX_SLIPPAGE_INCREASE, ZERO_BYTES)
+        );
+        bytes memory calls = planner.encode();
+
+        vm.prank(bob);
+        vm.expectRevert(Unauthorized.selector);
+        lpm.modifyLiquidities(calls, _deadline);
+
+        assertEq(lpm.getPositionLiquidity(tokenId), liquidityBefore);
+
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(alice, PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(alice, PermissionFlags.ALL_ALLOWED);
+    }
+
     // Helpers for toggling the hook allowlist in tests. Uses a raw selector call to mirror the
     // pattern established by `setAllowedHooks` (line 227).
     function _setHookAllowedForKey(PoolKey memory key, bool allowed) internal {


### PR DESCRIPTION
## Related Issue
- [ECO-347](https://linear.app/uniswap/issue/ECO-347)

## Description of changes
- `_increase()` and `_increaseFromDeltas()` only check that the caller has `LIQUIDITY_ALLOWED` permissionFlag, not the actual owner of the position.
- So this is possible:
  - Alice mints when she's allowlisted, approves Bob (also allowlisted)
  - Alice gets revoked (Bob stays allowlisted)
  - Bob can still grow Alice's position because Bob still has both gates (Alice's approval persists; Bob's allowlist standing persists)
  - Alice's revoked position keeps growing, defeating the revocation's intent
- This PR just adds a check to `_increase()` and `_increaseFromDeltas()` to validate the owner of the position has `LIQUIDITY_ALLOWED` too.