### PR TITLE
feat(lens): add cross-chain v4 pool reserves lens

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -31,8 +31,10 @@ fuzz.runs = 100
 [profile.ci]
 fuzz_runs = 100_000
 
+# 50M matches geth's default eth_call gas cap (--rpc.gascap); the documented single-shot
+# ReservesLens call exceeds a 30M block-style limit by design (~33M for tick spacing 1)
 [profile.gas]
-gas_limit=30_000_000
+gas_limit=50_000_000
 
 [rpc_endpoints]
 sepolia = "https://rpc.sepolia.org"

--- a/script/DeployReservesLens.s.sol
+++ b/script/DeployReservesLens.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/console2.sol";
+import "forge-std/Script.sol";
+
+import {IReservesLens} from "../src/interfaces/IReservesLens.sol";
+import {ReservesLens} from "../src/lens/ReservesLens.sol";
+
+contract DeployReservesLens is Script {
+    address private constant CANONICAL_CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    function setUp() public {}
+
+    /// @notice Deploys through the cross-chain deterministic deployment proxy.
+    /// @dev Example: forge script --broadcast --sig 'run(bytes32)' --rpc-url <RPC_URL>
+    ///      --private-key <PRIV_KEY> script/DeployReservesLens.s.sol:DeployReservesLens <SALT>
+    function run(bytes32 salt) public returns (IReservesLens lens) {
+        bytes memory initcode = type(ReservesLens).creationCode;
+        address expected = _computeAddress(salt, keccak256(initcode));
+        require(CANONICAL_CREATE2_DEPLOYER.code.length != 0, "canonical CREATE2 deployer missing");
+
+        vm.startBroadcast();
+        if (expected.code.length == 0) {
+            (bool success,) = CANONICAL_CREATE2_DEPLOYER.call(abi.encodePacked(salt, initcode));
+            require(success && expected.code.length != 0, "ReservesLens deployment failed");
+        }
+        vm.stopBroadcast();
+
+        lens = IReservesLens(expected);
+        console2.log("ReservesLens", expected);
+        console2.logBytes32(keccak256(expected.code));
+    }
+
+    function _computeAddress(bytes32 salt, bytes32 initcodeHash) private pure returns (address) {
+        return address(
+            uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), CANONICAL_CREATE2_DEPLOYER, salt, initcodeHash))))
+        );
+    }
+}

--- a/scripts/reserves-lens-reference.ts
+++ b/scripts/reserves-lens-reference.ts
@@ -75,20 +75,18 @@ async function rpcBatch(data: string[]): Promise<string[]> {
         })),
       ),
     });
-    let results: Array<{ id: number; result?: string; error?: { message: string } }> | undefined;
+    const byId = new Map<number, string>();
     if (response.ok) {
       const payload = await response.json();
-      if (Array.isArray(payload)) results = payload;
+      if (Array.isArray(payload)) {
+        for (const entry of payload as Array<{ id?: number; result?: string }>) {
+          if (typeof entry?.id === "number" && typeof entry.result === "string") byId.set(entry.id, entry.result);
+        }
+      }
     }
-    if (!results) {
-      results = [];
-      for (let index = 0; index < chunk.length; index++) results.push(await rpcSingle(chunk[index], start + index));
-    }
-    results.sort((a, b) => a.id - b.id);
-    for (let index = 0; index < results.length; index++) {
-      const result = results[index];
-      if (result.result) output.push(result.result);
-      else output.push((await rpcSingle(chunk[index], start + index)).result);
+    for (let index = 0; index < chunk.length; index++) {
+      const id = start + index;
+      output.push(byId.get(id) ?? (await rpcSingle(chunk[index], id)).result);
     }
   }
   return output;

--- a/scripts/reserves-lens-reference.ts
+++ b/scripts/reserves-lens-reference.ts
@@ -11,7 +11,7 @@
  * ABI, deliberately independent of ReservesLens' raw-storage implementation.
  */
 
-const [, , rpcUrl, stateView, poolId, spacingArg, blockTag = "latest"] = process.argv;
+const [, , rpcUrl, stateView, poolId, spacingArg, blockTagArg = "latest"] = process.argv;
 if (!rpcUrl || !stateView || !poolId || !spacingArg) {
   throw new Error("expected: <rpc-url> <state-view> <pool-id> <tick-spacing> [block-tag]");
 }
@@ -20,6 +20,29 @@ const spacing = BigInt(spacingArg);
 if (spacing < 1n || spacing > 32767n) throw new Error("invalid tick spacing");
 if (!/^0x[0-9a-fA-F]{40}$/.test(stateView)) throw new Error("invalid StateView address");
 if (!/^0x[0-9a-fA-F]{64}$/.test(poolId)) throw new Error("invalid pool id");
+
+async function rpcRequest(method: string, params: unknown[]): Promise<unknown> {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json", "user-agent": "v4-reserves-lens-reference/1.0" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 0, method, params }),
+  });
+  if (!response.ok) throw new Error(`RPC HTTP ${response.status}`);
+  const value = (await response.json()) as { result?: unknown; error?: { message: string } };
+  if (value.result === undefined || value.result === null) throw new Error(value.error?.message ?? `${method} failed`);
+  return value.result;
+}
+
+// Pin floating tags ("latest", "safe", "finalized") to one concrete block. The reads below span thousands of
+// sequential eth_call batches; a new block arriving mid-run would tear the snapshot across blocks, producing
+// either spurious invariant failures or a silently inconsistent reference value.
+const blockTag = /^0x[0-9a-fA-F]+$/.test(blockTagArg)
+  ? blockTagArg
+  : ((await rpcRequest("eth_getBlockByNumber", [blockTagArg, false])) as { number: string }).number;
+
+// A valid eth_call result is one or more 32-byte words; bare "0x" means no contract code at the target.
+const isCallResult = (value: unknown): value is string =>
+  typeof value === "string" && value.startsWith("0x") && value.length > 2 && (value.length - 2) % 64 === 0;
 
 const MIN_TICK = -887272n;
 const MAX_TICK = 887272n;
@@ -51,7 +74,10 @@ async function rpcSingle(calldata: string, id: number): Promise<{ id: number; re
     });
     if (response.ok) {
       const value = (await response.json()) as { id: number; result?: string; error?: { message: string } };
-      if (value.result) return { id, result: value.result };
+      if (isCallResult(value.result)) return { id, result: value.result };
+      if (value.result === "0x") {
+        throw new Error(`eth_call returned no data — is a StateView contract deployed at ${stateView}?`);
+      }
       lastError = value.error?.message ?? lastError;
     } else lastError = `RPC HTTP ${response.status}`;
     await delay(250 * (attempt + 1));
@@ -80,7 +106,7 @@ async function rpcBatch(data: string[]): Promise<string[]> {
       const payload = await response.json();
       if (Array.isArray(payload)) {
         for (const entry of payload as Array<{ id?: number; result?: string }>) {
-          if (typeof entry?.id === "number" && typeof entry.result === "string") byId.set(entry.id, entry.result);
+          if (typeof entry?.id === "number" && isCallResult(entry.result)) byId.set(entry.id, entry.result);
         }
       }
     }

--- a/scripts/reserves-lens-reference.ts
+++ b/scripts/reserves-lens-reference.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+/**
+ * Dependency-free offchain reference for ReservesLens core amounts.
+ *
+ * Usage:
+ *   node scripts/reserves-lens-reference.ts \
+ *     <rpc-url> <state-view> <pool-id> <tick-spacing> [block-tag]
+ *
+ * Node 22+ runs this TypeScript directly. Reads go through the canonical StateView
+ * ABI, deliberately independent of ReservesLens' raw-storage implementation.
+ */
+
+const [, , rpcUrl, stateView, poolId, spacingArg, blockTag = "latest"] = process.argv;
+if (!rpcUrl || !stateView || !poolId || !spacingArg) {
+  throw new Error("expected: <rpc-url> <state-view> <pool-id> <tick-spacing> [block-tag]");
+}
+
+const spacing = BigInt(spacingArg);
+if (spacing < 1n || spacing > 32767n) throw new Error("invalid tick spacing");
+if (!/^0x[0-9a-fA-F]{40}$/.test(stateView)) throw new Error("invalid StateView address");
+if (!/^0x[0-9a-fA-F]{64}$/.test(poolId)) throw new Error("invalid pool id");
+
+const MIN_TICK = -887272n;
+const MAX_TICK = 887272n;
+const Q96 = 1n << 96n;
+const MAX_UINT256 = (1n << 256n) - 1n;
+const GET_SLOT0 = "c815641c";
+const GET_TICK_BITMAP = "1c7ccb4c";
+const GET_TICK_LIQUIDITY = "caedab54";
+const GET_LIQUIDITY = "fa6793d5";
+
+const word = (value: bigint) => (value < 0n ? (1n << 256n) + value : value).toString(16).padStart(64, "0");
+const callData = (selector: string, ...args: Array<bigint | string>) =>
+  `0x${selector}${args.map((arg) => (typeof arg === "string" ? arg.slice(2) : word(arg))).join("")}`;
+
+const delay = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function rpcSingle(calldata: string, id: number): Promise<{ id: number; result: string }> {
+  let lastError = "RPC call failed";
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json", "user-agent": "v4-reserves-lens-reference/1.0" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "eth_call",
+        params: [{ to: stateView, data: calldata }, blockTag],
+      }),
+    });
+    if (response.ok) {
+      const value = (await response.json()) as { id: number; result?: string; error?: { message: string } };
+      if (value.result) return { id, result: value.result };
+      lastError = value.error?.message ?? lastError;
+    } else lastError = `RPC HTTP ${response.status}`;
+    await delay(250 * (attempt + 1));
+  }
+  throw new Error(lastError);
+}
+
+async function rpcBatch(data: string[]): Promise<string[]> {
+  const output: string[] = [];
+  for (let start = 0; start < data.length; start += 10) {
+    const chunk = data.slice(start, start + 10);
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json", "user-agent": "v4-reserves-lens-reference/1.0" },
+      body: JSON.stringify(
+        chunk.map((calldata, index) => ({
+          jsonrpc: "2.0",
+          id: start + index,
+          method: "eth_call",
+          params: [{ to: stateView, data: calldata }, blockTag],
+        })),
+      ),
+    });
+    let results: Array<{ id: number; result?: string; error?: { message: string } }> | undefined;
+    if (response.ok) {
+      const payload = await response.json();
+      if (Array.isArray(payload)) results = payload;
+    }
+    if (!results) {
+      results = [];
+      for (let index = 0; index < chunk.length; index++) results.push(await rpcSingle(chunk[index], start + index));
+    }
+    results.sort((a, b) => a.id - b.id);
+    for (let index = 0; index < results.length; index++) {
+      const result = results[index];
+      if (result.result) output.push(result.result);
+      else output.push((await rpcSingle(chunk[index], start + index)).result);
+    }
+  }
+  return output;
+}
+
+const signed = (value: bigint, bits: bigint) => {
+  const sign = 1n << (bits - 1n);
+  return value & sign ? value - (1n << bits) : value;
+};
+const outputWord = (data: string, index: number) => BigInt(`0x${data.slice(2 + index * 64, 2 + (index + 1) * 64)}`);
+
+function sqrtAtTick(tick: bigint): bigint {
+  const absTick = tick < 0n ? -tick : tick;
+  if (absTick > MAX_TICK) throw new Error(`tick out of range: ${tick}`);
+  const constants = [
+    0xfffcb933bd6fad37aa2d162d1a594001n, 0xfff97272373d413259a46990580e213an,
+    0xfff2e50f5f656932ef12357cf3c7fdccn, 0xffe5caca7e10e4e61c3624eaa0941cd0n,
+    0xffcb9843d60f6159c9db58835c926644n, 0xff973b41fa98c081472e6896dfb254c0n,
+    0xff2ea16466c96a3843ec78b326b52861n, 0xfe5dee046a99a2a811c461f1969c3053n,
+    0xfcbe86c7900a88aedcffc83b479aa3a4n, 0xf987a7253ac413176f2b074cf7815e54n,
+    0xf3392b0822b70005940c7a398e4b70f3n, 0xe7159475a2c29b7443b29c7fa6e889d9n,
+    0xd097f3bdfd2022b8845ad8f792aa5825n, 0xa9f746462d870fdf8a65dc1f90e061e5n,
+    0x70d869a156d2a1b890bb3df62baf32f7n, 0x31be135f97d08fd981231505542fcfa6n,
+    0x9aa508b5b7a84e1c677de54f3e99bc9n, 0x5d6af8dedb81196699c329225ee604n,
+    0x2216e584f5fa1ea926041bedfe98n, 0x48a170391f7dc42444e8fa2n,
+  ];
+  let price = 1n << 128n;
+  for (let bit = 0; bit < constants.length; bit++) {
+    if ((absTick & (1n << BigInt(bit))) !== 0n) price = (price * constants[bit]) >> 128n;
+  }
+  if (tick > 0n) price = MAX_UINT256 / price;
+  return (price + (1n << 32n) - 1n) >> 32n;
+}
+
+const amount0 = (sqrtA: bigint, sqrtB: bigint, liquidity: bigint) => {
+  if (sqrtA > sqrtB) [sqrtA, sqrtB] = [sqrtB, sqrtA];
+  return (((liquidity << 96n) * (sqrtB - sqrtA)) / sqrtB) / sqrtA;
+};
+const amount1 = (sqrtA: bigint, sqrtB: bigint, liquidity: bigint) => {
+  if (sqrtA > sqrtB) [sqrtA, sqrtB] = [sqrtB, sqrtA];
+  return (liquidity * (sqrtB - sqrtA)) / Q96;
+};
+
+const [slot0, liquidityOutput] = await rpcBatch([callData(GET_SLOT0, poolId), callData(GET_LIQUIDITY, poolId)]);
+const sqrtPriceX96 = outputWord(slot0, 0);
+const currentTick = signed(outputWord(slot0, 1) & ((1n << 24n) - 1n), 24n);
+const storedActive = outputWord(liquidityOutput, 0);
+if (sqrtPriceX96 === 0n) throw new Error("pool is not initialized");
+
+const minUsable = (MIN_TICK / spacing) * spacing;
+const maxUsable = (MAX_TICK / spacing) * spacing;
+const minWord = (minUsable / spacing) >> 8n;
+const maxWord = (maxUsable / spacing) >> 8n;
+const bitmapCalls: string[] = [];
+for (let position = minWord; position <= maxWord; position++) {
+  bitmapCalls.push(callData(GET_TICK_BITMAP, poolId, position));
+}
+const bitmaps = await rpcBatch(bitmapCalls);
+
+const ticks: bigint[] = [];
+for (let index = 0; index < bitmaps.length; index++) {
+  let bitmap = outputWord(bitmaps[index], 0);
+  const position = minWord + BigInt(index);
+  for (let bit = 0n; bitmap !== 0n; bit++) {
+    if ((bitmap & 1n) !== 0n) ticks.push((position * 256n + bit) * spacing);
+    bitmap >>= 1n;
+  }
+}
+const tickWords = await rpcBatch(ticks.map((tick) => callData(GET_TICK_LIQUIDITY, poolId, tick)));
+
+let running = 0n;
+let previous: bigint | undefined;
+let coreAmount0 = 0n;
+let coreAmount1 = 0n;
+let reconstructedActive = 0n;
+for (let index = 0; index < ticks.length; index++) {
+  const gross = outputWord(tickWords[index], 0) & ((1n << 128n) - 1n);
+  const net = signed(outputWord(tickWords[index], 1) & ((1n << 128n) - 1n), 128n);
+  if (gross === 0n) throw new Error(`bitmap/tick mismatch at ${ticks[index]}`);
+  if (net === 0n) continue;
+  const tick = ticks[index];
+  if (previous !== undefined) {
+    if (currentTick >= previous && currentTick < tick) reconstructedActive = running;
+    if (running !== 0n) {
+      const sqrtA = sqrtAtTick(previous);
+      const sqrtB = sqrtAtTick(tick);
+      if (currentTick < previous) coreAmount0 += amount0(sqrtA, sqrtB, running);
+      else if (currentTick < tick) {
+        coreAmount0 += amount0(sqrtPriceX96, sqrtB, running);
+        coreAmount1 += amount1(sqrtA, sqrtPriceX96, running);
+      } else coreAmount1 += amount1(sqrtA, sqrtB, running);
+    }
+  }
+  running += net;
+  if (running < 0n) throw new Error(`negative running liquidity at ${tick}`);
+  previous = tick;
+}
+if (running !== 0n) throw new Error("final running liquidity is non-zero");
+if (reconstructedActive !== storedActive) throw new Error("reconstructed active liquidity does not match StateView");
+
+console.log(
+  JSON.stringify(
+    {
+      blockTag,
+      poolId,
+      tickSpacing: spacing.toString(),
+      sqrtPriceX96: sqrtPriceX96.toString(),
+      tick: currentTick.toString(),
+      activeLiquidity: reconstructedActive.toString(),
+      coreAmount0: coreAmount0.toString(),
+      coreAmount1: coreAmount1.toString(),
+      initializedTicks: ticks.length,
+    },
+    null,
+    2,
+  ),
+);

