### PR TITLE
fix: correct deprecated function reference in action dispatch comments

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -200,7 +200,7 @@ contract PositionManager is
                 _increase(tokenId, liquidity, amount0Max, amount1Max, hookData);
                 return;
             } else if (action == Actions.INCREASE_LIQUIDITY_FROM_DELTAS) {
-                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _increaseFromDeltas().
+                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _increase() instead.
                 (uint256 tokenId, uint128 amount0Max, uint128 amount1Max, bytes calldata hookData) =
                     params.decodeIncreaseLiquidityFromDeltasParams();
                 _increaseFromDeltas(tokenId, amount0Max, amount1Max, hookData);
@@ -224,7 +224,7 @@ contract PositionManager is
                 _mint(poolKey, tickLower, tickUpper, liquidity, amount0Max, amount1Max, _mapRecipient(owner), hookData);
                 return;
             } else if (action == Actions.MINT_POSITION_FROM_DELTAS) {
-                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _mintFromDeltas().
+                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _mint() instead.
                 (
                     PoolKey calldata poolKey,
                     int24 tickLower,


### PR DESCRIPTION
## Summary

In `PositionManager.sol`, the action dispatch comments for `INCREASE_LIQUIDITY_FROM_DELTAS` and `MINT_POSITION_FROM_DELTAS` incorrectly reference the deprecated functions themselves as the "see also" guidance, rather than pointing developers to the safe replacements.

## Changes

**Line 203** (before):
`// DEPRECATED - vulnerable to sandwich attacks, do not use. See _increaseFromDeltas().`

**Line 203** (after):
`// DEPRECATED - vulnerable to sandwich attacks, do not use. See _increase() instead.`

**Line 227** (before):
`// DEPRECATED - vulnerable to sandwich attacks, do not use. See _mintFromDeltas().`

**Line 227** (after):
`// DEPRECATED - vulnerable to sandwich attacks, do not use. See _mint() instead.`

The function-level NatSpec at lines 308 and 392 already correctly references `_increase()` and `_mint()` — this PR aligns the action dispatch comments to match.