### PR TITLE
fix(lens): degrade per-call gas backstop to INSUFFICIENT_GAS instead of reverting

### DIFF
--- a/snapshots/ReservesLensGasTest.json
+++ b/snapshots/ReservesLensGasTest.json
@@ -1,6 +1,6 @@
 {
   "ReservesLens initcode hash (as uint256)": "92830991933286275337533000209364624083988208276193295243669663534797527362908",
   "ReservesLens_Bytecode": "15631",
-  "ReservesLens_empty_tickSpacingOne_page512": "2021992",
-  "ReservesLens_empty_tickSpacingOne_singleShot": "31646961"
+  "ReservesLens_empty_tickSpacingOne_page512": "2026492",
+  "ReservesLens_empty_tickSpacingOne_singleShot": "31651461"
 }

--- a/snapshots/ReservesLensGasTest.json
+++ b/snapshots/ReservesLensGasTest.json
@@ -1,6 +1,6 @@
 {
-  "ReservesLens initcode hash (as uint256)": "63686162268770475158304820924765911598195774196289156149271656108897798614227",
-  "ReservesLens_Bytecode": "15634",
+  "ReservesLens initcode hash (as uint256)": "92830991933286275337533000209364624083988208276193295243669663534797527362908",
+  "ReservesLens_Bytecode": "15631",
   "ReservesLens_empty_tickSpacingOne_page512": "2021992",
   "ReservesLens_empty_tickSpacingOne_singleShot": "31646961"
 }