--- a/snapshots/ReservesLensGasTest.json
+++ b/snapshots/ReservesLensGasTest.json
@@ -1,6 +1,6 @@
 {
-  "ReservesLens initcode hash (as uint256)": "4159793417869786952628488771894068776849272484226774657078810442256315282473",
-  "ReservesLens_Bytecode": "13401",
-  "ReservesLens_empty_tickSpacingOne_page512": "2079695",
-  "ReservesLens_empty_tickSpacingOne_singleShot": "33302194"
+  "ReservesLens initcode hash (as uint256)": "74070654346721130412083078172635237849460563382062333419096350316944070206397",
+  "ReservesLens_Bytecode": "13565",
+  "ReservesLens_empty_tickSpacingOne_page512": "2072499",
+  "ReservesLens_empty_tickSpacingOne_singleShot": "33301522"
 }

--- a/snapshots/ReservesLensGasTest.json
+++ b/snapshots/ReservesLensGasTest.json
@@ -1,6 +1,6 @@
 {
   "ReservesLens initcode hash (as uint256)": "45608651080114521430260486104576980152518983087610011566070495558713560855202",
   "ReservesLens_Bytecode": "13864",
-  "ReservesLens_empty_tickSpacingOne_page512": "2021285",
-  "ReservesLens_empty_tickSpacingOne_singleShot": "31645962"
+  "ReservesLens_empty_tickSpacingOne_page512": "2025785",
+  "ReservesLens_empty_tickSpacingOne_singleShot": "31650462"
 }

--- a/snapshots/ReservesLensGasTest.json
+++ b/snapshots/ReservesLensGasTest.json
@@ -1,6 +1,6 @@
 {
-  "ReservesLens initcode hash (as uint256)": "74070654346721130412083078172635237849460563382062333419096350316944070206397",
-  "ReservesLens_Bytecode": "13565",
-  "ReservesLens_empty_tickSpacingOne_page512": "2072499",
-  "ReservesLens_empty_tickSpacingOne_singleShot": "33301522"
+  "ReservesLens initcode hash (as uint256)": "45608651080114521430260486104576980152518983087610011566070495558713560855202",
+  "ReservesLens_Bytecode": "13864",
+  "ReservesLens_empty_tickSpacingOne_page512": "2021285",
+  "ReservesLens_empty_tickSpacingOne_singleShot": "31645962"
 }

--- a/snapshots/ReservesLensGasTest.json
+++ b/snapshots/ReservesLensGasTest.json
@@ -1,0 +1,6 @@
+{
+  "ReservesLens initcode hash (as uint256)": "4159793417869786952628488771894068776849272484226774657078810442256315282473",
+  "ReservesLens_Bytecode": "13401",
+  "ReservesLens_empty_tickSpacingOne_page512": "2079695",
+  "ReservesLens_empty_tickSpacingOne_singleShot": "33302194"
+}

