### PR TITLE
fix(permissions-adapter): use safeTransferFrom in depositForVerification

### DIFF
--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,3 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242599"
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242611"
 }

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -51,7 +51,7 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
 
     /// @inheritdoc IPermissionsAdapter
     function depositForVerification(uint256 amount) external {
-        PERMISSIONED_TOKEN.transferFrom(msg.sender, address(this), amount);
+        SafeERC20(address(PERMISSIONED_TOKEN)).safeTransferFrom(msg.sender, address(this), amount);
         emit VerificationDeposit(msg.sender, amount);
     }
 

--- a/test/hooks/permissionedPools/PermissionsAdapter.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapter.t.sol
@@ -138,6 +138,32 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         assertEq(permissionedToken.balanceOf(address(permissionsAdapter)), amount);
     }
 
+    /// @dev USDT-style underlying tokens omit the bool return value on transferFrom. The raw
+    ///      `transferFrom` call would revert when Solidity tries to decode bool from empty
+    ///      returndata; `safeTransferFrom` accepts empty returndata as success.
+    function test_DepositForVerification_NonReturningUnderlying() public {
+        NonReturningToken usdtLike = new NonReturningToken();
+        bytes memory args = abi.encode(IERC20(address(usdtLike)), mockPoolManager, owner, allowlistChecker);
+        bytes memory initcode = abi.encodePacked(vm.getCode("PermissionsAdapter.sol:PermissionsAdapter"), args);
+        address adapter;
+        assembly {
+            adapter := create(0, add(initcode, 0x20), mload(initcode))
+        }
+
+        address depositor = makeAddr("noReturnDepositor");
+        uint256 amount = 1e18;
+        usdtLike.mint(depositor, amount);
+        vm.prank(depositor);
+        usdtLike.approve(adapter, amount);
+
+        vm.expectEmit(true, true, true, true);
+        emit IPermissionsAdapter.VerificationDeposit(depositor, amount);
+        vm.prank(depositor);
+        IPermissionsAdapter(adapter).depositForVerification(amount);
+
+        assertEq(usdtLike.balanceOf(adapter), amount);
+    }
+
     function test_UpdateSwappingEnabled(bool enabled) public {
         vm.prank(owner);
         vm.expectEmit(true, true, true, true);
@@ -417,5 +443,40 @@ contract BypassAllowlistChecker is IAllowlistChecker {
 
     function supportsInterface(bytes4) external pure returns (bool) {
         return true;
+    }
+}
+
+/// @notice USDT-style ERC20: omits the bool return value on transfer/transferFrom. Used to confirm
+///         that `PermissionsAdapter.depositForVerification` tolerates non-standard return shapes.
+contract NonReturningToken {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    string public name = "NonReturning";
+    string public symbol = "NORET";
+    uint8 public decimals = 18;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external {
+        allowance[msg.sender][spender] = amount;
+    }
+
+    function transfer(address to, uint256 amount) external {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        // intentionally no return value
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external {
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        require(balanceOf[from] >= amount, "balance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        // intentionally no return value
     }
 }


### PR DESCRIPTION
## Related Issue
[ECO-429](https://linear.app/uniswap/issue/ECO-429/sc-39-permissionsadapterdepositforverification-should-use-safeerc20) (parent: [ECO-336](https://linear.app/uniswap/issue/ECO-336/sc-cantina-ur-audit))

## Description of changes

`depositForVerification` called `PERMISSIONED_TOKEN.transferFrom(...)` through the raw `IERC20` interface. Two failure modes for non-standard underlyings:
1. **USDT-style tokens** (no bool return) revert when Solidity tries to decode `bool` from empty returndata, bricking adapter verification.
2. **Tokens that return `false`** on failure are silently treated as success because the return value is discarded.

Switched to solmate `SafeTransferLib.safeTransferFrom` via the existing `SafeERC20` alias and `using SafeTransferLib for SafeERC20 global` pattern already used elsewhere in the file (e.g., `_unwrap` at line 125). Single-line code change.

## Sweep

Audited every `.transfer` / `.transferFrom` / `.approve` call across `src/hooks/permissionedPools/`. Only this one site needed fixing. The other sites are already safe:
- `Currency.wrap(...).transfer(...)` in `PermissionedV4Router.sol:40`, `PermissionedPositionManager.sol:235,267` → v4-core's `CurrencyLibrary.transfer` is inlined solmate-style `safeTransfer` (low-level call + returndata validation).
- `permit2.transferFrom(...)` in `PermissionedPositionManager.sol:237` → Permit2's own interface; safety handled by Permit2.

## Test coverage

- `test_DepositForVerification_NonReturningUnderlying` — deploys a fresh `PermissionsAdapter` with a USDT-style underlying (transferFrom omits return value), then exercises `depositForVerification` and asserts the deposit lands. Without the fix this test reverts on the empty-returndata decode.
- Existing `test_DepositForVerification` fuzz test (vanilla ERC-20 path) still passes.

Full perm-pool suite: 182/182 passing.