--- a/src/interfaces/IReservesLens.sol
+++ b/src/interfaces/IReservesLens.sol
@@ -14,9 +14,10 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 interface IReservesLens {
     /// @notice Status of optional URC-3 hook statistics
     /// @dev DIRECT means the resolved provider is the hook itself (whether resolved from address(0) or passed
-    ///      explicitly); EXTERNAL means a distinct third-party provider. INSUFFICIENT_GAS means the probe was not
-    ///      attempted because remaining gas could not guarantee the stats stipends after the EIP-150 63/64 reduction;
-    ///      core fields are still valid and the caller can retry with more gas to obtain hook statistics.
+    ///      explicitly); EXTERNAL means a distinct third-party provider. INSUFFICIENT_GAS means a probe or stats call
+    ///      was not attempted because remaining gas could not guarantee its stipend after the EIP-150 63/64 reduction
+    ///      (checked up front and again before each stats call, since memory-expansion overhead scales with prior
+    ///      work in the call frame); core fields are still valid and the caller can retry with more gas.
     enum HookStatsStatus {
         NO_HOOK,
         NOT_SUPPORTED,
@@ -75,12 +76,6 @@ interface IReservesLens {
 
     /// @notice Thrown when a paged-call work budget is outside supported bounds
     error InvalidScanBudget(uint32 maxReads);
-
-    /// @notice Thrown when remaining gas cannot guarantee a hook-stats gas stipend after the EIP-150 63/64 reduction
-    /// @dev Backstop only: gas headroom for the ERC165 probes and all stats calls is checked up front and reported as
-    ///      INSUFFICIENT_GAS status, so this error should be unreachable. It exists so that a budgeting mistake can
-    ///      never gas-starve a healthy provider and misreport it as CALL_FAILED.
-    error InsufficientGasForHookStats();
 
     /// @notice Thrown when the supplied manager returns a malformed response to a batched extsload
     error ManagerBatchReadFailed(address manager, bytes32 firstSlot, bytes32 lastSlot, uint256 count);

--- a/src/lens/ReservesLens.sol
+++ b/src/lens/ReservesLens.sol
@@ -61,7 +61,8 @@ contract ReservesLens is IReservesLens {
     enum StaticCallStatus {
         SUCCESS,
         FAILED,
-        INVALID_RESPONSE
+        INVALID_RESPONSE,
+        INSUFFICIENT_GAS
     }
 
     /// @inheritdoc IReservesLens
@@ -471,20 +472,25 @@ contract ReservesLens is IReservesLens {
     }
 
     function _hookFailureStatus(StaticCallStatus status) private pure returns (HookStatsStatus) {
+        if (status == StaticCallStatus.INSUFFICIENT_GAS) return HookStatsStatus.INSUFFICIENT_GAS;
         return status == StaticCallStatus.FAILED ? HookStatsStatus.CALL_FAILED : HookStatsStatus.INVALID_RESPONSE;
     }
 
     /// @dev Bounds untrusted provider calls to HOOK_STATS_GAS_LIMIT so a malicious provider cannot consume the
     ///      caller's whole budget. EIP-150 forwards at most 63/64 of remaining gas, so the requested limit is only
-    ///      honored when enough gas remains. HOOK_STATS_GAS_BUDGET is checked before the probe sequence starts, so
-    ///      this guard is an unreachable backstop: if budgeting is ever wrong it reverts rather than let a starved
-    ///      provider be misclassified as CALL_FAILED.
+    ///      honored when enough gas remains. HOOK_STATS_GAS_BUDGET is checked before the probe sequence starts as a
+    ///      fast path, but memory expansion between the check and the final stats call scales with the free memory
+    ///      pointer (quadratic memory pricing after large scans or batches), so no constant overhead estimate can be
+    ///      guaranteed. A starved call therefore degrades to INSUFFICIENT_GAS status instead of reverting away the
+    ///      caller's completed core scan, and can never be misclassified as CALL_FAILED.
     function _boundedStaticcall(address target, bytes memory input, uint256 expectedSize)
         private
         view
         returns (StaticCallStatus status, bytes32 word0, bytes32 word1)
     {
-        if (gasleft() < (HOOK_STATS_GAS_LIMIT * 64) / 63 + 1_000) revert InsufficientGasForHookStats();
+        if (gasleft() < (HOOK_STATS_GAS_LIMIT * 64) / 63 + 1_000) {
+            return (StaticCallStatus.INSUFFICIENT_GAS, bytes32(0), bytes32(0));
+        }
 
         bool success;
         uint256 returnSize;

--- a/test/ReservesLens.hooks.t.sol
+++ b/test/ReservesLens.hooks.t.sol
@@ -181,6 +181,33 @@ contract ReservesLensHookTest is Test, Deployers {
         assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.INVALID_PROVIDER));
     }
 
+    /// @dev The hook-stats path must degrade to INSUFFICIENT_GAS at ANY gas budget, never revert away the core
+    ///      scan. The stipend-boundary check inside _boundedStaticcall is exercised by a provider that legally
+    ///      consumes nearly its full stipend on every call, so a caller landing between the up-front budget check
+    ///      and the per-call threshold degrades instead of reverting. Core amounts must be intact either way.
+    function testFuzz_hookStats_anyGasBudgetDegradesNeverReverts(uint32 rawGas) public {
+        key = _initializeHookPool(MockHookStats.Mode.VALID_GAS_HEAVY);
+        IReservesLens.PoolTVL memory expected = lens.getPoolTVL(manager, key, address(0));
+        assertEq(uint8(expected.statsStatus), uint8(IReservesLens.HookStatsStatus.DIRECT));
+
+        // Lower bound comfortably covers the core scan so an out-of-gas in the scan itself (an ordinary OOG,
+        // not the guarantee under test) cannot trip the fuzz run; upper bound is well past the stats budget.
+        uint256 gasBudget = bound(uint256(rawGas), 900_000, 3_000_000);
+        IReservesLens.PoolTVL memory result = lens.getPoolTVL{gas: gasBudget}(manager, key, address(0));
+
+        assertEq(result.coreAmount0, expected.coreAmount0);
+        assertEq(result.coreAmount1, expected.coreAmount1);
+        assertEq(result.activeLiquidity, expected.activeLiquidity);
+        if (result.statsStatus == IReservesLens.HookStatsStatus.DIRECT) {
+            assertEq(result.hookReserves0, expected.hookReserves0);
+            assertEq(result.hookReserves1, expected.hookReserves1);
+        } else {
+            assertEq(uint8(result.statsStatus), uint8(IReservesLens.HookStatsStatus.INSUFFICIENT_GAS));
+            assertEq(result.hookReserves0, 0);
+            assertEq(result.hookReserves1, 0);
+        }
+    }
+
     function _initializeHookPool(MockHookStats.Mode mode) private returns (PoolKey memory poolKey) {
         MockHookStats implementation = new MockHookStats(hookAddress, mode);
         vm.etch(hookAddress, address(implementation).code);

--- a/test/mocks/MockHookStats.sol
+++ b/test/mocks/MockHookStats.sol
@@ -14,7 +14,8 @@ contract MockHookStats is IHookStats {
         UNIVERSAL_ERC165,
         RETURN_BOMB,
         SHORT_RETURN,
-        GAS_BURN
+        GAS_BURN,
+        VALID_GAS_HEAVY
     }
 
     address private immutable REPORTED_HOOK;
@@ -31,10 +32,18 @@ contract MockHookStats is IHookStats {
     }
 
     function hook() external view returns (address) {
+        if (MODE == Mode.VALID_GAS_HEAVY) _burnMostForwardedGas();
         return MODE == Mode.WRONG_HOOK ? address(0xdead) : REPORTED_HOOK;
     }
 
+    /// @notice Consumes nearly the entire forwarded stipend before answering, to exercise the caller's
+    ///         worst-case gas accounting with responses that are still fully valid
+    function _burnMostForwardedGas() private view {
+        while (gasleft() > 30_000) {}
+    }
+
     function getReserves(PoolKey calldata) external view returns (uint256 amount0, uint256 amount1) {
+        if (MODE == Mode.VALID_GAS_HEAVY) _burnMostForwardedGas();
         if (MODE == Mode.REVERT_STATS) revert("STATS_REVERTED");
         if (MODE == Mode.RETURN_BOMB) {
             assembly ("memory-safe") {
@@ -56,6 +65,7 @@ contract MockHookStats is IHookStats {
     }
 
     function getEffectiveLiquidity(PoolKey calldata) external view returns (uint256 amount0, uint256 amount1) {
+        if (MODE == Mode.VALID_GAS_HEAVY) _burnMostForwardedGas();
         if (MODE == Mode.REVERT_STATS) revert("STATS_REVERTED");
         return MODE == Mode.INVALID_EFFECTIVE ? (1001, 2001) : (500, 1000);
     }


### PR DESCRIPTION
Stacked on #577. One behavioral change plus its test coverage.

## Problem

#577's up-front `HOOK_STATS_GAS_BUDGET` check reserves a constant 15k for local overhead between the check and the last stats call, with the per-call gas guard as a "should be unreachable" revert backstop. But that overhead is not constant: EVM memory pricing is quadratic against the frame's free memory pointer, which a tick-spacing-1 scan leaves at ~450KB (~58 gas/word marginal vs 3 fresh), and `getPoolTVLBatch` compounds it across pools (never freed within the frame). Worked worst case: a batch of several spacing-1 pools ending in a hooked pool whose provider legally consumes its full stipends, called with gas just above the budget threshold, passes the up-front check and then hits `InsufficientGasForHookStats` at the third stats call — reverting away ~100M+ gas of completed core scanning. That is exactly the failure mode #577 set out to eliminate, reachable in freeze-forever bytecode, because a constant pad can never beat quadratic memory growth.

## Fix

The per-call guard now degrades exactly like the up-front check: it returns `INSUFFICIENT_GAS` status with core amounts intact instead of reverting. The up-front budget check is kept as a fast path, but its overhead estimate is no longer load-bearing — any budgeting error in any memory regime yields the honest status. The now-unreachable `InsufficientGasForHookStats` error is removed from the interface (pre-freeze, no compat concern).

## Coverage

- New `MockHookStats.Mode.VALID_GAS_HEAVY`: burns ~94% of every forwarded stipend and still answers validly, exercising worst-case stipend consumption with a healthy provider.
- New fuzz test `testFuzz_hookStats_anyGasBudgetDegradesNeverReverts`: for any gas budget in [900k, 3M], the call never reverts and every outcome is either `DIRECT` with correct stats or `INSUFFICIENT_GAS` with intact core amounts. This pins the guarantee itself rather than an overhead estimate.
- All suites green (18 hooks, 35 main, fuzz, invariant 128k calls, gas); snapshots regenerated (bytecode 15,634 → 15,631).

🤖 Generated with [Claude Code](https://claude.com/claude-code)