--- a/src/interfaces/IReservesLens.sol
+++ b/src/interfaces/IReservesLens.sol
@@ -71,12 +71,10 @@ interface IReservesLens {
     /// @notice Thrown when a paged-call work budget is outside supported bounds
     error InvalidScanBudget(uint32 maxReads);
 
-    /// @notice Thrown when a PoolManager storage read fails or has an invalid response size
-    error ManagerReadFailed(address manager, bytes32 slot);
-
-    /// @notice Thrown when a batched PoolManager storage read fails or has an invalid response size
-    /// @dev Batch reads fail atomically; firstSlot, lastSlot, and slotCount describe the whole failed batch
-    error ManagerBatchReadFailed(address manager, bytes32 firstSlot, bytes32 lastSlot, uint256 slotCount);
+    /// @notice Thrown when remaining gas cannot guarantee the hook-stats gas stipend after the EIP-150 63/64 reduction
+    /// @dev Without this check a healthy provider could be gas-starved and misreported as CALL_FAILED, making the
+    ///      reported status depend on the caller's gas budget instead of on-chain state. Retry with more gas.
+    error InsufficientGasForHookStats();
 
     /// @notice Thrown when reconstructed liquidity is inconsistent with PoolManager state
     error LiquidityInvariantFailed(PoolId poolId);
@@ -100,9 +98,10 @@ interface IReservesLens {
     error InputLengthMismatch();
 
     /// @notice Computes the complete pool snapshot in one call
-    /// @dev The full initialized-tick domain is scanned. Bitmap-word reads alone cost ~33M gas for a tick-spacing-one
-    ///      pool even when it is empty, which exceeds the common 30M eth_call cap; use getPoolTVLPaged for small tick
-    ///      spacings or providers with low simulation gas limits.
+    /// @dev The full initialized-tick domain is scanned. Bitmap-word reads alone cost ~32M gas for a tick-spacing-one
+    ///      pool even when it is empty, which exceeds a 30M block-style gas limit (though most providers cap eth_call
+    ///      higher, e.g. geth's 50M default); use getPoolTVLPaged for small tick spacings or providers with low
+    ///      simulation gas limits.
     /// @param manager PoolManager whose state is read. The caller is responsible for selecting the canonical manager.
     /// @param key Complete pool key emitted by PoolManager.Initialize
     /// @param statsProvider Optional external URC-3 provider, or address(0) to probe the hook directly

--- a/src/interfaces/IReservesLens.sol
+++ b/src/interfaces/IReservesLens.sol
@@ -74,6 +74,10 @@ interface IReservesLens {
     /// @notice Thrown when a PoolManager storage read fails or has an invalid response size
     error ManagerReadFailed(address manager, bytes32 slot);
 
+    /// @notice Thrown when a batched PoolManager storage read fails or has an invalid response size
+    /// @dev Batch reads fail atomically; firstSlot, lastSlot, and slotCount describe the whole failed batch
+    error ManagerBatchReadFailed(address manager, bytes32 firstSlot, bytes32 lastSlot, uint256 slotCount);
+
     /// @notice Thrown when reconstructed liquidity is inconsistent with PoolManager state
     error LiquidityInvariantFailed(PoolId poolId);
 
@@ -96,8 +100,9 @@ interface IReservesLens {
     error InputLengthMismatch();
 
     /// @notice Computes the complete pool snapshot in one call
-    /// @dev The full initialized-tick domain is scanned. A tick-spacing-one pool can exceed a 30M gas RPC limit even
-    ///      when sparse; callers must fall back to getPoolTVLPaged when the single call exceeds their provider cap.
+    /// @dev The full initialized-tick domain is scanned. Bitmap-word reads alone cost ~33M gas for a tick-spacing-one
+    ///      pool even when it is empty, which exceeds the common 30M eth_call cap; use getPoolTVLPaged for small tick
+    ///      spacings or providers with low simulation gas limits.
     /// @param manager PoolManager whose state is read. The caller is responsible for selecting the canonical manager.
     /// @param key Complete pool key emitted by PoolManager.Initialize
     /// @param statsProvider Optional external URC-3 provider, or address(0) to probe the hook directly

--- a/src/interfaces/IReservesLens.sol
+++ b/src/interfaces/IReservesLens.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+/// @title ReservesLens interface
+/// @notice Computes the token amounts represented by a v4 pool's aggregate core liquidity curve
+/// @dev Core amounts are liquidity principal at the current price. They exclude uncollected LP fees, protocol fees,
+///      donations, and hook-managed assets. Hook-reported reserves and effective liquidity are returned separately and
+///      must not be treated as core-derived values. Calls are intended to use an explicit RPC block tag when results are
+///      stored or compared over time.
+interface IReservesLens {
+    /// @notice Status of optional URC-3 hook statistics
+    enum HookStatsStatus {
+        NO_HOOK,
+        NOT_SUPPORTED,
+        DIRECT,
+        EXTERNAL,
+        INVALID_PROVIDER,
+        CALL_FAILED,
+        INVALID_RESPONSE
+    }
+
+    /// @notice Complete pool liquidity-TVL snapshot
+    struct PoolTVL {
+        /// @notice Fee-excluded token0 principal derived from PoolManager liquidity state
+        uint256 coreAmount0;
+        /// @notice Fee-excluded token1 principal derived from PoolManager liquidity state
+        uint256 coreAmount1;
+        /// @notice Hook-reported token0 assets under management; meaningful only for DIRECT or EXTERNAL status
+        uint256 hookReserves0;
+        /// @notice Hook-reported token1 assets under management; meaningful only for DIRECT or EXTERNAL status
+        uint256 hookReserves1;
+        /// @notice Hook-reported token0 liquidity immediately available to swap
+        uint256 hookEffective0;
+        /// @notice Hook-reported token1 liquidity immediately available to swap
+        uint256 hookEffective1;
+        /// @notice Pool sqrt price used for the core calculation
+        uint160 sqrtPriceX96;
+        /// @notice Pool tick used for the core calculation
+        int24 tick;
+        /// @notice Active core liquidity stored by PoolManager
+        uint128 activeLiquidity;
+        /// @notice Block number at which this snapshot was evaluated
+        uint256 blockNumber;
+        /// @notice URC-3 provider queried for hook statistics, if any
+        address statsProvider;
+        /// @notice The fourteen v4 permission bits decoded from the hook address
+        uint16 hookPermissions;
+        /// @notice Whether any return-delta permission bit permits custom accounting
+        bool hasCustomAccounting;
+        /// @notice Availability and provenance of the hook-reported fields
+        HookStatsStatus statsStatus;
+    }
+
+    /// @notice Initialized tick data compatible with the v3 TickLens field layout
+    struct PopulatedTick {
+        int24 tick;
+        int128 liquidityNet;
+        uint128 liquidityGross;
+    }
+
+    /// @notice Thrown when the pool identified by the supplied key is not initialized
+    error PoolNotInitialized(PoolId poolId);
+
+    /// @notice Thrown when tick spacing is outside v4-core bounds
+    error InvalidTickSpacing(int24 tickSpacing);
+
+    /// @notice Thrown when a paged-call work budget is outside supported bounds
+    error InvalidScanBudget(uint32 maxReads);
+
+    /// @notice Thrown when a PoolManager storage read fails or has an invalid response size
+    error ManagerReadFailed(address manager, bytes32 slot);
+
+    /// @notice Thrown when reconstructed liquidity is inconsistent with PoolManager state
+    error LiquidityInvariantFailed(PoolId poolId);
+
+    /// @notice Thrown when an initialized tick is inconsistent with its bitmap entry or pool bounds
+    error TickInvariantFailed(PoolId poolId, int256 tick);
+
+    /// @notice Thrown when a continuation cursor has an invalid encoding
+    error InvalidCursor();
+
+    /// @notice Thrown when a continuation cursor version is unsupported
+    error UnsupportedCursorVersion(uint8 version);
+
+    /// @notice Thrown when a cursor is used with a different manager or pool
+    error CursorContextMismatch();
+
+    /// @notice Thrown when pages are evaluated at different blocks
+    error CursorBlockMismatch(uint256 expected, uint256 actual);
+
+    /// @notice Thrown when parallel batch inputs have different lengths
+    error InputLengthMismatch();
+
+    /// @notice Computes the complete pool snapshot in one call
+    /// @dev The full initialized-tick domain is scanned. A tick-spacing-one pool can exceed a 30M gas RPC limit even
+    ///      when sparse; callers must fall back to getPoolTVLPaged when the single call exceeds their provider cap.
+    /// @param manager PoolManager whose state is read. The caller is responsible for selecting the canonical manager.
+    /// @param key Complete pool key emitted by PoolManager.Initialize
+    /// @param statsProvider Optional external URC-3 provider, or address(0) to probe the hook directly
+    /// @return result Fee-excluded core amounts and separately labeled optional hook statistics
+    function getPoolTVL(IPoolManager manager, PoolKey calldata key, address statsProvider)
+        external
+        view
+        returns (PoolTVL memory result);
+
+    /// @notice Computes complete snapshots for multiple pools on one PoolManager
+    /// @dev One expensive pool reverts the complete batch. Prefer independent RPC calls for large or untrusted batches.
+    /// @param manager PoolManager whose state is read
+    /// @param keys Complete pool keys
+    /// @param statsProviders One optional URC-3 provider per key; use address(0) to probe each hook directly
+    function getPoolTVLBatch(IPoolManager manager, PoolKey[] calldata keys, address[] calldata statsProviders)
+        external
+        view
+        returns (PoolTVL[] memory results);
+
+    /// @notice Returns all initialized ticks in one compressed bitmap word
+    /// @dev Field layout mirrors v3 TickLens, adapted to a v4 PoolManager and PoolKey.
+    function getPopulatedTicksInWord(IPoolManager manager, PoolKey calldata key, int16 wordPos)
+        external
+        view
+        returns (PopulatedTick[] memory populatedTicks);
+
+    /// @notice Computes a bounded portion of a pool snapshot
+    /// @dev Pass an empty cursor to start and pass returned cursors unchanged. All pages must use the same explicit block
+    ///      tag. Intermediate results are incomplete and must not be treated as TVL. Cursor provenance cannot be
+    ///      authenticated by this stateless contract, so pagination is intended for offchain callers.
+    /// @param manager PoolManager whose state is read
+    /// @param key Complete pool key emitted by PoolManager.Initialize
+    /// @param statsProvider Optional external URC-3 provider, or address(0) to probe the hook directly
+    /// @param cursor Empty to start or the exact opaque cursor returned by the prior page
+    /// @param maxReads Approximate bitmap/tick storage-read work budget for this page
+    /// @return result Complete only when done is true
+    /// @return nextCursor Opaque continuation cursor, empty when done is true
+    /// @return done Whether the complete result has been produced
+    function getPoolTVLPaged(
+        IPoolManager manager,
+        PoolKey calldata key,
+        address statsProvider,
+        bytes calldata cursor,
+        uint32 maxReads
+    ) external view returns (PoolTVL memory result, bytes memory nextCursor, bool done);
+}

--- a/src/interfaces/external/IHookStats.sol
+++ b/src/interfaces/external/IHookStats.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+/// @title Hook statistics interface
+/// @notice URC-3 interface for hook-managed reserves and immediately available liquidity
+interface IHookStats is IERC165 {
+    /// @notice Returns total reserves managed by the hook for a pool
+    function getReserves(PoolKey calldata key) external view returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Returns hook-managed assets immediately available for swapping
+    function getEffectiveLiquidity(PoolKey calldata key) external view returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Returns the hook whose statistics this contract reports
+    function hook() external view returns (address);
+}

--- a/src/lens/ReservesLens.sol
+++ b/src/lens/ReservesLens.sol
@@ -12,16 +12,6 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {IReservesLens} from "../interfaces/IReservesLens.sol";
 import {IHookStats} from "../interfaces/external/IHookStats.sol";
 
-/// @notice Single-overload views of IExtsload so selectors are compile-time-checked; Solidity cannot
-///         disambiguate the overloaded extsload members for .selector or abi.encodeCall
-interface IExtsloadWord {
-    function extsload(bytes32 slot) external view returns (bytes32 value);
-}
-
-interface IExtsloadSparse {
-    function extsload(bytes32[] calldata slots) external view returns (bytes32[] memory values);
-}
-
 /// @title ReservesLens
 /// @notice Stateless view contract for v4 core liquidity TVL and optional URC-3 hook statistics
 /// @dev Reconstructs the aggregate liquidity curve by walking initialized ticks in ascending order, applying each
@@ -32,6 +22,7 @@ interface IExtsloadSparse {
 ///      PoolManager and obtaining the complete PoolKey from its Initialize event.
 contract ReservesLens is IReservesLens {
     using PoolIdLibrary for PoolKey;
+    using StateLibrary for IPoolManager;
 
     uint8 private constant CURSOR_VERSION = 1;
     uint256 private constant CURSOR_LENGTH = 15 * 32;
@@ -96,7 +87,7 @@ contract ReservesLens is IReservesLens {
     {
         PoolId poolId = key.toId();
         _initialize(manager, key.tickSpacing, poolId);
-        uint256 bitmap = uint256(_readWord(address(manager), _tickBitmapSlot(poolId, wordPos)));
+        uint256 bitmap = manager.getTickBitmap(poolId, wordPos);
         uint256 remaining = bitmap;
         uint256 count;
         while (remaining != 0) {
@@ -165,19 +156,10 @@ contract ReservesLens is IReservesLens {
             revert InvalidTickSpacing(tickSpacing);
         }
 
-        bytes32 poolStateSlot = _poolStateSlot(poolId);
-        bytes32 slot0 = _readWord(address(manager), poolStateSlot);
-        uint160 sqrtPriceX96;
-        int24 currentTick;
-        assembly ("memory-safe") {
-            sqrtPriceX96 := and(slot0, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-            currentTick := signextend(2, shr(160, slot0))
-        }
+        (uint160 sqrtPriceX96, int24 currentTick,,) = manager.getSlot0(poolId);
         if (sqrtPriceX96 == 0) revert PoolNotInitialized(poolId);
 
-        uint128 activeLiquidity = uint128(
-            uint256(_readWord(address(manager), bytes32(uint256(poolStateSlot) + StateLibrary.LIQUIDITY_OFFSET)))
-        );
+        uint128 activeLiquidity = manager.getLiquidity(poolId);
         int24 minCompressed = TickMath.minUsableTick(tickSpacing) / tickSpacing;
 
         state = ScanState({
@@ -204,34 +186,20 @@ contract ReservesLens is IReservesLens {
         view
         returns (ScanState memory, bool done)
     {
-        int24 maxTick = TickMath.maxUsableTick(tickSpacing);
-        int16 maxWord = int16((maxTick / tickSpacing) >> 8);
+        int16 maxWord = _maxWord(tickSpacing);
         uint32 reads;
 
         while (state.wordPos <= maxWord) {
             if (reads >= maxReads) return (state, false);
 
-            uint256 bitmap = uint256(_readWord(address(manager), _tickBitmapSlot(poolId, state.wordPos)));
+            uint256 bitmap = manager.getTickBitmap(poolId, state.wordPos);
             reads++;
-
-            if (state.bitPos == 256) {
-                state.wordPos = int16(int256(state.wordPos) + 1);
-                state.bitPos = 0;
-                continue;
-            }
+            // resume mid-word; a shift of 256 yields zero, so a bitPos-256 cursor skips the word entirely
             if (state.bitPos != 0) bitmap &= type(uint256).max << state.bitPos;
 
-            while (bitmap != 0) {
-                uint8 bit = BitMath.leastSignificantBit(bitmap);
-                if (reads >= maxReads) {
-                    state.bitPos = bit;
-                    return (state, false);
-                }
-                _processInitializedTick(manager, tickSpacing, poolId, state, bit);
-                reads++;
-                bitmap &= bitmap - 1;
-                state.bitPos = uint16(bit) + 1;
-            }
+            bool wordDone;
+            (reads, wordDone) = _processWord(manager, tickSpacing, poolId, state, bitmap, reads, maxReads);
+            if (!wordDone) return (state, false);
 
             state.wordPos = int16(int256(state.wordPos) + 1);
             state.bitPos = 0;
@@ -246,8 +214,7 @@ contract ReservesLens is IReservesLens {
         view
         returns (ScanState memory)
     {
-        int24 maxTick = TickMath.maxUsableTick(tickSpacing);
-        int16 maxWord = int16((maxTick / tickSpacing) >> 8);
+        int16 maxWord = _maxWord(tickSpacing);
         int256 nextWord = state.wordPos;
 
         while (nextWord <= maxWord) {
@@ -257,16 +224,11 @@ contract ReservesLens is IReservesLens {
             for (uint256 i; i < count; i++) {
                 slots[i] = _tickBitmapSlot(poolId, int16(nextWord + int256(i)));
             }
-            bytes32[] memory bitmaps = _readWords(address(manager), slots);
+            bytes32[] memory bitmaps = manager.extsload(slots);
 
             for (uint256 i; i < count; i++) {
                 state.wordPos = int16(nextWord + int256(i));
-                uint256 bitmap = uint256(bitmaps[i]);
-                while (bitmap != 0) {
-                    uint8 bit = BitMath.leastSignificantBit(bitmap);
-                    _processInitializedTick(manager, tickSpacing, poolId, state, bit);
-                    bitmap &= bitmap - 1;
-                }
+                _processWord(manager, tickSpacing, poolId, state, uint256(bitmaps[i]), 0, type(uint32).max);
             }
             nextWord += int256(count);
         }
@@ -275,6 +237,35 @@ contract ReservesLens is IReservesLens {
         state.bitPos = 0;
         _validateComplete(poolId, state);
         return state;
+    }
+
+    /// @dev Processes every initialized tick in one bitmap word, charging one read per tick against the budget.
+    ///      Returns done=false with state.bitPos positioned on the unprocessed bit when the budget is exhausted.
+    function _processWord(
+        IPoolManager manager,
+        int24 tickSpacing,
+        PoolId poolId,
+        ScanState memory state,
+        uint256 bitmap,
+        uint32 reads,
+        uint32 maxReads
+    ) private view returns (uint32, bool done) {
+        while (bitmap != 0) {
+            uint8 bit = BitMath.leastSignificantBit(bitmap);
+            if (reads >= maxReads) {
+                state.bitPos = bit;
+                return (reads, false);
+            }
+            _processInitializedTick(manager, tickSpacing, poolId, state, bit);
+            reads++;
+            bitmap &= bitmap - 1;
+            state.bitPos = uint16(bit) + 1;
+        }
+        return (reads, true);
+    }
+
+    function _maxWord(int24 tickSpacing) private pure returns (int16) {
+        return int16((TickMath.maxUsableTick(tickSpacing) / tickSpacing) >> 8);
     }
 
     function _validateComplete(PoolId poolId, ScanState memory state) private pure {
@@ -349,11 +340,7 @@ contract ReservesLens is IReservesLens {
         view
         returns (uint128 liquidityGross, int128 liquidityNet)
     {
-        bytes32 tickWord = _readWord(address(manager), _tickInfoSlot(poolId, tick));
-        assembly ("memory-safe") {
-            liquidityGross := and(tickWord, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-            liquidityNet := signextend(15, shr(128, tickWord))
-        }
+        (liquidityGross, liquidityNet) = manager.getTickLiquidity(poolId, tick);
         if (liquidityGross == 0) revert TickInvariantFailed(poolId, tick);
     }
 
@@ -386,7 +373,7 @@ contract ReservesLens is IReservesLens {
         }
 
         (StaticCallStatus hookStatus, bytes32 hookWord,) =
-            _boundedStaticcall(provider, HOOK_STATS_GAS_LIMIT, abi.encodeCall(IHookStats.hook, ()), 32);
+            _boundedStaticcall(provider, abi.encodeCall(IHookStats.hook, ()), 32);
         if (hookStatus != StaticCallStatus.SUCCESS) {
             result.statsStatus = _hookFailureStatus(hookStatus);
             return;
@@ -398,15 +385,14 @@ contract ReservesLens is IReservesLens {
         }
 
         (StaticCallStatus reservesStatus, bytes32 reserves0, bytes32 reserves1) =
-            _boundedStaticcall(provider, HOOK_STATS_GAS_LIMIT, abi.encodeCall(IHookStats.getReserves, (key)), 64);
+            _boundedStaticcall(provider, abi.encodeCall(IHookStats.getReserves, (key)), 64);
         if (reservesStatus != StaticCallStatus.SUCCESS) {
             result.statsStatus = _hookFailureStatus(reservesStatus);
             return;
         }
 
-        (StaticCallStatus effectiveStatus, bytes32 effective0, bytes32 effective1) = _boundedStaticcall(
-            provider, HOOK_STATS_GAS_LIMIT, abi.encodeCall(IHookStats.getEffectiveLiquidity, (key)), 64
-        );
+        (StaticCallStatus effectiveStatus, bytes32 effective0, bytes32 effective1) =
+            _boundedStaticcall(provider, abi.encodeCall(IHookStats.getEffectiveLiquidity, (key)), 64);
         if (effectiveStatus != StaticCallStatus.SUCCESS) {
             result.statsStatus = _hookFailureStatus(effectiveStatus);
             return;
@@ -432,59 +418,23 @@ contract ReservesLens is IReservesLens {
         return status == StaticCallStatus.FAILED ? HookStatsStatus.CALL_FAILED : HookStatsStatus.INVALID_RESPONSE;
     }
 
-    function _readWord(address manager, bytes32 slot) private view returns (bytes32 value) {
-        bytes memory input = abi.encodeCall(IExtsloadWord.extsload, (slot));
-        (StaticCallStatus status, bytes32 word,) = _boundedStaticcall(manager, gasleft(), input, 32);
-        if (status != StaticCallStatus.SUCCESS) revert ManagerReadFailed(manager, slot);
-        return word;
-    }
-
-    function _readWords(address manager, bytes32[] memory slots) private view returns (bytes32[] memory values) {
-        bytes memory input = abi.encodeCall(IExtsloadSparse.extsload, (slots));
-        uint256 expectedSize = 64 + slots.length * 32;
-        bytes memory output = new bytes(expectedSize);
-        bool success;
-        uint256 returnSize;
-        assembly ("memory-safe") {
-            success := staticcall(gas(), manager, add(input, 0x20), mload(input), add(output, 0x20), expectedSize)
-            returnSize := returndatasize()
-        }
-        if (!success || returnSize != expectedSize) {
-            revert ManagerBatchReadFailed(manager, slots[0], slots[slots.length - 1], slots.length);
-        }
-
-        uint256 offset;
-        uint256 length;
-        assembly ("memory-safe") {
-            offset := mload(add(output, 0x20))
-            length := mload(add(output, 0x40))
-        }
-        if (offset != 32 || length != slots.length) {
-            revert ManagerBatchReadFailed(manager, slots[0], slots[slots.length - 1], slots.length);
-        }
-
-        values = new bytes32[](length);
-        for (uint256 i; i < length; i++) {
-            bytes32 word;
-            assembly ("memory-safe") {
-                word := mload(add(add(output, 0x60), mul(i, 0x20)))
-            }
-            values[i] = word;
-        }
-    }
-
-    function _boundedStaticcall(address target, uint256 gasLimit, bytes memory input, uint256 expectedSize)
+    /// @dev Bounds untrusted provider calls to HOOK_STATS_GAS_LIMIT so a malicious provider cannot consume the
+    ///      caller's whole budget. EIP-150 forwards at most 63/64 of remaining gas, so the requested limit is only
+    ///      honored when enough gas remains; revert rather than let a starved provider be misclassified as CALL_FAILED.
+    function _boundedStaticcall(address target, bytes memory input, uint256 expectedSize)
         private
         view
         returns (StaticCallStatus status, bytes32 word0, bytes32 word1)
     {
+        if (gasleft() < (HOOK_STATS_GAS_LIMIT * 64) / 63 + 1_000) revert InsufficientGasForHookStats();
+
         bool success;
         uint256 returnSize;
         assembly ("memory-safe") {
             let output := mload(0x40)
             mstore(output, 0)
             mstore(add(output, 0x20), 0)
-            success := staticcall(gasLimit, target, add(input, 0x20), mload(input), output, 0x40)
+            success := staticcall(HOOK_STATS_GAS_LIMIT, target, add(input, 0x20), mload(input), output, 0x40)
             returnSize := returndatasize()
             word0 := mload(output)
             word1 := mload(add(output, 0x20))
@@ -498,17 +448,10 @@ contract ReservesLens is IReservesLens {
         return keccak256(abi.encode(address(manager), PoolId.unwrap(poolId)));
     }
 
-    function _poolStateSlot(PoolId poolId) private pure returns (bytes32) {
-        return keccak256(abi.encodePacked(PoolId.unwrap(poolId), StateLibrary.POOLS_SLOT));
-    }
-
+    /// @dev Raw slot for pools[poolId].tickBitmap[wordPos], for the batched extsload in _scanComplete; single-word
+    ///      reads go through StateLibrary getters instead
     function _tickBitmapSlot(PoolId poolId, int16 wordPos) private pure returns (bytes32) {
-        bytes32 mappingSlot = bytes32(uint256(_poolStateSlot(poolId)) + StateLibrary.TICK_BITMAP_OFFSET);
+        bytes32 mappingSlot = bytes32(uint256(StateLibrary._getPoolStateSlot(poolId)) + StateLibrary.TICK_BITMAP_OFFSET);
         return keccak256(abi.encodePacked(int256(wordPos), mappingSlot));
-    }
-
-    function _tickInfoSlot(PoolId poolId, int24 tick) private pure returns (bytes32) {
-        bytes32 mappingSlot = bytes32(uint256(_poolStateSlot(poolId)) + StateLibrary.TICKS_OFFSET);
-        return keccak256(abi.encodePacked(int256(tick), mappingSlot));
     }
 }

--- a/src/lens/ReservesLens.sol
+++ b/src/lens/ReservesLens.sol
@@ -12,6 +12,16 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {IReservesLens} from "../interfaces/IReservesLens.sol";
 import {IHookStats} from "../interfaces/external/IHookStats.sol";
 
+/// @notice Single-overload views of IExtsload so selectors are compile-time-checked; Solidity cannot
+///         disambiguate the overloaded extsload members for .selector or abi.encodeCall
+interface IExtsloadWord {
+    function extsload(bytes32 slot) external view returns (bytes32 value);
+}
+
+interface IExtsloadSparse {
+    function extsload(bytes32[] calldata slots) external view returns (bytes32[] memory values);
+}
+
 /// @title ReservesLens
 /// @notice Stateless view contract for v4 core liquidity TVL and optional URC-3 hook statistics
 /// @dev Reconstructs the aggregate liquidity curve by walking initialized ticks in ascending order, applying each
@@ -31,8 +41,6 @@ contract ReservesLens is IReservesLens {
     uint256 private constant HOOK_STATS_GAS_LIMIT = 500_000;
     uint160 private constant ALL_HOOK_MASK = (1 << 14) - 1;
     uint16 private constant CUSTOM_ACCOUNTING_MASK = (1 << 4) - 1;
-    bytes4 private constant EXTSLOAD_SELECTOR = bytes4(keccak256("extsload(bytes32)"));
-    bytes4 private constant EXTSLOAD_SPARSE_SELECTOR = bytes4(keccak256("extsload(bytes32[])"));
 
     struct ScanState {
         uint8 version;
@@ -425,14 +433,14 @@ contract ReservesLens is IReservesLens {
     }
 
     function _readWord(address manager, bytes32 slot) private view returns (bytes32 value) {
-        (StaticCallStatus status, bytes32 word,) =
-            _boundedStaticcall(manager, gasleft(), abi.encodeWithSelector(EXTSLOAD_SELECTOR, slot), 32);
+        bytes memory input = abi.encodeCall(IExtsloadWord.extsload, (slot));
+        (StaticCallStatus status, bytes32 word,) = _boundedStaticcall(manager, gasleft(), input, 32);
         if (status != StaticCallStatus.SUCCESS) revert ManagerReadFailed(manager, slot);
         return word;
     }
 
     function _readWords(address manager, bytes32[] memory slots) private view returns (bytes32[] memory values) {
-        bytes memory input = abi.encodeWithSelector(EXTSLOAD_SPARSE_SELECTOR, slots);
+        bytes memory input = abi.encodeCall(IExtsloadSparse.extsload, (slots));
         uint256 expectedSize = 64 + slots.length * 32;
         bytes memory output = new bytes(expectedSize);
         bool success;
@@ -441,7 +449,9 @@ contract ReservesLens is IReservesLens {
             success := staticcall(gas(), manager, add(input, 0x20), mload(input), add(output, 0x20), expectedSize)
             returnSize := returndatasize()
         }
-        if (!success || returnSize != expectedSize) revert ManagerReadFailed(manager, slots[0]);
+        if (!success || returnSize != expectedSize) {
+            revert ManagerBatchReadFailed(manager, slots[0], slots[slots.length - 1], slots.length);
+        }
 
         uint256 offset;
         uint256 length;
@@ -449,7 +459,9 @@ contract ReservesLens is IReservesLens {
             offset := mload(add(output, 0x20))
             length := mload(add(output, 0x40))
         }
-        if (offset != 32 || length != slots.length) revert ManagerReadFailed(manager, slots[0]);
+        if (offset != 32 || length != slots.length) {
+            revert ManagerBatchReadFailed(manager, slots[0], slots[slots.length - 1], slots.length);
+        }
 
         values = new bytes32[](length);
         for (uint256 i; i < length; i++) {

--- a/src/lens/ReservesLens.sol
+++ b/src/lens/ReservesLens.sol
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ERC165Checker} from "openzeppelin-contracts/contracts/utils/introspection/ERC165Checker.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {BitMath} from "@uniswap/v4-core/src/libraries/BitMath.sol";
+import {SqrtPriceMath} from "@uniswap/v4-core/src/libraries/SqrtPriceMath.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IReservesLens} from "../interfaces/IReservesLens.sol";
+import {IHookStats} from "../interfaces/external/IHookStats.sol";
+
+/// @title ReservesLens
+/// @notice Stateless view contract for v4 core liquidity TVL and optional URC-3 hook statistics
+/// @dev Reconstructs the aggregate liquidity curve by walking initialized ticks in ascending order, applying each
+///      liquidityNet, and using core SqrtPriceMath for every nonzero-liquidity interval. Raw PoolManager state is read
+///      through extsload; this contract is therefore coupled to the StateLibrary storage layout of compatible v4
+///      PoolManager deployments. The PoolManager is supplied per call so constructor-free bytecode can be deployed at
+///      the same deterministic address on every compatible chain. Callers are responsible for selecting the canonical
+///      PoolManager and obtaining the complete PoolKey from its Initialize event.
+contract ReservesLens is IReservesLens {
+    using PoolIdLibrary for PoolKey;
+
+    uint8 private constant CURSOR_VERSION = 1;
+    uint256 private constant CURSOR_LENGTH = 15 * 32;
+    uint32 private constant MIN_PAGE_READS = 2;
+    uint32 private constant MAX_PAGE_READS = 4096;
+    uint256 private constant BITMAP_BATCH_SIZE = 256;
+    uint256 private constant HOOK_STATS_GAS_LIMIT = 500_000;
+    uint160 private constant ALL_HOOK_MASK = (1 << 14) - 1;
+    uint16 private constant CUSTOM_ACCOUNTING_MASK = (1 << 4) - 1;
+    bytes4 private constant EXTSLOAD_SELECTOR = bytes4(keccak256("extsload(bytes32)"));
+    bytes4 private constant EXTSLOAD_SPARSE_SELECTOR = bytes4(keccak256("extsload(bytes32[])"));
+
+    struct ScanState {
+        uint8 version;
+        uint256 blockNumber;
+        bytes32 contextHash;
+        uint160 sqrtPriceX96;
+        int24 currentTick;
+        uint128 activeLiquidity;
+        int16 wordPos;
+        uint16 bitPos;
+        bool hasPreviousTick;
+        int24 previousTick;
+        uint128 runningLiquidity;
+        uint256 amount0;
+        uint256 amount1;
+        bool observedCurrentLiquidity;
+        uint128 currentLiquidity;
+    }
+
+    enum StaticCallStatus {
+        SUCCESS,
+        FAILED,
+        INVALID_RESPONSE
+    }
+
+    /// @inheritdoc IReservesLens
+    function getPoolTVL(IPoolManager manager, PoolKey calldata key, address statsProvider)
+        external
+        view
+        returns (PoolTVL memory result)
+    {
+        return _getPoolTVL(manager, key, statsProvider);
+    }
+
+    /// @inheritdoc IReservesLens
+    function getPoolTVLBatch(IPoolManager manager, PoolKey[] calldata keys, address[] calldata statsProviders)
+        external
+        view
+        returns (PoolTVL[] memory results)
+    {
+        if (keys.length != statsProviders.length) revert InputLengthMismatch();
+        results = new PoolTVL[](keys.length);
+        for (uint256 i; i < keys.length; i++) {
+            results[i] = _getPoolTVL(manager, keys[i], statsProviders[i]);
+        }
+    }
+
+    /// @inheritdoc IReservesLens
+    function getPopulatedTicksInWord(IPoolManager manager, PoolKey calldata key, int16 wordPos)
+        external
+        view
+        returns (PopulatedTick[] memory populatedTicks)
+    {
+        PoolId poolId = key.toId();
+        _initialize(manager, key.tickSpacing, poolId);
+        uint256 bitmap = uint256(_readWord(address(manager), _tickBitmapSlot(poolId, wordPos)));
+        uint256 remaining = bitmap;
+        uint256 count;
+        while (remaining != 0) {
+            count++;
+            remaining &= remaining - 1;
+        }
+
+        populatedTicks = new PopulatedTick[](count);
+        for (uint256 i; bitmap != 0; i++) {
+            uint8 bit = BitMath.leastSignificantBit(bitmap);
+            populatedTicks[i] = _readPopulatedTick(manager, poolId, key.tickSpacing, wordPos, bit);
+            bitmap &= bitmap - 1;
+        }
+    }
+
+    function _getPoolTVL(IPoolManager manager, PoolKey calldata key, address statsProvider)
+        private
+        view
+        returns (PoolTVL memory result)
+    {
+        PoolId poolId = key.toId();
+        ScanState memory state = _initialize(manager, key.tickSpacing, poolId);
+        state = _scanComplete(manager, key.tickSpacing, poolId, state);
+        result = _result(state, key);
+        _readHookStats(result, key, statsProvider);
+    }
+
+    /// @inheritdoc IReservesLens
+    function getPoolTVLPaged(
+        IPoolManager manager,
+        PoolKey calldata key,
+        address statsProvider,
+        bytes calldata cursor,
+        uint32 maxReads
+    ) external view returns (PoolTVL memory result, bytes memory nextCursor, bool done) {
+        if (maxReads < MIN_PAGE_READS || maxReads > MAX_PAGE_READS) revert InvalidScanBudget(maxReads);
+
+        PoolId poolId = key.toId();
+        ScanState memory state;
+        if (cursor.length == 0) {
+            state = _initialize(manager, key.tickSpacing, poolId);
+        } else {
+            if (cursor.length != CURSOR_LENGTH) revert InvalidCursor();
+            state = abi.decode(cursor, (ScanState));
+            if (state.version != CURSOR_VERSION) revert UnsupportedCursorVersion(state.version);
+            if (state.contextHash != _contextHash(manager, poolId)) revert CursorContextMismatch();
+            if (state.blockNumber != block.number) revert CursorBlockMismatch(state.blockNumber, block.number);
+            if (state.bitPos > 256) revert InvalidCursor();
+        }
+
+        (state, done) = _scan(manager, key.tickSpacing, poolId, state, maxReads);
+        result = _result(state, key);
+        if (done) {
+            _readHookStats(result, key, statsProvider);
+        } else {
+            nextCursor = abi.encode(state);
+        }
+    }
+
+    function _initialize(IPoolManager manager, int24 tickSpacing, PoolId poolId)
+        private
+        view
+        returns (ScanState memory state)
+    {
+        if (tickSpacing < TickMath.MIN_TICK_SPACING || tickSpacing > TickMath.MAX_TICK_SPACING) {
+            revert InvalidTickSpacing(tickSpacing);
+        }
+
+        bytes32 poolStateSlot = _poolStateSlot(poolId);
+        bytes32 slot0 = _readWord(address(manager), poolStateSlot);
+        uint160 sqrtPriceX96;
+        int24 currentTick;
+        assembly ("memory-safe") {
+            sqrtPriceX96 := and(slot0, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+            currentTick := signextend(2, shr(160, slot0))
+        }
+        if (sqrtPriceX96 == 0) revert PoolNotInitialized(poolId);
+
+        uint128 activeLiquidity = uint128(
+            uint256(_readWord(address(manager), bytes32(uint256(poolStateSlot) + StateLibrary.LIQUIDITY_OFFSET)))
+        );
+        int24 minCompressed = TickMath.minUsableTick(tickSpacing) / tickSpacing;
+
+        state = ScanState({
+            version: CURSOR_VERSION,
+            blockNumber: block.number,
+            contextHash: _contextHash(manager, poolId),
+            sqrtPriceX96: sqrtPriceX96,
+            currentTick: currentTick,
+            activeLiquidity: activeLiquidity,
+            wordPos: int16(minCompressed >> 8),
+            bitPos: 0,
+            hasPreviousTick: false,
+            previousTick: 0,
+            runningLiquidity: 0,
+            amount0: 0,
+            amount1: 0,
+            observedCurrentLiquidity: false,
+            currentLiquidity: 0
+        });
+    }
+
+    function _scan(IPoolManager manager, int24 tickSpacing, PoolId poolId, ScanState memory state, uint32 maxReads)
+        private
+        view
+        returns (ScanState memory, bool done)
+    {
+        int24 maxTick = TickMath.maxUsableTick(tickSpacing);
+        int16 maxWord = int16((maxTick / tickSpacing) >> 8);
+        uint32 reads;
+
+        while (state.wordPos <= maxWord) {
+            if (reads >= maxReads) return (state, false);
+
+            uint256 bitmap = uint256(_readWord(address(manager), _tickBitmapSlot(poolId, state.wordPos)));
+            reads++;
+
+            if (state.bitPos == 256) {
+                state.wordPos = int16(int256(state.wordPos) + 1);
+                state.bitPos = 0;
+                continue;
+            }
+            if (state.bitPos != 0) bitmap &= type(uint256).max << state.bitPos;
+
+            while (bitmap != 0) {
+                uint8 bit = BitMath.leastSignificantBit(bitmap);
+                if (reads >= maxReads) {
+                    state.bitPos = bit;
+                    return (state, false);
+                }
+                _processInitializedTick(manager, tickSpacing, poolId, state, bit);
+                reads++;
+                bitmap &= bitmap - 1;
+                state.bitPos = uint16(bit) + 1;
+            }
+
+            state.wordPos = int16(int256(state.wordPos) + 1);
+            state.bitPos = 0;
+        }
+
+        _validateComplete(poolId, state);
+        return (state, true);
+    }
+
+    function _scanComplete(IPoolManager manager, int24 tickSpacing, PoolId poolId, ScanState memory state)
+        private
+        view
+        returns (ScanState memory)
+    {
+        int24 maxTick = TickMath.maxUsableTick(tickSpacing);
+        int16 maxWord = int16((maxTick / tickSpacing) >> 8);
+        int256 nextWord = state.wordPos;
+
+        while (nextWord <= maxWord) {
+            uint256 remaining = uint256(int256(maxWord) - nextWord + 1);
+            uint256 count = remaining < BITMAP_BATCH_SIZE ? remaining : BITMAP_BATCH_SIZE;
+            bytes32[] memory slots = new bytes32[](count);
+            for (uint256 i; i < count; i++) {
+                slots[i] = _tickBitmapSlot(poolId, int16(nextWord + int256(i)));
+            }
+            bytes32[] memory bitmaps = _readWords(address(manager), slots);
+
+            for (uint256 i; i < count; i++) {
+                state.wordPos = int16(nextWord + int256(i));
+                uint256 bitmap = uint256(bitmaps[i]);
+                while (bitmap != 0) {
+                    uint8 bit = BitMath.leastSignificantBit(bitmap);
+                    _processInitializedTick(manager, tickSpacing, poolId, state, bit);
+                    bitmap &= bitmap - 1;
+                }
+            }
+            nextWord += int256(count);
+        }
+
+        state.wordPos = int16(int256(maxWord) + 1);
+        state.bitPos = 0;
+        _validateComplete(poolId, state);
+        return state;
+    }
+
+    function _validateComplete(PoolId poolId, ScanState memory state) private pure {
+        if (state.runningLiquidity != 0) revert LiquidityInvariantFailed(poolId);
+        uint128 reconstructed = state.observedCurrentLiquidity ? state.currentLiquidity : 0;
+        if (reconstructed != state.activeLiquidity) revert LiquidityInvariantFailed(poolId);
+    }
+
+    function _processInitializedTick(
+        IPoolManager manager,
+        int24 tickSpacing,
+        PoolId poolId,
+        ScanState memory state,
+        uint8 bit
+    ) private view {
+        int24 minTick = TickMath.minUsableTick(tickSpacing);
+        int24 maxTick = TickMath.maxUsableTick(tickSpacing);
+        int256 compressed = int256(state.wordPos) * 256 + int256(uint256(bit));
+        int256 tickValue = compressed * int256(tickSpacing);
+        if (tickValue < minTick || tickValue > maxTick) revert TickInvariantFailed(poolId, tickValue);
+
+        int24 tick = int24(tickValue);
+        (, int128 liquidityNet) = _readTick(manager, poolId, tick);
+        if (liquidityNet == 0) return;
+
+        if (state.hasPreviousTick) _accumulateInterval(state, state.previousTick, tick);
+        state.runningLiquidity = _addLiquidity(poolId, state.runningLiquidity, liquidityNet);
+        state.previousTick = tick;
+        state.hasPreviousTick = true;
+    }
+
+    function _accumulateInterval(ScanState memory state, int24 tickA, int24 tickB) private pure {
+        if (state.currentTick >= tickA && state.currentTick < tickB) {
+            state.currentLiquidity = state.runningLiquidity;
+            state.observedCurrentLiquidity = true;
+        }
+        if (state.runningLiquidity == 0) return;
+
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(tickA);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(tickB);
+        if (state.currentTick < tickA) {
+            state.amount0 += SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, state.runningLiquidity, false);
+        } else if (state.currentTick < tickB) {
+            state.amount0 += SqrtPriceMath.getAmount0Delta(state.sqrtPriceX96, sqrtB, state.runningLiquidity, false);
+            state.amount1 += SqrtPriceMath.getAmount1Delta(sqrtA, state.sqrtPriceX96, state.runningLiquidity, false);
+        } else {
+            state.amount1 += SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, state.runningLiquidity, false);
+        }
+    }
+
+    function _addLiquidity(PoolId poolId, uint128 liquidity, int128 delta) private pure returns (uint128 next) {
+        int256 value = int256(uint256(liquidity)) + int256(delta);
+        if (value < 0 || uint256(value) > type(uint128).max) revert LiquidityInvariantFailed(poolId);
+        next = uint128(uint256(value));
+    }
+
+    function _result(ScanState memory state, PoolKey calldata key) private pure returns (PoolTVL memory result) {
+        address hook = address(key.hooks);
+        result.coreAmount0 = state.amount0;
+        result.coreAmount1 = state.amount1;
+        result.sqrtPriceX96 = state.sqrtPriceX96;
+        result.tick = state.currentTick;
+        result.activeLiquidity = state.activeLiquidity;
+        result.blockNumber = state.blockNumber;
+        result.hookPermissions = uint16(uint160(hook) & ALL_HOOK_MASK);
+        result.hasCustomAccounting = result.hookPermissions & CUSTOM_ACCOUNTING_MASK != 0;
+        result.statsStatus = hook == address(0) ? HookStatsStatus.NO_HOOK : HookStatsStatus.NOT_SUPPORTED;
+    }
+
+    function _readTick(IPoolManager manager, PoolId poolId, int24 tick)
+        private
+        view
+        returns (uint128 liquidityGross, int128 liquidityNet)
+    {
+        bytes32 tickWord = _readWord(address(manager), _tickInfoSlot(poolId, tick));
+        assembly ("memory-safe") {
+            liquidityGross := and(tickWord, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+            liquidityNet := signextend(15, shr(128, tickWord))
+        }
+        if (liquidityGross == 0) revert TickInvariantFailed(poolId, tick);
+    }
+
+    function _readPopulatedTick(IPoolManager manager, PoolId poolId, int24 tickSpacing, int16 wordPos, uint8 bit)
+        private
+        view
+        returns (PopulatedTick memory populated)
+    {
+        int256 tickValue = (int256(wordPos) * 256 + int256(uint256(bit))) * int256(tickSpacing);
+        if (tickValue < TickMath.minUsableTick(tickSpacing) || tickValue > TickMath.maxUsableTick(tickSpacing)) {
+            revert TickInvariantFailed(poolId, tickValue);
+        }
+        populated.tick = int24(tickValue);
+        (populated.liquidityGross, populated.liquidityNet) = _readTick(manager, poolId, populated.tick);
+    }
+
+    function _readHookStats(PoolTVL memory result, PoolKey calldata key, address suppliedProvider) private view {
+        address hook = address(key.hooks);
+        if (hook == address(0)) {
+            result.statsStatus = HookStatsStatus.NO_HOOK;
+            return;
+        }
+
+        address provider = suppliedProvider == address(0) ? hook : suppliedProvider;
+        result.statsProvider = provider;
+        if (!ERC165Checker.supportsInterface(provider, type(IHookStats).interfaceId)) {
+            result.statsStatus =
+                suppliedProvider == address(0) ? HookStatsStatus.NOT_SUPPORTED : HookStatsStatus.INVALID_PROVIDER;
+            return;
+        }
+
+        (StaticCallStatus hookStatus, bytes32 hookWord,) =
+            _boundedStaticcall(provider, HOOK_STATS_GAS_LIMIT, abi.encodeCall(IHookStats.hook, ()), 32);
+        if (hookStatus != StaticCallStatus.SUCCESS) {
+            result.statsStatus = _hookFailureStatus(hookStatus);
+            return;
+        }
+        uint256 reportedHook = uint256(hookWord);
+        if (reportedHook > type(uint160).max || address(uint160(reportedHook)) != hook) {
+            result.statsStatus = HookStatsStatus.INVALID_PROVIDER;
+            return;
+        }
+
+        (StaticCallStatus reservesStatus, bytes32 reserves0, bytes32 reserves1) =
+            _boundedStaticcall(provider, HOOK_STATS_GAS_LIMIT, abi.encodeCall(IHookStats.getReserves, (key)), 64);
+        if (reservesStatus != StaticCallStatus.SUCCESS) {
+            result.statsStatus = _hookFailureStatus(reservesStatus);
+            return;
+        }
+
+        (StaticCallStatus effectiveStatus, bytes32 effective0, bytes32 effective1) = _boundedStaticcall(
+            provider, HOOK_STATS_GAS_LIMIT, abi.encodeCall(IHookStats.getEffectiveLiquidity, (key)), 64
+        );
+        if (effectiveStatus != StaticCallStatus.SUCCESS) {
+            result.statsStatus = _hookFailureStatus(effectiveStatus);
+            return;
+        }
+
+        result.hookReserves0 = uint256(reserves0);
+        result.hookReserves1 = uint256(reserves1);
+        result.hookEffective0 = uint256(effective0);
+        result.hookEffective1 = uint256(effective1);
+        if (result.hookEffective0 > result.hookReserves0 || result.hookEffective1 > result.hookReserves1) {
+            result.hookReserves0 = 0;
+            result.hookReserves1 = 0;
+            result.hookEffective0 = 0;
+            result.hookEffective1 = 0;
+            result.statsStatus = HookStatsStatus.INVALID_RESPONSE;
+            return;
+        }
+
+        result.statsStatus = suppliedProvider == address(0) ? HookStatsStatus.DIRECT : HookStatsStatus.EXTERNAL;
+    }
+
+    function _hookFailureStatus(StaticCallStatus status) private pure returns (HookStatsStatus) {
+        return status == StaticCallStatus.FAILED ? HookStatsStatus.CALL_FAILED : HookStatsStatus.INVALID_RESPONSE;
+    }
+
+    function _readWord(address manager, bytes32 slot) private view returns (bytes32 value) {
+        (StaticCallStatus status, bytes32 word,) =
+            _boundedStaticcall(manager, gasleft(), abi.encodeWithSelector(EXTSLOAD_SELECTOR, slot), 32);
+        if (status != StaticCallStatus.SUCCESS) revert ManagerReadFailed(manager, slot);
+        return word;
+    }
+
+    function _readWords(address manager, bytes32[] memory slots) private view returns (bytes32[] memory values) {
+        bytes memory input = abi.encodeWithSelector(EXTSLOAD_SPARSE_SELECTOR, slots);
+        uint256 expectedSize = 64 + slots.length * 32;
+        bytes memory output = new bytes(expectedSize);
+        bool success;
+        uint256 returnSize;
+        assembly ("memory-safe") {
+            success := staticcall(gas(), manager, add(input, 0x20), mload(input), add(output, 0x20), expectedSize)
+            returnSize := returndatasize()
+        }
+        if (!success || returnSize != expectedSize) revert ManagerReadFailed(manager, slots[0]);
+
+        uint256 offset;
+        uint256 length;
+        assembly ("memory-safe") {
+            offset := mload(add(output, 0x20))
+            length := mload(add(output, 0x40))
+        }
+        if (offset != 32 || length != slots.length) revert ManagerReadFailed(manager, slots[0]);
+
+        values = new bytes32[](length);
+        for (uint256 i; i < length; i++) {
+            bytes32 word;
+            assembly ("memory-safe") {
+                word := mload(add(add(output, 0x60), mul(i, 0x20)))
+            }
+            values[i] = word;
+        }
+    }
+
+    function _boundedStaticcall(address target, uint256 gasLimit, bytes memory input, uint256 expectedSize)
+        private
+        view
+        returns (StaticCallStatus status, bytes32 word0, bytes32 word1)
+    {
+        bool success;
+        uint256 returnSize;
+        assembly ("memory-safe") {
+            let output := mload(0x40)
+            mstore(output, 0)
+            mstore(add(output, 0x20), 0)
+            success := staticcall(gasLimit, target, add(input, 0x20), mload(input), output, 0x40)
+            returnSize := returndatasize()
+            word0 := mload(output)
+            word1 := mload(add(output, 0x20))
+        }
+        if (!success) return (StaticCallStatus.FAILED, bytes32(0), bytes32(0));
+        if (returnSize != expectedSize) return (StaticCallStatus.INVALID_RESPONSE, bytes32(0), bytes32(0));
+        return (StaticCallStatus.SUCCESS, word0, word1);
+    }
+
+    function _contextHash(IPoolManager manager, PoolId poolId) private pure returns (bytes32) {
+        return keccak256(abi.encode(address(manager), PoolId.unwrap(poolId)));
+    }
+
+    function _poolStateSlot(PoolId poolId) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(PoolId.unwrap(poolId), StateLibrary.POOLS_SLOT));
+    }
+
+    function _tickBitmapSlot(PoolId poolId, int16 wordPos) private pure returns (bytes32) {
+        bytes32 mappingSlot = bytes32(uint256(_poolStateSlot(poolId)) + StateLibrary.TICK_BITMAP_OFFSET);
+        return keccak256(abi.encodePacked(int256(wordPos), mappingSlot));
+    }
+
+    function _tickInfoSlot(PoolId poolId, int24 tick) private pure returns (bytes32) {
+        bytes32 mappingSlot = bytes32(uint256(_poolStateSlot(poolId)) + StateLibrary.TICKS_OFFSET);
+        return keccak256(abi.encodePacked(int256(tick), mappingSlot));
+    }
+}

--- a/test/ReservesLens.fork.t.sol
+++ b/test/ReservesLens.fork.t.sol
@@ -39,7 +39,7 @@ contract ReservesLensForkTest is Test {
 
     function test_base_realPoolsMatchStateViewReference() public {
         string memory rpc = vm.envOr("BASE_RPC_URL", string(""));
-        if (bytes(rpc).length == 0) return;
+        vm.skip(bytes(rpc).length == 0);
         vm.createSelectFork(rpc, BASE_BLOCK);
         ReservesLens lens = new ReservesLens();
 
@@ -51,7 +51,7 @@ contract ReservesLensForkTest is Test {
 
     function test_robinhoodChain_realPoolsMatchStateViewReference() public {
         string memory rpc = vm.envOr("ROBINHOOD_RPC_URL", string(""));
-        if (bytes(rpc).length == 0) return;
+        vm.skip(bytes(rpc).length == 0);
         vm.createSelectFork(rpc, ROBINHOOD_BLOCK);
         ReservesLens lens = new ReservesLens();
 

--- a/test/ReservesLens.fork.t.sol
+++ b/test/ReservesLens.fork.t.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {BitMath} from "@uniswap/v4-core/src/libraries/BitMath.sol";
+import {SqrtPriceMath} from "@uniswap/v4-core/src/libraries/SqrtPriceMath.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IReservesLens} from "../src/interfaces/IReservesLens.sol";
+import {IStateView} from "../src/interfaces/IStateView.sol";
+import {ReservesLens} from "../src/lens/ReservesLens.sol";
+
+/// @notice Pinned real-pool comparisons against the independently deployed StateView read path.
+/// @dev Set BASE_RPC_URL and/or ROBINHOOD_RPC_URL to run.
+contract ReservesLensForkTest is Test {
+    using PoolIdLibrary for PoolKey;
+
+    uint256 private constant BASE_BLOCK = 48_410_000;
+    uint256 private constant ROBINHOOD_BLOCK = 6_448_000;
+    IPoolManager private constant BASE_MANAGER = IPoolManager(0x498581fF718922c3f8e6A244956aF099B2652b2b);
+    IStateView private constant BASE_STATE_VIEW = IStateView(0xA3c0c9b65baD0b08107Aa264b0f3dB444b867A71);
+    IPoolManager private constant ROBINHOOD_MANAGER = IPoolManager(0x8366a39CC670B4001A1121B8F6A443A643e40951);
+    IStateView private constant ROBINHOOD_STATE_VIEW = IStateView(0xF3334192D15450CdD385c8B70e03f9A6bD9E673b);
+
+    struct ReferenceState {
+        uint160 sqrtPriceX96;
+        int24 currentTick;
+        uint128 running;
+        bool hasPrevious;
+        int24 previous;
+        uint256 amount0;
+        uint256 amount1;
+        uint128 reconstructedActive;
+    }
+
+    function test_base_realPoolsMatchStateViewReference() public {
+        string memory rpc = vm.envOr("BASE_RPC_URL", string(""));
+        if (bytes(rpc).length == 0) return;
+        vm.createSelectFork(rpc, BASE_BLOCK);
+        ReservesLens lens = new ReservesLens();
+
+        _compare(lens, BASE_MANAGER, BASE_STATE_VIEW, _nativeUnhooked60());
+        _compare(lens, BASE_MANAGER, BASE_STATE_VIEW, _usdcUnhooked200());
+        _compare(lens, BASE_MANAGER, BASE_STATE_VIEW, _nativeHooked200());
+        _compare(lens, BASE_MANAGER, BASE_STATE_VIEW, _dynamicHooked200());
+    }
+
+    function test_robinhoodChain_realPoolsMatchStateViewReference() public {
+        string memory rpc = vm.envOr("ROBINHOOD_RPC_URL", string(""));
+        if (bytes(rpc).length == 0) return;
+        vm.createSelectFork(rpc, ROBINHOOD_BLOCK);
+        ReservesLens lens = new ReservesLens();
+
+        _compare(lens, ROBINHOOD_MANAGER, ROBINHOOD_STATE_VIEW, _robinhoodHooked200());
+    }
+
+    function _compare(ReservesLens lens, IPoolManager poolManager, IStateView stateView, PoolKey memory poolKey)
+        private
+    {
+        PoolId poolId = poolKey.toId();
+        (uint256 expected0, uint256 expected1, uint128 expectedActive) = _stateViewReference(stateView, poolKey);
+
+        uint256 gasBefore = gasleft();
+        IReservesLens.PoolTVL memory actual = lens.getPoolTVL(poolManager, poolKey, address(0));
+        uint256 gasUsed = gasBefore - gasleft();
+
+        assertEq(actual.coreAmount0, expected0, "amount0");
+        assertEq(actual.coreAmount1, expected1, "amount1");
+        assertEq(actual.activeLiquidity, expectedActive, "active liquidity");
+        emit log_named_bytes32("pool id", PoolId.unwrap(poolId));
+        emit log_named_uint("single-shot gas", gasUsed);
+    }
+
+    function _stateViewReference(IStateView stateView, PoolKey memory poolKey)
+        private
+        view
+        returns (uint256 amount0, uint256 amount1, uint128 activeLiquidity)
+    {
+        PoolId poolId = poolKey.toId();
+        ReferenceState memory state;
+        (state.sqrtPriceX96, state.currentTick,,) = stateView.getSlot0(poolId);
+        activeLiquidity = stateView.getLiquidity(poolId);
+        int24 maxTick = TickMath.maxUsableTick(poolKey.tickSpacing);
+        int24 minCompressed = TickMath.minUsableTick(poolKey.tickSpacing) / poolKey.tickSpacing;
+        int16 wordPos = int16(minCompressed >> 8);
+        int16 maxWord = int16((maxTick / poolKey.tickSpacing) >> 8);
+
+        while (wordPos <= maxWord) {
+            uint256 bitmap = stateView.getTickBitmap(poolId, wordPos);
+            while (bitmap != 0) {
+                uint8 bit = BitMath.leastSignificantBit(bitmap);
+                int24 tick = int24((int256(wordPos) * 256 + int256(uint256(bit))) * int256(poolKey.tickSpacing));
+                (, int128 net) = stateView.getTickLiquidity(poolId, tick);
+                if (net != 0) _consumeTick(state, tick, net);
+                bitmap &= bitmap - 1;
+            }
+            wordPos = int16(int256(wordPos) + 1);
+        }
+
+        assertEq(state.running, 0, "reference final liquidity");
+        assertEq(state.reconstructedActive, activeLiquidity, "StateView active liquidity");
+        return (state.amount0, state.amount1, activeLiquidity);
+    }
+
+    function _consumeTick(ReferenceState memory state, int24 tick, int128 net) private pure {
+        if (state.hasPrevious) {
+            if (state.currentTick >= state.previous && state.currentTick < tick) {
+                state.reconstructedActive = state.running;
+            }
+            _addInterval(state, state.previous, tick);
+        }
+        state.running = uint128(uint256(int256(uint256(state.running)) + int256(net)));
+        state.previous = tick;
+        state.hasPrevious = true;
+    }
+
+    function _addInterval(ReferenceState memory state, int24 tickA, int24 tickB) private pure {
+        if (state.running == 0) return;
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(tickA);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(tickB);
+        if (state.currentTick < tickA) {
+            state.amount0 += SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, state.running, false);
+        } else if (state.currentTick < tickB) {
+            state.amount0 += SqrtPriceMath.getAmount0Delta(state.sqrtPriceX96, sqrtB, state.running, false);
+            state.amount1 += SqrtPriceMath.getAmount1Delta(sqrtA, state.sqrtPriceX96, state.running, false);
+        } else {
+            state.amount1 += SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, state.running, false);
+        }
+    }
+
+    function _nativeUnhooked60() private pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(address(bytes20(hex"ae2f44ab8e3d21dbbd4d13e287fa167139df7cdc"))),
+            fee: 3000,
+            tickSpacing: 60,
+            hooks: IHooks(address(0))
+        });
+    }
+
+    function _usdcUnhooked200() private pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(bytes20(hex"833589fcd6edb6e08f4c7c32d4f71b54bda02913"))),
+            currency1: Currency.wrap(address(bytes20(hex"b200000000000000000000cc6ef45b2edadc7b3f"))),
+            fee: 0x0d5ffc,
+            tickSpacing: 200,
+            hooks: IHooks(address(0))
+        });
+    }
+
+    function _nativeHooked200() private pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(address(bytes20(hex"b20000000000000000000028f8cbbdda0469f701"))),
+            fee: 0,
+            tickSpacing: 200,
+            hooks: IHooks(address(bytes20(hex"a068cf4c52abdd3479145c4b3cbd8e3d71542a44")))
+        });
+    }
+
+    function _dynamicHooked200() private pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(bytes20(hex"387c91d4d7b3a0bb72b743615324b2e0d8512271"))),
+            currency1: Currency.wrap(address(bytes20(hex"ce74d58e78c43f00b8159e1b9287736f8f6b06fc"))),
+            fee: 0x800000,
+            tickSpacing: 200,
+            hooks: IHooks(address(bytes20(hex"0469a4bd3724dc86c9542f4694c976da13c450c0")))
+        });
+    }
+
+    function _robinhoodHooked200() private pure returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(bytes20(hex"0bd7d308f8e1639fab988df18a8011f41eacad73"))),
+            currency1: Currency.wrap(address(bytes20(hex"894fac757250f8e02180e1856957274d84ac4ba3"))),
+            fee: 0x800000,
+            tickSpacing: 200,
+            hooks: IHooks(address(bytes20(hex"4e3468951d49f2eea976ed0d6e75ffcb44a9a544")))
+        });
+    }
+}

--- a/test/ReservesLens.fuzz.t.sol
+++ b/test/ReservesLens.fuzz.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IReservesLens} from "../src/interfaces/IReservesLens.sol";
+import {ReservesLens} from "../src/lens/ReservesLens.sol";
+import {ReservesReference} from "./shared/ReservesReference.sol";
+
+contract ReservesLensFuzzTest is Test, Deployers {
+    using StateLibrary for *;
+
+    ReservesLens internal lens;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        key = PoolKey(currency0, currency1, 3000, 60, IHooks(address(0)));
+        manager.initialize(key, SQRT_PRICE_1_1);
+        lens = new ReservesLens();
+    }
+
+    function test_fuzz_matchesIndependentAggregate(
+        int16[6] memory rawTicks,
+        uint96[3] memory rawLiquidity,
+        bool performSwap,
+        bool zeroForOne,
+        uint96 rawSwapAmount,
+        uint32 rawBudget
+    ) public {
+        ReservesReference.Position[] memory positions = new ReservesReference.Position[](4);
+        positions[0] = ReservesReference.Position(-6000, 6000, 10_000_000 ether);
+        _add(positions[0]);
+
+        for (uint256 i; i < 3; i++) {
+            int24 a = int24(int256(bound(int256(rawTicks[i * 2]), -90, 89))) * 60;
+            int24 b = int24(int256(bound(int256(rawTicks[i * 2 + 1]), -90, 89))) * 60;
+            if (a == b) b += b == 89 * 60 ? int24(-60) : int24(60);
+            if (a > b) (a, b) = (b, a);
+            uint128 liquidity = uint128(bound(uint256(rawLiquidity[i]), 1, 1_000_000 ether));
+            positions[i + 1] = ReservesReference.Position(a, b, liquidity);
+            _add(positions[i + 1]);
+        }
+
+        if (performSwap) {
+            uint256 swapAmount = bound(uint256(rawSwapAmount), 1, 1 ether);
+            swap(key, zeroForOne, -int256(swapAmount), ZERO_BYTES);
+        }
+
+        (uint160 sqrtPriceX96, int24 currentTick,,) = manager.getSlot0(key.toId());
+        (uint256 expected0, uint256 expected1, uint128 expectedActive) =
+            ReservesReference.aggregate(sqrtPriceX96, currentTick, positions);
+        IReservesLens.PoolTVL memory single = lens.getPoolTVL(manager, key, address(0));
+        assertEq(single.coreAmount0, expected0);
+        assertEq(single.coreAmount1, expected1);
+        assertEq(single.activeLiquidity, expectedActive);
+
+        uint32 budget = uint32(bound(uint256(rawBudget), 2, 64));
+        IReservesLens.PoolTVL memory paged = _getPaged(budget);
+        assertEq(paged.coreAmount0, single.coreAmount0);
+        assertEq(paged.coreAmount1, single.coreAmount1);
+        assertEq(paged.activeLiquidity, single.activeLiquidity);
+    }
+
+    function _add(ReservesReference.Position memory position) private {
+        modifyLiquidityRouter.modifyLiquidity(
+            key,
+            ModifyLiquidityParams(position.lower, position.upper, int256(uint256(position.liquidity)), bytes32(0)),
+            ZERO_BYTES
+        );
+    }
+
+    function _getPaged(uint32 budget) private view returns (IReservesLens.PoolTVL memory result) {
+        bytes memory cursor;
+        bool done;
+        uint256 pages;
+        while (!done) {
+            (result, cursor, done) = lens.getPoolTVLPaged(manager, key, address(0), cursor, budget);
+            assertLt(++pages, 10_000);
+        }
+    }
+}

--- a/test/ReservesLens.gas.t.sol
+++ b/test/ReservesLens.gas.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IReservesLens} from "../src/interfaces/IReservesLens.sol";
+import {ReservesLens} from "../src/lens/ReservesLens.sol";
+
+/// @notice Stable synthetic gas baselines. Real-pool distributions are produced by the fork comparison harness.
+contract ReservesLensGasTest is Test, Deployers {
+    ReservesLens internal lens;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        lens = new ReservesLens();
+    }
+
+    function test_gas_bytecodeSize() public {
+        vm.snapshotValue("ReservesLens_Bytecode", address(lens).code.length);
+    }
+
+    function test_reservesLens_initcodeHash() public {
+        vm.snapshotValue(
+            "ReservesLens initcode hash (as uint256)", uint256(keccak256(vm.getCode("ReservesLens.sol:ReservesLens")))
+        );
+    }
+
+    function test_gas_singleShot_emptyTickSpacingOne() public {
+        PoolKey memory spacingOne = PoolKey(currency0, currency1, 100, 1, IHooks(address(0)));
+        manager.initialize(spacingOne, SQRT_PRICE_1_1);
+
+        uint256 gasBefore = gasleft();
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, spacingOne, address(0));
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.snapshotGasLastCall("ReservesLens_empty_tickSpacingOne_singleShot");
+
+        assertEq(result.coreAmount0, 0);
+        assertEq(result.coreAmount1, 0);
+        assertLt(gasUsed, 40_000_000, "unexpected regression in the tick-spacing-one baseline");
+        emit log_named_uint("empty tickSpacing=1 single-shot gas", gasUsed);
+    }
+
+    function test_gas_page512_emptyTickSpacingOne() public {
+        PoolKey memory spacingOne = PoolKey(currency0, currency1, 100, 1, IHooks(address(0)));
+        manager.initialize(spacingOne, SQRT_PRICE_1_1);
+
+        uint256 gasBefore = gasleft();
+        (, bytes memory cursor, bool done) = lens.getPoolTVLPaged(manager, spacingOne, address(0), bytes(""), 512);
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.snapshotGasLastCall("ReservesLens_empty_tickSpacingOne_page512");
+
+        assertFalse(done);
+        assertGt(cursor.length, 0);
+        assertLt(gasUsed, 3_000_000, "recommended page should fit conservative provider caps");
+        emit log_named_uint("empty tickSpacing=1 512-read page gas", gasUsed);
+    }
+}

--- a/test/ReservesLens.hooks.t.sol
+++ b/test/ReservesLens.hooks.t.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IReservesLens} from "../src/interfaces/IReservesLens.sol";
+import {ReservesLens} from "../src/lens/ReservesLens.sol";
+import {MockHookStats} from "./mocks/MockHookStats.sol";
+
+contract ReservesLensHookTest is Test, Deployers {
+    ReservesLens internal lens;
+    address internal hookAddress;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        lens = new ReservesLens();
+        hookAddress = address(uint160(0x10000 | Hooks.BEFORE_SWAP_FLAG));
+    }
+
+    function test_directHookStats() public {
+        key = _initializeHookPool(MockHookStats.Mode.VALID);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(result.hookReserves0, 1000);
+        assertEq(result.hookReserves1, 2000);
+        assertEq(result.hookEffective0, 500);
+        assertEq(result.hookEffective1, 1000);
+        assertEq(result.statsProvider, hookAddress);
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.DIRECT));
+        assertEq(result.hookPermissions, uint16(Hooks.BEFORE_SWAP_FLAG));
+        assertFalse(result.hasCustomAccounting);
+    }
+
+    function test_customAccountingPermissionIsDecoded() public {
+        hookAddress = address(uint160(0x10000 | Hooks.BEFORE_SWAP_FLAG | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG));
+        key = _initializeHookPool(MockHookStats.Mode.VALID);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertTrue(result.hasCustomAccounting);
+    }
+
+    function test_externalHookStats() public {
+        key = _initializeHookPool(MockHookStats.Mode.VALID);
+        MockHookStats provider = new MockHookStats(hookAddress, MockHookStats.Mode.VALID);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(provider));
+        assertEq(result.hookReserves0, 1000);
+        assertEq(result.statsProvider, address(provider));
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.EXTERNAL));
+    }
+
+    function test_nonSupportingHookDoesNotRevertCore() public {
+        key = _initializeHookPool(MockHookStats.Mode.UNIVERSAL_ERC165);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(result.coreAmount0, 0);
+        assertEq(result.coreAmount1, 0);
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.NOT_SUPPORTED));
+    }
+
+    function test_revertingProviderDoesNotRevertCore() public {
+        key = _initializeHookPool(MockHookStats.Mode.REVERT_STATS);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(result.coreAmount0, 0);
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.CALL_FAILED));
+    }
+
+    function test_wrongHookPointerIsInvalidProvider() public {
+        key = _initializeHookPool(MockHookStats.Mode.WRONG_HOOK);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.INVALID_PROVIDER));
+    }
+
+    function test_effectiveGreaterThanReservesIsInvalid() public {
+        key = _initializeHookPool(MockHookStats.Mode.INVALID_EFFECTIVE);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(result.hookReserves0, 0);
+        assertEq(result.hookEffective0, 0);
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.INVALID_RESPONSE));
+    }
+
+    function test_returnBombIsBoundedAndInvalid() public {
+        key = _initializeHookPool(MockHookStats.Mode.RETURN_BOMB);
+        uint256 gasBefore = gasleft();
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        uint256 gasUsed = gasBefore - gasleft();
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.INVALID_RESPONSE));
+        assertLt(gasUsed, 2_000_000);
+    }
+
+    function test_shortReturnIsInvalid() public {
+        key = _initializeHookPool(MockHookStats.Mode.SHORT_RETURN);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.INVALID_RESPONSE));
+    }
+
+    function test_gasGriefingProviderIsCapped() public {
+        key = _initializeHookPool(MockHookStats.Mode.GAS_BURN);
+        uint256 gasBefore = gasleft();
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        uint256 gasUsed = gasBefore - gasleft();
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.CALL_FAILED));
+        assertLt(gasUsed, 2_000_000);
+    }
+
+    function test_EOAExternalProviderIsInvalid() public {
+        key = _initializeHookPool(MockHookStats.Mode.VALID);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0xbeef));
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.INVALID_PROVIDER));
+    }
+
+    function _initializeHookPool(MockHookStats.Mode mode) private returns (PoolKey memory poolKey) {
+        MockHookStats implementation = new MockHookStats(hookAddress, mode);
+        vm.etch(hookAddress, address(implementation).code);
+        poolKey = PoolKey(currency0, currency1, 3000, 60, IHooks(hookAddress));
+        manager.initialize(poolKey, SQRT_PRICE_1_1);
+    }
+}

