### PR TITLE
fix: replace deprecated fuzz_runs with fuzz.runs in foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ ffi = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/" }, { access = "read", path = "foundry-out/" }]
 evm_version = "cancun"
 gas_limit = "3000000000"
-fuzz_runs = 10_000
+fuzz.runs = 10_000
 bytecode_hash = "none"
 
 additional_compiler_profiles = [
@@ -28,7 +28,7 @@ optimizer_runs = 200
 fuzz.runs = 100
 
 [profile.ci]
-fuzz_runs = 100_000
+fuzz.runs = 100_000
 
 [profile.gas]
 gas_limit=30_000_000

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -200,7 +200,7 @@ contract PositionManager is
                 _increase(tokenId, liquidity, amount0Max, amount1Max, hookData);
                 return;
             } else if (action == Actions.INCREASE_LIQUIDITY_FROM_DELTAS) {
-                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _increaseFromDeltas().
+                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _increase() instead.
                 (uint256 tokenId, uint128 amount0Max, uint128 amount1Max, bytes calldata hookData) =
                     params.decodeIncreaseLiquidityFromDeltasParams();
                 _increaseFromDeltas(tokenId, amount0Max, amount1Max, hookData);
@@ -224,7 +224,7 @@ contract PositionManager is
                 _mint(poolKey, tickLower, tickUpper, liquidity, amount0Max, amount1Max, _mapRecipient(owner), hookData);
                 return;
             } else if (action == Actions.MINT_POSITION_FROM_DELTAS) {
-                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _mintFromDeltas().
+                // DEPRECATED - vulnerable to sandwich attacks, do not use. See _mint() instead.
                 (
                     PoolKey calldata poolKey,
                     int24 tickLower,


### PR DESCRIPTION
Fixes #512

Foundry deprecated the `fuzz_runs` top-level config key in favor of 
`fuzz.runs`. This caused two warnings on every `forge test` run:

Warning: Found unknown `fuzz_runs` config for profile `ci` defined in foundry.toml
Warning: Found unknown `fuzz_runs` config for profile `default` defined in foundry.toml

Fix: replaced both occurrences with the correct `fuzz.runs` syntax.
No functional changes tests run identically.