### PR TITLE
fix(permissioned-position-manager): resolve recipient sentinel before emitting ClaimWithdrawn

### DIFF
--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242599"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "234615"
 }

--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "234615"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242599"
 }

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -110,18 +110,19 @@ contract PermissionedPositionManager is PositionManager {
     /// @dev Caller must hold the claim or have called PoolManager.setOperator(permPosm, true). For permissioned
     ///      currencies, `to` must clear the underlying token's issuer compliance on unwrap. `to` follows the
     ///      standard `Actions.TAKE` recipient sentinels: `address(1)` remaps to the caller, `address(2)` to this
-    ///      contract.
+    ///      contract. Sentinels are resolved before both the underlying delivery and the `ClaimWithdrawn` event.
     /// @param currency The currency whose 6909 claim is being burned
     /// @param amount The amount of claim to burn (and underlying to deliver)
     /// @param to The recipient of the underlying currency
     function withdrawClaim(Currency currency, uint256 amount, address to) external isNotLocked {
+        address resolvedTo = _mapRecipient(to);
         bytes memory actions = abi.encodePacked(uint8(Actions.BURN_6909), uint8(Actions.TAKE));
         bytes[] memory params = new bytes[](2);
         params[0] = abi.encode(currency, msg.sender, amount);
-        params[1] = abi.encode(currency, to, amount);
+        params[1] = abi.encode(currency, resolvedTo, amount);
         poolManager.unlock(abi.encode(actions, params));
 
-        emit ClaimWithdrawn(currency, msg.sender, to, amount);
+        emit ClaimWithdrawn(currency, msg.sender, resolvedTo, amount);
     }
 
     /// @inheritdoc PositionManager

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -2104,6 +2104,67 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         assertEq(_balanceOf(currency0, to) - toBefore, claim);
     }
 
+    /// @dev `MSG_SENDER` sentinel must resolve to the action executor in both the underlying delivery and
+    ///      the `ClaimWithdrawn` event. Same cascade-to-6909 setup as the round-trip test.
+    function test_withdrawClaim_resolves_msg_sender_sentinel() public {
+        address admin = makeAddr("WC_ADMIN_MS");
+        address other = makeAddr("WC_OTHER_MS");
+        _setupUnwindPositionTests(admin, other);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(admin, false);
+
+        vm.prank(admin);
+        _unwind(tokenId);
+
+        uint256 claim = manager.balanceOf(admin, key0.currency0.toId());
+        assertGt(claim, 0);
+
+        // re-list admin so the unwrap on TAKE can deliver underlying back to it
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(admin, PermissionFlags.ALL_ALLOWED);
+
+        vm.prank(admin);
+        manager.setOperator(address(lpm), true);
+
+        vm.expectEmit(true, true, true, true);
+        emit ClaimWithdrawn(key0.currency0, admin, admin, claim);
+        vm.prank(admin);
+        _withdrawClaim(key0.currency0, claim, ActionConstants.MSG_SENDER);
+    }
+
+    /// @dev `ADDRESS_THIS` sentinel must resolve to the position manager in both the delivery and the event.
+    function test_withdrawClaim_resolves_address_this_sentinel() public {
+        address admin = makeAddr("WC_ADMIN_AT");
+        address other = makeAddr("WC_OTHER_AT");
+        _setupUnwindPositionTests(admin, other);
+
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key0);
+
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(alice, false);
+        MockPermissionedToken(Currency.unwrap(currency0)).setTokenAllowlist(admin, false);
+
+        vm.prank(admin);
+        _unwind(tokenId);
+
+        uint256 claim = manager.balanceOf(admin, key0.currency0.toId());
+        assertGt(claim, 0);
+
+        // permPosm must be allowed to receive the underlying when the TAKE unwraps into it
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(address(lpm), PermissionFlags.ALL_ALLOWED);
+
+        vm.prank(admin);
+        manager.setOperator(address(lpm), true);
+
+        vm.expectEmit(true, true, true, true);
+        emit ClaimWithdrawn(key0.currency0, admin, address(lpm), claim);
+        vm.prank(admin);
+        _withdrawClaim(key0.currency0, claim, ActionConstants.ADDRESS_THIS);
+    }
+
     /// @dev Caller has not authorized permPosm via `setOperator` → BURN_6909 underflows on the allowance check.
     function test_withdrawClaim_reverts_without_operator() public {
         vm.startPrank(alice);


### PR DESCRIPTION
## Related Issue
[ECO-427](https://linear.app/uniswap/issue/ECO-427/sc-37-withdrawclaim-emits-unresolved-sentinel-recipient) (parent: [ECO-336](https://linear.app/uniswap/issue/ECO-336/sc-cantina-ur-audit))

## Description of changes

`withdrawClaim` passed the caller-supplied `to` straight into the `TAKE` action AND emitted it raw in `ClaimWithdrawn(currency, msg.sender, to, amount)`. The `TAKE` action handler later resolved `address(1)` (`MSG_SENDER`) and `address(2)` (`ADDRESS_THIS`) via `_mapRecipient`, so tokens were delivered to the right address — but the event always recorded the literal sentinel. Off-chain consumers indexing `ClaimWithdrawn.to` saw a meaningless sentinel instead of the real recipient.

Fix: resolve once at the top of `withdrawClaim` via `_mapRecipient(to)` and use the resolved address in both the inner `TAKE` action params and the event. `_mapRecipient` reads `_getLocker()`, which the `isNotLocked` modifier sets to `msg.sender` before the function body — so the resolution happens against the same locker the inner `TAKE` will see.

## Test coverage
- `test_withdrawClaim_resolves_msg_sender_sentinel` — caller passes `ActionConstants.MSG_SENDER`; event records the caller's address; underlying delivered to the caller.
- `test_withdrawClaim_resolves_address_this_sentinel` — caller passes `ActionConstants.ADDRESS_THIS`; event records `address(permPosm)`; underlying delivered to the position manager itself.
- Existing `test_withdrawClaim_round_trip` (concrete-address fuzz) and the two `test_withdrawClaim_reverts_*` regressions still pass.

Full perm-pool suite: 183/183 passing.