--- a/test/ReservesLens.hooks.t.sol
+++ b/test/ReservesLens.hooks.t.sol
@@ -103,6 +103,15 @@ contract ReservesLensHookTest is Test, Deployers {
         assertLt(gasUsed, 2_000_000);
     }
 
+    function test_insufficientGasForHookStatsRevertsInsteadOfMisclassifying() public {
+        key = _initializeHookPool(MockHookStats.Mode.VALID);
+        // Enough gas to complete the core scan and ERC165 probe, but not enough to guarantee the 500k
+        // hook-stats stipend after the EIP-150 63/64 reduction. Without the guard this healthy provider
+        // would be gas-starved and misreported as CALL_FAILED.
+        vm.expectRevert(IReservesLens.InsufficientGasForHookStats.selector);
+        lens.getPoolTVL{gas: 650_000}(manager, key, address(0));
+    }
+
     function test_EOAExternalProviderIsInvalid() public {
         key = _initializeHookPool(MockHookStats.Mode.VALID);
         IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0xbeef));

--- a/test/ReservesLens.invariant.t.sol
+++ b/test/ReservesLens.invariant.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IReservesLens} from "../src/interfaces/IReservesLens.sol";
+import {ReservesLens} from "../src/lens/ReservesLens.sol";
+import {ReservesReference} from "./shared/ReservesReference.sol";
+
+contract ReservesLensInvariantTest is StdInvariant, Test, Deployers {
+    using StateLibrary for *;
+
+    int24[4] private lowers = [int24(-2400), int24(-600), int24(-120), int24(0)];
+    int24[4] private uppers = [int24(-1200), int24(600), int24(120), int24(1200)];
+    uint128[4] private liquidities;
+    uint128 private constant BASE_LIQUIDITY = 10_000_000 ether;
+    ReservesLens private lens;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        key = PoolKey(currency0, currency1, 3000, 60, IHooks(address(0)));
+        manager.initialize(key, SQRT_PRICE_1_1);
+        lens = new ReservesLens();
+        _modify(-6000, 6000, int256(uint256(BASE_LIQUIDITY)));
+
+        bytes4[] memory selectors = new bytes4[](4);
+        selectors[0] = this.addLiquidity.selector;
+        selectors[1] = this.removeLiquidity.selector;
+        selectors[2] = this.swapPool.selector;
+        selectors[3] = this.donate.selector;
+        targetSelector(FuzzSelector({addr: address(this), selectors: selectors}));
+        targetContract(address(this));
+    }
+
+    function addLiquidity(uint8 rawIndex, uint96 rawAmount) external {
+        uint256 index = rawIndex % liquidities.length;
+        uint128 amount = uint128(bound(uint256(rawAmount), 1 ether, 1_000_000 ether));
+        if (type(uint128).max - liquidities[index] < amount) return;
+        _modify(lowers[index], uppers[index], int256(uint256(amount)));
+        liquidities[index] += amount;
+    }
+
+    function removeLiquidity(uint8 rawIndex, uint96 rawAmount) external {
+        uint256 index = rawIndex % liquidities.length;
+        uint128 current = liquidities[index];
+        if (current == 0) return;
+        uint128 amount = current < 2 ether ? current : uint128(bound(uint256(rawAmount), 1 ether, current));
+        _modify(lowers[index], uppers[index], -int256(uint256(amount)));
+        liquidities[index] -= amount;
+    }
+
+    function swapPool(bool zeroForOne, uint96 rawAmount) external {
+        uint256 amount = bound(uint256(rawAmount), 1, 1 ether);
+        swap(key, zeroForOne, -int256(amount), ZERO_BYTES);
+    }
+
+    function donate(uint64 raw0, uint64 raw1) external {
+        donateRouter.donate(key, uint256(raw0), uint256(raw1), ZERO_BYTES);
+    }
+
+    function invariant_matchesRecordedPositionAggregate() public view {
+        ReservesReference.Position[] memory positions = new ReservesReference.Position[](5);
+        positions[0] = ReservesReference.Position(-6000, 6000, BASE_LIQUIDITY);
+        for (uint256 i; i < liquidities.length; i++) {
+            positions[i + 1] = ReservesReference.Position(lowers[i], uppers[i], liquidities[i]);
+        }
+
+        (uint160 sqrtPriceX96, int24 currentTick,,) = manager.getSlot0(key.toId());
+        (uint256 expected0, uint256 expected1, uint128 expectedActive) =
+            ReservesReference.aggregate(sqrtPriceX96, currentTick, positions);
+        IReservesLens.PoolTVL memory actual = lens.getPoolTVL(manager, key, address(0));
+        assertEq(actual.coreAmount0, expected0);
+        assertEq(actual.coreAmount1, expected1);
+        assertEq(actual.activeLiquidity, expectedActive);
+    }
+
+    function _modify(int24 lower, int24 upper, int256 delta) private {
+        modifyLiquidityNoChecks.modifyLiquidity(key, ModifyLiquidityParams(lower, upper, delta, bytes32(0)), ZERO_BYTES);
+    }
+}

