### PR TITLE
hardening: track and refund msg.value for position manager settle

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -109,6 +109,9 @@ contract PositionManager is
     Permit2Forwarder,
     NativeWrapper
 {
+    using CurrencyLibrary for Currency;
+    using PoolIdLibrary for PoolKey;
+    using PositionConfigLibrary for PositionConfig;
     using StateLibrary for IPoolManager;
     using TransientStateLibrary for IPoolManager;
     using SafeCast for uint256;
@@ -169,11 +172,23 @@ contract PositionManager is
     }
 
     /// @inheritdoc IPositionManager
+    modifier setMsgValue() {
+        _setMsgValue(msg.value);
+        _;
+        _refundETH(msg.sender, _getMsgValue());
+        _setMsgValue(0);
+    }
+
+    /// @inheritdoc IPositionManager
+    /// @param unlockData is an encoding of actions, params, and currencies
+    /// @return returnData is the endocing of each actions return information
     function modifyLiquidities(bytes calldata unlockData, uint256 deadline)
         external
         payable
         isNotLocked
         checkDeadline(deadline)
+        setMsgValue
+        returns (bytes[] memory)
     {
         _executeActions(unlockData);
     }
@@ -475,7 +490,7 @@ contract PositionManager is
         if (currencyDelta < 0) {
             // Casting is safe due to limits on the total supply of a pool
             _settle(currency, caller, uint256(-currencyDelta));
-        } else {
+        } else if (currencyDelta > 0) {
             _take(currency, caller, uint256(currencyDelta));
         }
     }
@@ -570,5 +585,11 @@ contract PositionManager is
     {
         bytes32 positionId = Position.calculatePositionKey(address(this), tickLower, tickUpper, bytes32(tokenId));
         liquidity = poolManager.getPositionLiquidity(poolKey.toId(), positionId);
+    }
+
+    // implementation of abstract function DeltaResolver._pay
+    function _pay(Currency token, address payer, uint256 amount) internal override {
+        // TODO: Should we also support direct transfer?
+        permit2.transferFrom(payer, address(poolManager), uint160(amount), Currency.unwrap(token));
     }
 }

--- a/src/base/DeltaResolver.sol
+++ b/src/base/DeltaResolver.sol
@@ -18,6 +18,13 @@ abstract contract DeltaResolver is ImmutableState {
     error DeltaNotNegative(Currency currency);
     /// @notice Emitted when the contract does not have enough balance to wrap or unwrap.
     error InsufficientBalance();
+    /// @notice ETH was passed to a settlement action for a non-native currency
+    error UnexpectedValue();
+    /// @notice ETH refund failed.
+    error ETHTransferFailed();
+
+    /// @dev Transient slot holding the ETH value attached to the active execution.
+    uint256 internal constant MSG_VALUE_SLOT = uint256(keccak256("UniswapV4Periphery.msgValue")) - 1;
 
     /// @notice Take an amount of currency out of the PoolManager
     /// @param currency Currency to take
@@ -39,9 +46,18 @@ abstract contract DeltaResolver is ImmutableState {
         if (amount == 0) return;
 
         poolManager.sync(currency);
+        uint256 msgValue = _getMsgValue();
         if (currency.isAddressZero()) {
             poolManager.settle{value: amount}();
+            if (msgValue > amount) {
+                _setMsgValue(msgValue - amount);
+            } else {
+                _setMsgValue(0);
+            }
         } else {
+            if (msgValue != 0) {
+                revert UnexpectedValue();
+            }
             _pay(currency, payer, amount);
             poolManager.settle();
         }
@@ -53,7 +69,6 @@ abstract contract DeltaResolver is ImmutableState {
     /// @param payer The address who should pay tokens
     /// @param amount The number of tokens to send
     function _pay(Currency token, address payer, uint256 amount) internal virtual;
-
     /// @notice Obtain the full amount owed by this contract (negative delta)
     /// @param currency Currency to get the delta for
     /// @return amount The amount owed by this contract as a uint256
@@ -119,5 +134,26 @@ abstract contract DeltaResolver is ImmutableState {
         }
         if (amount > balance) revert InsufficientBalance();
         return amount;
+    }
+
+    /// @dev Store the ETH value attached to the active call in transient storage.
+    function _setMsgValue(uint256 value) internal {
+        assembly ("memory-safe") {
+            tstore(MSG_VALUE_SLOT, value);
+        }
+    }
+
+    /// @dev Read the ETH value attached to the active call from transient storage.
+    function _getMsgValue() internal view returns (uint256 value) {
+        assembly ("memory-safe") {
+            value := tload(MSG_VALUE_SLOT);
+        }
+    }
+
+    /// @dev Refund unspent ETH at the end of a call.
+    function _refundETH(address to, uint256 amount) internal {
+        if (amount == 0) return;
+        (bool success,) = payable(to).call{value: amount}("");
+        if (!success) revert ETHTransferFailed();
     }
 }


### PR DESCRIPTION
## Summary
- track msg.value in transient storage during modifyLiquidities
- settle native with exact msg.value consumption
- refund unused ETH at end of execution
- reject msg.value on non-native settle paths

## Files
- src/PositionManager.sol
- src/base/DeltaResolver.sol

## Note
Based on existing hardening work from support-native-routing branch; replays cleanly and remains minimal.