--- a/test/ReservesLens.t.sol
+++ b/test/ReservesLens.t.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {SqrtPriceMath} from "@uniswap/v4-core/src/libraries/SqrtPriceMath.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IReservesLens} from "../src/interfaces/IReservesLens.sol";
+import {ReservesLens} from "../src/lens/ReservesLens.sol";
+import {Deploy} from "./shared/Deploy.sol";
+
+contract ReservesLensTest is Test, Deployers {
+    using StateLibrary for *;
+
+    ReservesLens internal lens;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+        key = PoolKey(currency0, currency1, 3000, 60, IHooks(address(0)));
+        manager.initialize(key, SQRT_PRICE_1_1);
+        lens = new ReservesLens();
+    }
+
+    function test_emptyInitializedPool() public view {
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(result.coreAmount0, 0);
+        assertEq(result.coreAmount1, 0);
+        assertEq(result.sqrtPriceX96, SQRT_PRICE_1_1);
+        assertEq(result.tick, 0);
+        assertEq(result.activeLiquidity, 0);
+        assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.NO_HOOK));
+    }
+
+    function test_maximumTickSpacing() public {
+        PoolKey memory maximumSpacing = PoolKey(currency0, currency1, 100, 32767, IHooks(address(0)));
+        manager.initialize(maximumSpacing, SQRT_PRICE_1_1);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, maximumSpacing, address(0));
+        assertEq(result.coreAmount0, 0);
+        assertEq(result.coreAmount1, 0);
+    }
+
+    function test_constructorFreeCreate2Deployment() public {
+        bytes32 salt = keccak256("RESERVES_LENS_V1");
+        bytes memory initcode = vm.getCode("ReservesLens.sol:ReservesLens");
+        address expected = vm.computeCreate2Address(salt, keccak256(initcode), address(this));
+        IReservesLens deployed = Deploy.reservesLens(salt);
+        assertEq(address(deployed), expected);
+        assertEq(keccak256(address(deployed).code), keccak256(address(lens).code));
+    }
+
+    function test_singleInRangePosition() public {
+        uint128 liquidity = 10_000 ether;
+        _modify(-120, 120, int256(uint256(liquidity)));
+
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        uint256 expected0 =
+            SqrtPriceMath.getAmount0Delta(SQRT_PRICE_1_1, TickMath.getSqrtPriceAtTick(120), liquidity, false);
+        uint256 expected1 =
+            SqrtPriceMath.getAmount1Delta(TickMath.getSqrtPriceAtTick(-120), SQRT_PRICE_1_1, liquidity, false);
+        assertEq(result.coreAmount0, expected0);
+        assertEq(result.coreAmount1, expected1);
+        assertEq(result.activeLiquidity, liquidity);
+    }
+
+    function test_positionsBelowAndAbovePrice() public {
+        uint128 belowLiquidity = 7_000 ether;
+        uint128 aboveLiquidity = 11_000 ether;
+        _modify(-240, -120, int256(uint256(belowLiquidity)));
+        _modify(120, 300, int256(uint256(aboveLiquidity)));
+
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        uint256 expected0 = SqrtPriceMath.getAmount0Delta(
+            TickMath.getSqrtPriceAtTick(120), TickMath.getSqrtPriceAtTick(300), aboveLiquidity, false
+        );
+        uint256 expected1 = SqrtPriceMath.getAmount1Delta(
+            TickMath.getSqrtPriceAtTick(-240), TickMath.getSqrtPriceAtTick(-120), belowLiquidity, false
+        );
+        assertEq(result.coreAmount0, expected0);
+        assertEq(result.coreAmount1, expected1);
+        assertEq(result.activeLiquidity, 0);
+    }
+
+    function test_removedPositionIsNotCounted() public {
+        _modify(-120, 120, 10_000 ether);
+        _modify(-120, 120, -10_000 ether);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        assertEq(result.coreAmount0, 0);
+        assertEq(result.coreAmount1, 0);
+        assertEq(result.activeLiquidity, 0);
+    }
+
+    function test_zeroNetTickDoesNotSplitAggregateRounding() public {
+        uint128 liquidity = 1_000_000;
+        _modify(-120, 0, int256(uint256(liquidity)));
+        _modify(0, 120, int256(uint256(liquidity)));
+
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        uint256 expected0 =
+            SqrtPriceMath.getAmount0Delta(SQRT_PRICE_1_1, TickMath.getSqrtPriceAtTick(120), liquidity, false);
+        uint256 expected1 =
+            SqrtPriceMath.getAmount1Delta(TickMath.getSqrtPriceAtTick(-120), SQRT_PRICE_1_1, liquidity, false);
+        assertEq(result.coreAmount0, expected0);
+        assertEq(result.coreAmount1, expected1);
+        assertEq(result.activeLiquidity, liquidity);
+    }
+
+    function test_afterSwapUsesStoredPriceAndTick() public {
+        uint128 liquidity = 10_000 ether;
+        _modify(-600, 600, int256(uint256(liquidity)));
+        swap(key, true, -int256(100 ether), ZERO_BYTES);
+
+        (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(key.toId());
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL(manager, key, address(0));
+        uint256 expected0 =
+            SqrtPriceMath.getAmount0Delta(sqrtPriceX96, TickMath.getSqrtPriceAtTick(600), liquidity, false);
+        uint256 expected1 =
+            SqrtPriceMath.getAmount1Delta(TickMath.getSqrtPriceAtTick(-600), sqrtPriceX96, liquidity, false);
+        assertEq(result.sqrtPriceX96, sqrtPriceX96);
+        assertEq(result.tick, tick);
+        assertEq(result.coreAmount0, expected0);
+        assertEq(result.coreAmount1, expected1);
+    }
+
+    function test_donationsAreExcluded() public {
+        _modify(-120, 120, 10_000 ether);
+        IReservesLens.PoolTVL memory beforeDonation = lens.getPoolTVL(manager, key, address(0));
+        donateRouter.donate(key, 100 ether, 200 ether, ZERO_BYTES);
+        IReservesLens.PoolTVL memory afterDonation = lens.getPoolTVL(manager, key, address(0));
+        assertEq(afterDonation.coreAmount0, beforeDonation.coreAmount0);
+        assertEq(afterDonation.coreAmount1, beforeDonation.coreAmount1);
+    }
+
+    function test_pagedEqualsSingleShot() public {
+        _modify(-600, 600, 10_000 ether);
+        _modify(-120, 180, 4_000 ether);
+        _modify(0, 60, 2_000 ether);
+
+        IReservesLens.PoolTVL memory expected = lens.getPoolTVL(manager, key, address(0));
+        (IReservesLens.PoolTVL memory actual, uint256 pages) = _getPaged(key, 20);
+        assertGt(pages, 1);
+        _assertCoreEq(actual, expected);
+    }
+
+    function test_pagedMinimumBudgetMakesProgress() public {
+        _modify(-120, 120, 10_000 ether);
+        IReservesLens.PoolTVL memory expected = lens.getPoolTVL(manager, key, address(0));
+        (IReservesLens.PoolTVL memory actual,) = _getPaged(key, 2);
+        _assertCoreEq(actual, expected);
+    }
+
+    function test_batchEqualsIndividualCalls() public {
+        _modify(-120, 120, 10_000 ether);
+        PoolKey memory other = PoolKey(currency0, currency1, 500, 10, IHooks(address(0)));
+        manager.initialize(other, SQRT_PRICE_1_1);
+
+        PoolKey[] memory keys = new PoolKey[](2);
+        keys[0] = key;
+        keys[1] = other;
+        address[] memory providers = new address[](2);
+        IReservesLens.PoolTVL[] memory results = lens.getPoolTVLBatch(manager, keys, providers);
+
+        assertEq(results.length, 2);
+        _assertCoreEq(results[0], lens.getPoolTVL(manager, key, address(0)));
+        _assertCoreEq(results[1], lens.getPoolTVL(manager, other, address(0)));
+    }
+
+    function test_getPopulatedTicksInWord() public {
+        _modify(-120, 120, 10_000 ether);
+        _modify(0, 60, 2_000 ether);
+
+        IReservesLens.PopulatedTick[] memory ticks = lens.getPopulatedTicksInWord(manager, key, 0);
+        assertEq(ticks.length, 3);
+        assertEq(ticks[0].tick, 0);
+        assertEq(ticks[0].liquidityNet, 2_000 ether);
+        assertEq(ticks[0].liquidityGross, 2_000 ether);
+        assertEq(ticks[1].tick, 60);
+        assertEq(ticks[1].liquidityNet, -2_000 ether);
+        assertEq(ticks[1].liquidityGross, 2_000 ether);
+        assertEq(ticks[2].tick, 120);
+        assertEq(ticks[2].liquidityNet, -10_000 ether);
+        assertEq(ticks[2].liquidityGross, 10_000 ether);
+    }
+
+    function test_RevertWhen_BatchInputLengthsDiffer() public {
+        PoolKey[] memory keys = new PoolKey[](1);
+        keys[0] = key;
+        address[] memory providers = new address[](0);
+        vm.expectRevert(IReservesLens.InputLengthMismatch.selector);
+        lens.getPoolTVLBatch(manager, keys, providers);
+    }
+
+    function test_RevertWhen_Uninitialized() public {
+        PoolKey memory other = key;
+        other.fee = 500;
+        vm.expectRevert(abi.encodeWithSelector(IReservesLens.PoolNotInitialized.selector, other.toId()));
+        lens.getPoolTVL(manager, other, address(0));
+    }
+
+    function test_RevertWhen_ManagerDoesNotImplementExtsload() public {
+        vm.expectRevert();
+        lens.getPoolTVL(IPoolManager(address(0xbeef)), key, address(0));
+    }
+
+    function test_RevertWhen_InvalidPageBudget() public {
+        vm.expectRevert(abi.encodeWithSelector(IReservesLens.InvalidScanBudget.selector, uint32(1)));
+        lens.getPoolTVLPaged(manager, key, address(0), bytes(""), 1);
+        vm.expectRevert(abi.encodeWithSelector(IReservesLens.InvalidScanBudget.selector, uint32(4097)));
+        lens.getPoolTVLPaged(manager, key, address(0), bytes(""), 4097);
+    }
+
+    function test_RevertWhen_CursorBlockChanges() public {
+        (, bytes memory cursor, bool done) = lens.getPoolTVLPaged(manager, key, address(0), bytes(""), 2);
+        assertFalse(done);
+        uint256 previousBlock = block.number;
+        vm.roll(previousBlock + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(IReservesLens.CursorBlockMismatch.selector, previousBlock, previousBlock + 1)
+        );
+        lens.getPoolTVLPaged(manager, key, address(0), cursor, 2);
+    }
+
+    function test_RevertWhen_CursorContextChanges() public {
+        (, bytes memory cursor, bool done) = lens.getPoolTVLPaged(manager, key, address(0), bytes(""), 2);
+        assertFalse(done);
+        PoolKey memory other = key;
+        other.fee = 500;
+        vm.expectRevert(IReservesLens.CursorContextMismatch.selector);
+        lens.getPoolTVLPaged(manager, other, address(0), cursor, 2);
+    }
+
+    function _modify(int24 lower, int24 upper, int256 liquidityDelta) private {
+        modifyLiquidityRouter.modifyLiquidity(
+            key, ModifyLiquidityParams(lower, upper, liquidityDelta, bytes32(0)), ZERO_BYTES
+        );
+    }
+
+    function _getPaged(PoolKey memory poolKey, uint32 budget)
+        private
+        view
+        returns (IReservesLens.PoolTVL memory result, uint256 pages)
+    {
+        bytes memory cursor;
+        bool done;
+        while (!done) {
+            (result, cursor, done) = lens.getPoolTVLPaged(manager, poolKey, address(0), cursor, budget);
+            pages++;
+            assertLt(pages, 10_000);
+        }
+    }
+
+    function _assertCoreEq(IReservesLens.PoolTVL memory actual, IReservesLens.PoolTVL memory expected) private pure {
+        assertEq(actual.coreAmount0, expected.coreAmount0);
+        assertEq(actual.coreAmount1, expected.coreAmount1);
+        assertEq(actual.sqrtPriceX96, expected.sqrtPriceX96);
+        assertEq(actual.tick, expected.tick);
+        assertEq(actual.activeLiquidity, expected.activeLiquidity);
+        assertEq(actual.blockNumber, expected.blockNumber);
+    }
+}

--- a/test/mocks/MockHookStats.sol
+++ b/test/mocks/MockHookStats.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IHookStats} from "../../src/interfaces/external/IHookStats.sol";
+
+contract MockHookStats is IHookStats {
+    enum Mode {
+        VALID,
+        REVERT_STATS,
+        INVALID_EFFECTIVE,
+        WRONG_HOOK,
+        UNIVERSAL_ERC165,
+        RETURN_BOMB,
+        SHORT_RETURN,
+        GAS_BURN
+    }
+
+    address private immutable REPORTED_HOOK;
+    Mode private immutable MODE;
+
+    constructor(address reportedHook, Mode mode) {
+        REPORTED_HOOK = reportedHook;
+        MODE = mode;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+        if (MODE == Mode.UNIVERSAL_ERC165) return true;
+        return interfaceId == type(IHookStats).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    function hook() external view returns (address) {
+        return MODE == Mode.WRONG_HOOK ? address(0xdead) : REPORTED_HOOK;
+    }
+
+    function getReserves(PoolKey calldata) external view returns (uint256 amount0, uint256 amount1) {
+        if (MODE == Mode.REVERT_STATS) revert("STATS_REVERTED");
+        if (MODE == Mode.RETURN_BOMB) {
+            assembly ("memory-safe") {
+                return(0, 0x1000)
+            }
+        }
+        if (MODE == Mode.SHORT_RETURN) {
+            assembly ("memory-safe") {
+                mstore(0, 123)
+                return(0, 0x20)
+            }
+        }
+        if (MODE == Mode.GAS_BURN) {
+            assembly ("memory-safe") {
+                for {} 1 {} {}
+            }
+        }
+        return (1000, 2000);
+    }
+
+    function getEffectiveLiquidity(PoolKey calldata) external view returns (uint256 amount0, uint256 amount1) {
+        if (MODE == Mode.REVERT_STATS) revert("STATS_REVERTED");
+        return MODE == Mode.INVALID_EFFECTIVE ? (1001, 2001) : (500, 1000);
+    }
+}

--- a/test/shared/Deploy.sol
+++ b/test/shared/Deploy.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.26;
 import {Vm} from "forge-std/Vm.sol";
 import {IPositionDescriptor} from "../../src/interfaces/IPositionDescriptor.sol";
 import {IPositionManager} from "../../src/interfaces/IPositionManager.sol";
+import {IReservesLens} from "../../src/interfaces/IReservesLens.sol";
 import {IV4Quoter} from "../../src/interfaces/IV4Quoter.sol";
 import {IStateView} from "../../src/interfaces/IStateView.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
@@ -59,6 +60,11 @@ library Deploy {
         assembly {
             quoter := create2(0, add(initcode, 0x20), mload(initcode), salt)
         }
+    }
+
+    function reservesLens(bytes32 salt) internal returns (IReservesLens lens) {
+        bytes memory initcode = vm.getCode("ReservesLens.sol:ReservesLens");
+        lens = IReservesLens(create2(initcode, salt));
     }
 
     function transparentUpgradeableProxy(address implementation, address admin, bytes memory data, bytes memory salt)

--- a/test/shared/ReservesReference.sol
+++ b/test/shared/ReservesReference.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {SqrtPriceMath} from "@uniswap/v4-core/src/libraries/SqrtPriceMath.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+
+library ReservesReference {
+    struct Position {
+        int24 lower;
+        int24 upper;
+        uint128 liquidity;
+    }
+
+    function aggregate(uint160 sqrtPriceX96, int24 currentTick, Position[] memory positions)
+        internal
+        pure
+        returns (uint256 amount0, uint256 amount1, uint128 activeLiquidity)
+    {
+        int24[] memory ticks = new int24[](positions.length * 2);
+        for (uint256 i; i < positions.length; i++) {
+            ticks[i * 2] = positions[i].lower;
+            ticks[i * 2 + 1] = positions[i].upper;
+        }
+        _sort(ticks);
+
+        uint128 running;
+        bool hasPrevious;
+        int24 previous;
+        uint256 index;
+        while (index < ticks.length) {
+            int24 tick = ticks[index];
+            int256 net;
+            while (index < ticks.length && ticks[index] == tick) index++;
+            for (uint256 i; i < positions.length; i++) {
+                if (positions[i].lower == tick) net += int256(uint256(positions[i].liquidity));
+                if (positions[i].upper == tick) net -= int256(uint256(positions[i].liquidity));
+            }
+            if (net == 0) continue;
+
+            if (hasPrevious) {
+                if (currentTick >= previous && currentTick < tick) activeLiquidity = running;
+                (uint256 interval0, uint256 interval1) = _amounts(sqrtPriceX96, currentTick, previous, tick, running);
+                amount0 += interval0;
+                amount1 += interval1;
+            }
+            running = uint128(uint256(int256(uint256(running)) + net));
+            previous = tick;
+            hasPrevious = true;
+        }
+        assert(running == 0);
+    }
+
+    function _amounts(uint160 sqrtPriceX96, int24 currentTick, int24 tickA, int24 tickB, uint128 liquidity)
+        private
+        pure
+        returns (uint256 amount0, uint256 amount1)
+    {
+        if (liquidity == 0) return (0, 0);
+        uint160 sqrtA = TickMath.getSqrtPriceAtTick(tickA);
+        uint160 sqrtB = TickMath.getSqrtPriceAtTick(tickB);
+        if (currentTick < tickA) {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, liquidity, false);
+        } else if (currentTick < tickB) {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtPriceX96, sqrtB, liquidity, false);
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtPriceX96, liquidity, false);
+        } else {
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, liquidity, false);
+        }
+    }
+
+    function _sort(int24[] memory values) private pure {
+        for (uint256 i = 1; i < values.length; i++) {
+            int24 value = values[i];
+            uint256 j = i;
+            while (j > 0 && values[j - 1] > value) {
+                values[j] = values[j - 1];
+                j--;
+            }
+            values[j] = value;
+        }
+    }
+}


### PR DESCRIPTION
Add a stateless ReservesLens that reconstructs fee-excluded token reserves from PoolManager tick and liquidity state.

- support single-call, paginated, and batch reserve reads
- expose v3 TickLens-compatible populated tick data
- integrate guarded URC-3 hook reserve reporting
- add deterministic CREATE2 deployment tooling
- add an independent TypeScript reference implementation
- cover deterministic, fuzz, invariant, hostile-hook, gas, and fork cases
- validate against live Base and Robinhood Chain pools

## Design notes

**Why the PoolManager is a call parameter instead of a constructor immutable.** Constructor arguments are part of the CREATE2 initcode hash, and PoolManager addresses differ per chain, so baking the manager in (StateView-style) would produce a different lens address on every chain. Taking the manager per call keeps the initcode constant, enabling one deterministic address on all chains via the canonical CREATE2 deployer. The tradeoff: callers are responsible for passing the canonical PoolManager; a wrong manager yields meaningless results for that caller only (the lens is stateless and view-only).

**Gas guidance for integrators.** `getPoolTVL` scans the full initialized-tick domain. Bitmap-word reads alone cost ~33M gas for a tickSpacing=1 pool even when empty (see `snapshots/ReservesLensGasTest.json`), which exceeds the common 30M `eth_call` cap. Use `getPoolTVLPaged` for small tick spacings or providers with low simulation gas limits; a 512-read page stays around 2M gas.

## Review fixes (second commit)

- encode extsload calls via single-overload mirror interfaces so selectors are compile-time-checked
- revert with `ManagerBatchReadFailed(first, last, count)` on atomic batch read failures instead of reporting `slots[0]`
- report fork tests as skipped via `vm.skip` when RPC env vars are unset
- match TypeScript reference batch RPC responses by JSON-RPC id so partial batch responses cannot misalign results
- document the measured single-shot gas floor in `getPoolTVL` NatSpec; regenerate snapshots
