### PR TITLE
refactor(perm-pools): Move the hook allowlist to PermissionsAdapter and enforce it across the router and position manager

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,8 @@ on:
       - main
   pull_request:
 
-permissions: {}
+permissions:
+  contents: read
 jobs:
   run-linters:
     name: Forge Linting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ on:
       - main
   pull_request:
 
-permissions: {}
+permissions:
+  contents: read
 jobs:
   run-tests:
     name: Forge Tests

--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,3 +1,5 @@
 {
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "242864"
+  "PermissionedV4Router_ExactIn3Hops_OrdinaryTokens_DistinctAssets": "261808",
+  "PermissionedV4Router_ExactInputSingle_OrdinaryTokens": "152056",
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "256406"
 }

--- a/snapshots/V4RouterTest.json
+++ b/snapshots/V4RouterTest.json
@@ -23,5 +23,5 @@
   "V4Router_ExactOutputSingle": "134076",
   "V4Router_ExactOutputSingle_nativeIn_sweepETH": "127158",
   "V4Router_ExactOutputSingle_nativeOut": "120592",
-  "router initcode hash (without constructor params, as uint256)": "42363725424555520568236519911959545672855231110666850371005005945997230752702"
+  "router initcode hash (without constructor params, as uint256)": "13879753072957690329751490072773068822094176245185708294534882769955974175406"
 }

--- a/src/V4Router.sol
+++ b/src/V4Router.sol
@@ -210,10 +210,17 @@ abstract contract V4Router is IV4Router, BaseActionsRouter, DeltaResolver {
         }
     }
 
+    /// @notice Validates a pool before swapping through it
+    /// @dev No-op by default. Called once per swap, i.e. for every hop of a multi-hop route.
+    ///      Inheriting routers override this to reject pools they must not trade in.
+    function _validatePoolKey(PoolKey memory poolKey) internal view virtual {}
+
     function _swap(PoolKey memory poolKey, bool zeroForOne, int256 amountSpecified, bytes calldata hookData)
         private
         returns (BalanceDelta delta)
     {
+        _validatePoolKey(poolKey);
+
         // for protection of exactOut swaps, sqrtPriceLimit is not exposed as a feature in this contract
         delta = poolManager.swap(
             poolKey,

--- a/src/base/DeltaResolver.sol
+++ b/src/base/DeltaResolver.sol
@@ -24,7 +24,7 @@ abstract contract DeltaResolver is ImmutableState {
     /// @param recipient Address to receive the currency
     /// @param amount Amount to take
     /// @dev Returns early if the amount is 0
-    function _take(Currency currency, address recipient, uint256 amount) internal {
+    function _take(Currency currency, address recipient, uint256 amount) internal virtual {
         if (amount == 0) return;
         poolManager.take(currency, recipient, amount);
     }

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -23,9 +23,6 @@ contract PermissionedPositionManager is PositionManager {
 
     IPermissionsAdapterFactory public immutable PERMISSIONS_ADAPTER_FACTORY;
 
-    mapping(Currency currency => mapping(IHooks hooks => bool)) public isAllowedHooks;
-
-    event AllowedHooksUpdated(Currency currency, IHooks hooks, bool allowed);
     event CurrencyUnwound(
         uint256 indexed tokenId,
         Currency indexed currency,
@@ -39,7 +36,6 @@ contract PermissionedPositionManager is PositionManager {
 
     error InvalidHook();
     error TransferDisabled();
-    error NotPermissionsAdapterAdmin();
     error NoVerifiedAdapter();
 
     /// @dev as this contract must know the hooks address in advance, it must be passed in as a constructor argument
@@ -55,23 +51,6 @@ contract PermissionedPositionManager is PositionManager {
         /// @dev The EIP712 domain separator still uses "Uniswap v4 Positions NFT" as the name
         name = "Uniswap v4 Permissioned Positions NFT";
         symbol = "UNI-V4-PERM-POSM";
-    }
-
-    /// @notice Sets the allowed hook for a given permissions adapter
-    /// @dev Sets which hooks are allowed to be used with a permissions adapter. Only callable by the owner of the permissions adapter.
-    ///      Revoking a hook (setting `allowed` to false) blocks future mints and liquidity increases on existing positions that use
-    ///      that hook; existing liquidity can still be decreased or burned so that holders can always exit.
-    /// @param currency The currency of the permissions adapter
-    /// @param hooks The hook to set the allowance for
-    /// @param allowed Whether the hook is allowed to be used with the permissions adapter
-    function setAllowedHook(Currency currency, IHooks hooks, bool allowed) external {
-        if (_getOwner(currency) != msg.sender) {
-            revert NotPermissionsAdapterAdmin();
-        }
-        bool oldAllowed = isAllowedHooks[currency][hooks];
-        if (oldAllowed == allowed) return;
-        isAllowedHooks[currency][hooks] = allowed;
-        emit AllowedHooksUpdated(currency, hooks, allowed);
     }
 
     /// @notice Force-exit the LP from a position. Burns the NFT, unwinds liquidity, and routes each currency.
@@ -214,7 +193,7 @@ contract PermissionedPositionManager is PositionManager {
     function _checkAllowedHook(Currency currency, IHooks hooks) internal view returns (bool) {
         address permissionedToken = _verifiedPermissionedTokenOf(currency);
         if (permissionedToken == address(0)) return true;
-        return isAllowedHooks[currency][hooks];
+        return IPermissionsAdapter(Currency.unwrap(currency)).allowedHooks(hooks);
     }
 
     /// @dev When paying to settle, if the currency is a permissioned token, wrap the token and transfer it to the pool manager.

--- a/src/hooks/permissionedPools/PermissionedV4Router.sol
+++ b/src/hooks/permissionedPools/PermissionedV4Router.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {ActionConstants} from "../../libraries/ActionConstants.sol";
-import {V4Router, IPoolManager, Currency} from "../../V4Router.sol";
+import {V4Router, IPoolManager, Currency, PoolKey} from "../../V4Router.sol";
 import {IPermissionsAdapter} from "./interfaces/IPermissionsAdapter.sol";
 import {IPermissionsAdapterFactory} from "./interfaces/IPermissionsAdapterFactory.sol";
 import {PermissionFlags} from "./libraries/PermissionFlags.sol";
@@ -15,11 +16,44 @@ abstract contract PermissionedV4Router is V4Router {
 
     error Unauthorized();
     error SwappingDisabled();
+    error HookNotAllowed();
 
     constructor(IPoolManager poolManager_, IPermissionsAdapterFactory permissionsAdapterFactory)
         V4Router(poolManager_)
     {
         PERMISSIONS_ADAPTER_FACTORY = permissionsAdapterFactory;
+    }
+
+    /// @inheritdoc V4Router
+    /// @dev Permission enforcement for a permissioned pool lives in its hook, so a pool holding a
+    ///      verified adapter must not be swapped through unless the adapter's owner has allow-listed
+    ///      that hook. Rejecting only `address(0)` is insufficient — a no-op hook, or an address mined
+    ///      without `BEFORE_SWAP_FLAG`, would otherwise pass.
+    function _validatePoolKey(PoolKey memory poolKey) internal view override {
+        if (address(PERMISSIONS_ADAPTER_FACTORY) == address(0)) return;
+        _validateHook(poolKey.currency0, poolKey.hooks);
+        _validateHook(poolKey.currency1, poolKey.hooks);
+    }
+
+    /// @notice Reverts if `currency` is a verified permissions adapter that has not allow-listed `hooks`
+    function _validateHook(Currency currency, IHooks hooks) internal view {
+        if (PERMISSIONS_ADAPTER_FACTORY.verifiedPermissionsAdapterOf(Currency.unwrap(currency)) == address(0)) return;
+        if (!IPermissionsAdapter(Currency.unwrap(currency)).allowedHooks(hooks)) revert HookNotAllowed();
+    }
+
+    function _take(Currency currency, address recipient, uint256 amount) internal virtual override {
+        address permissionedToken = address(PERMISSIONS_ADAPTER_FACTORY) == address(0)
+            ? address(0)
+            : PERMISSIONS_ADAPTER_FACTORY.verifiedPermissionsAdapterOf(Currency.unwrap(currency));
+
+        // If the token is permissioned, validate swapping is enabled and the sender is swap-allowed
+        if (permissionedToken != address(0)) {
+            IPermissionsAdapter permissionsAdapter = IPermissionsAdapter(Currency.unwrap(currency));
+            if (!permissionsAdapter.swappingEnabled()) revert SwappingDisabled();
+            if (!permissionsAdapter.isAllowed(msgSender(), PermissionFlags.SWAP_ALLOWED)) revert Unauthorized();
+        }
+
+        super._take(currency, recipient, amount);
     }
 
     function _pay(Currency currency, address payer, uint256 amount) internal virtual override {

--- a/src/hooks/permissionedPools/PermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/PermissionsAdapter.sol
@@ -30,6 +30,9 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
     /// @inheritdoc IPermissionsAdapter
     mapping(address wrapper => bool) public allowedWrappers;
 
+    /// @inheritdoc IPermissionsAdapter
+    mapping(IHooks hook => bool) public allowedHooks;
+
     constructor(
         IERC20 permissionedToken,
         address poolManager,
@@ -66,6 +69,11 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
     }
 
     /// @inheritdoc IPermissionsAdapter
+    function updateAllowedHook(IHooks hook, bool allowed) external onlyOwner {
+        _updateAllowedHook(hook, allowed);
+    }
+
+    /// @inheritdoc IPermissionsAdapter
     function updateSwappingEnabled(bool enabled) external onlyOwner {
         _updateSwappingEnabled(enabled);
     }
@@ -86,6 +94,13 @@ contract PermissionsAdapter is ERC20, Ownable2Step, IPermissionsAdapter {
     function _updateAllowedWrapper(address wrapper, bool allowed) internal {
         allowedWrappers[wrapper] = allowed;
         emit AllowedWrapperUpdated(wrapper, allowed);
+    }
+
+    function _updateAllowedHook(IHooks hook, bool allowed) internal {
+        bool oldAllowed = allowedHooks[hook];
+        if (oldAllowed == allowed) return;
+        allowedHooks[hook] = allowed;
+        emit AllowedHookUpdated(hook, allowed);
     }
 
     function _updateSwappingEnabled(bool enabled) internal {

--- a/src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol
+++ b/src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol
@@ -12,6 +12,9 @@ interface IPermissionsAdapter is IERC20 {
     /// @notice Emitted when an allowed wrapper is updated
     event AllowedWrapperUpdated(address indexed wrapper, bool allowed);
 
+    /// @notice Emitted when an allowed hook is updated
+    event AllowedHookUpdated(IHooks indexed hook, bool allowed);
+
     /// @notice Emitted when the swapping enabled status is updated
     event SwappingEnabledUpdated(bool enabled);
 
@@ -56,6 +59,14 @@ interface IPermissionsAdapter is IERC20 {
     /// @dev To ensure the permissions adapter cannot be wrapped in an ERC6909 token on the PoolManager, the wrapper must only implement `swap` or `modifyLiquidity` functions
     function updateAllowedWrapper(address wrapper, bool allowed) external;
 
+    /// @notice Updates the allowed hook
+    /// @param hook The hook to update
+    /// @param allowed Whether the hook is allowed
+    /// @dev Only callable by the owner
+    /// @dev Revoking a hook blocks future mints and liquidity increases on positions using it. Decreases
+    /// and burns are deliberately left open so that holders can always exit an existing position.
+    function updateAllowedHook(IHooks hook, bool allowed) external;
+
     /// @notice Updates the swapping enabled status
     /// @param enabled Whether swapping is enabled
     /// @dev Only callable by the owner
@@ -72,6 +83,11 @@ interface IPermissionsAdapter is IERC20 {
     /// @dev e.g., the permissioned pool manager, quoters or the swap router
     /// @dev Wrappers must honestly report `msgSender()` to maintain permission guarantees.
     function allowedWrappers(address wrapper) external view returns (bool);
+
+    /// @notice Returns whether a hook is allowed
+    /// @param hook The hook to check
+    /// @dev For a pool pairing two adapters, both adapters must approve the hook
+    function allowedHooks(IHooks hook) external view returns (bool);
 
     /// @notice Returns the swapping enabled status
     function swappingEnabled() external view returns (bool);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -220,22 +220,9 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
         Currency permissionsAdapterCurrency = Currency.wrap(address(permissionsAdapter));
 
-        setAllowedHooks(lpm, permissionsAdapterCurrency, permissionedHooks);
-        setAllowedHooks(tertiaryPosm, permissionsAdapterCurrency, permissionedHooks);
-
-        setAllowedHooks(lpm, permissionsAdapterCurrency, secondaryPermissionedHooks);
-        setAllowedHooks(secondaryPosm, permissionsAdapterCurrency, secondaryPermissionedHooks);
-        setAllowedHooks(tertiaryPosm, permissionsAdapterCurrency, secondaryPermissionedHooks);
-
-        setAllowedHooks(lpm, permissionsAdapterCurrency, insecureHooks);
-    }
-
-    function setAllowedHooks(IPositionManager posm, Currency currency, IHooks permissionedHooks_) internal {
-        // setAllowedHook selector
-        bytes4 selector = 0xb5cdc484;
-        bytes memory data = abi.encodeWithSelector(selector, currency, permissionedHooks_, true);
-        (bool success,) = address(posm).call(data);
-        require(success, "Failed to set hooks");
+        setAllowedHooks(permissionsAdapterCurrency, permissionedHooks, true);
+        setAllowedHooks(permissionsAdapterCurrency, secondaryPermissionedHooks, true);
+        setAllowedHooks(permissionsAdapterCurrency, insecureHooks, true);
     }
 
     function test_nameAndSymbol() public view {
@@ -643,24 +630,25 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), alice);
     }
 
-    function test_permissioned_mint_alt_posm_diff_hooks_reverts() public {
-        // secondary posm uses different hooks contract
-        _test_permissioned_mint_alt_posm_diff_hooks_reverts(key0, secondaryPosm);
-        _test_permissioned_mint_alt_posm_diff_hooks_reverts(key1, secondaryPosm);
-        _test_permissioned_mint_alt_posm_diff_hooks_reverts(key2, secondaryPosm);
+    function test_permissioned_mint_disallowed_hook_reverts() public {
+        _test_permissioned_mint_disallowed_hook_reverts(key0);
+        _test_permissioned_mint_disallowed_hook_reverts(key1);
+        _test_permissioned_mint_disallowed_hook_reverts(key2);
     }
 
-    function _test_permissioned_mint_alt_posm_diff_hooks_reverts(PoolKey memory key, IPositionManager posm) internal {
+    function _test_permissioned_mint_disallowed_hook_reverts(PoolKey memory key) internal {
         PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
-
         uint256 liquidity = 1e18;
 
-        // we don't use the helper, so we can choose which position manager to use
-        bytes memory calls = getMintEncoded(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+        // Revoke the hook as the adapter admin (address(this) owns both permissionsAdapter0 and permissionsAdapter2)
+        _setHookAllowedForKey(key, false);
 
         vm.prank(alice);
         vm.expectRevert(InvalidHook.selector);
-        posm.modifyLiquidities(calls, block.timestamp + 1);
+        mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+
+        // restore so the fan-out across keys is independent
+        _setHookAllowedForKey(key, true);
     }
 
     function test_permissioned_mint_alt_posm_same_hooks_reverts() public {
@@ -689,6 +677,35 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             )
         );
         posm.modifyLiquidities(calls, block.timestamp + 1);
+    }
+
+    function test_permissioned_mint_alt_posm_allowed_wrapper_succeeds() public {
+        // secondary posm is an allowed wrapper, so the adapter-level hook allowlist is sufficient on its own
+        _test_permissioned_mint_alt_posm_allowed_wrapper_succeeds(key0, secondaryPosm);
+        _test_permissioned_mint_alt_posm_allowed_wrapper_succeeds(key1, secondaryPosm);
+        _test_permissioned_mint_alt_posm_allowed_wrapper_succeeds(key2, secondaryPosm);
+    }
+
+    function _test_permissioned_mint_alt_posm_allowed_wrapper_succeeds(PoolKey memory key, IPositionManager posm)
+        internal
+    {
+        PositionConfig memory config = PositionConfig({poolKey: key, tickLower: -120, tickUpper: 120});
+
+        uint256 liquidity = 1e18;
+        uint256 tokenId = posm.nextTokenId();
+
+        // alice already approved permit2 on the underlying tokens; approve this posm as the permit2 spender
+        vm.startPrank(alice);
+        permit2.approve(Currency.unwrap(currency0), address(posm), type(uint160).max, type(uint48).max);
+        permit2.approve(Currency.unwrap(currency1), address(posm), type(uint160).max, type(uint48).max);
+        permit2.approve(Currency.unwrap(currency2), address(posm), type(uint160).max, type(uint48).max);
+
+        // we don't use the helper, so we can choose which position manager to use
+        bytes memory calls = getMintEncoded(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
+        posm.modifyLiquidities(calls, block.timestamp + 1);
+        vm.stopPrank();
+
+        assertEq(IERC721(address(posm)).ownerOf(tokenId), alice);
     }
 
     function test_permissioned_mint_disallowed_user_reverts() public {
@@ -1615,14 +1632,14 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         mint(config, liquidity, ActionConstants.MSG_SENDER, ZERO_BYTES);
 
         Currency revoked = revokeCurrency0 ? key.currency0 : key.currency1;
-        _setHookAllowed(revoked, key.hooks, false);
+        setAllowedHooks(revoked, key.hooks, false);
 
         vm.prank(alice);
         vm.expectRevert(InvalidHook.selector);
         increaseLiquidity(tokenId, config, liquidity, ZERO_BYTES);
 
         // Restore for the next iteration so the tests are independent.
-        _setHookAllowed(revoked, key.hooks, true);
+        setAllowedHooks(revoked, key.hooks, true);
     }
 
     // =============================================================================
@@ -1732,25 +1749,17 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(alice, PermissionFlags.ALL_ALLOWED);
     }
 
-    // Helpers for toggling the hook allowlist in tests. Uses a raw selector call to mirror the
-    // pattern established by `setAllowedHooks` (line 227).
+    // Helpers for toggling the hook allowlist in tests
     function _setHookAllowedForKey(PoolKey memory key, bool allowed) internal {
         _setHookAllowedIfPermissioned(key.currency0, key.hooks, allowed);
         _setHookAllowedIfPermissioned(key.currency1, key.hooks, allowed);
     }
 
     function _setHookAllowedIfPermissioned(Currency currency, IHooks hooks_, bool allowed) internal {
-        // setAllowedHook requires the currency to have a verified permissions adapter;
+        // updateAllowedHook requires the currency to have a verified permissions adapter;
         // skip unpermissioned currencies so mixed-pool keys (key0, key1) work with this helper.
         if (permissionsAdapterFactory.verifiedPermissionsAdapterOf(Currency.unwrap(currency)) == address(0)) return;
-        _setHookAllowed(currency, hooks_, allowed);
-    }
-
-    function _setHookAllowed(Currency currency, IHooks hooks_, bool allowed) internal {
-        // setAllowedHook(Currency,IHooks,bool) selector
-        bytes4 selector = 0xb5cdc484;
-        (bool success,) = address(lpm).call(abi.encodeWithSelector(selector, currency, hooks_, allowed));
-        require(success, "setAllowedHook failed");
+        setAllowedHooks(currency, hooks_, allowed);
     }
 
     // ===== unwindPosition / withdrawClaim helpers =====

--- a/test/hooks/permissionedPools/PermissionedV4Router.t.sol
+++ b/test/hooks/permissionedPools/PermissionedV4Router.t.sol
@@ -23,6 +23,10 @@ import {MockPermissionedToken, MockAllowlistChecker} from "./PermissionedPoolsBa
 import {MockPermissionedHooks} from "./mocks/MockPermissionedHooks.sol";
 import {PermissionFlags, PermissionFlag} from "../../../src/hooks/permissionedPools/libraries/PermissionFlags.sol";
 import {PathKey} from "../../../src/libraries/PathKey.sol";
+import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {MockUnapprovedWrapper} from "./mocks/MockUnapprovedWrapper.sol";
 
 contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
     using PermitHash for IAllowanceTransfer.PermitSingle;
@@ -131,6 +135,53 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
         vm.snapshotGasLastCall("PermissionedV4Router_ExactInputSingle_PermissionedTokens");
     }
 
+    /// @notice Cost of an ordinary, non-permissioned swap routed through the permissioned router.
+    ///         This is what UniversalRouter users pay, since V4SwapRouter inherits PermissionedV4Router.
+    function test_gas_swapExactInputSingle_ordinaryTokens() public {
+        uint256 amountIn = 1000;
+        // key2 is currency2/currency3 with no hook — neither side is a permissions adapter
+        IV4Router.ExactInputSingleParams memory params =
+            IV4Router.ExactInputSingleParams(key2, true, uint128(amountIn), 0, 0, bytes(""));
+
+        plan = plan.add(Actions.SWAP_EXACT_IN_SINGLE, abi.encode(params));
+        bytes memory data = plan.finalizeSwap(key2.currency0, key2.currency1, ActionConstants.MSG_SENDER);
+
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+        vm.snapshotGasLastCall("PermissionedV4Router_ExactInputSingle_OrdinaryTokens");
+    }
+
+    /// @notice Cost of an ordinary 3-hop swap over four distinct assets through the permissioned router.
+    ///         Distinct intermediates are what make multi-hop expensive: each is a currency the router
+    ///         never looked up before, so it costs a cold storage read that a same-pool route would not.
+    function test_gas_swapExactIn3Hops_ordinaryTokens_distinctAssets() public {
+        MockERC20[] memory extra = deployTokens(1, 2 ** 128, false);
+        Currency currency5 = Currency.wrap(address(extra[0]));
+        approveAllContracts(address(extra[0]));
+        extra[0].approve(address(permissionedRouter), type(uint256).max);
+        extra[0].approve(address(positionManager), type(uint256).max);
+
+        // key2 already covers currency2/currency3; add the two remaining legs
+        createPoolWithLiquidity(currency3, currency4, address(0));
+        createPoolWithLiquidity(currency4, currency5, address(0));
+
+        // currency2 -> currency3 -> currency4 -> currency5, no repeats
+        PathKey[] memory path = new PathKey[](3);
+        path[0] = PathKey(currency3, 3000, 60, IHooks(address(0)), bytes(""));
+        path[1] = PathKey(currency4, 3000, 60, IHooks(address(0)), bytes(""));
+        path[2] = PathKey(currency5, 3000, 60, IHooks(address(0)), bytes(""));
+
+        IV4Router.ExactInputParams memory params =
+            IV4Router.ExactInputParams(currency2, path, new uint256[](0), uint128(1000), 0);
+
+        // createPoolWithLiquidity builds its mint on the shared `plan`, so reset before the swap
+        plan = Planner.init();
+        plan = plan.add(Actions.SWAP_EXACT_IN, abi.encode(params));
+        bytes memory data = plan.finalizeSwap(currency2, currency5, ActionConstants.MSG_SENDER);
+
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+        vm.snapshotGasLastCall("PermissionedV4Router_ExactIn3Hops_OrdinaryTokens_DistinctAssets");
+    }
+
     /*//////////////////////////////////////////////////////////////
                         PERMISSION TESTS
     //////////////////////////////////////////////////////////////*/
@@ -167,6 +218,90 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
             )
         );
         permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+    }
+
+    error HookNotAllowed();
+
+    /// @notice A pool holding a verified adapter with no hook installed must be rejected before the swap runs.
+    ///         Uses an authorized swapper, so the rejection is attributable to the hook and not to SWAP_ALLOWED.
+    function test_swap_reverts_hooklessPoolWithVerifiedAdapter() public {
+        IERC20(Currency.unwrap(currency0)).transfer(alice, 2 ether);
+        currency4.transfer(alice, 2 ether);
+
+        // same currencies as key3, but with no hook installed
+        Currency currencyA = permissionsAdapter0Currency;
+        Currency currencyB = currency4;
+        if (Currency.unwrap(currencyA) > Currency.unwrap(currencyB)) (currencyA, currencyB) = (currencyB, currencyA);
+        PoolKey memory hooklessKey = PoolKey(currencyA, currencyB, 3000, 60, IHooks(address(0)));
+        manager.initialize(hooklessKey, SQRT_PRICE_1_1);
+
+        // ordinary token in, permissioned adapter out — the direction the router never used to check
+        bool zeroForOne = currencyA == currency4;
+        IV4Router.ExactInputSingleParams memory params =
+            IV4Router.ExactInputSingleParams(hooklessKey, zeroForOne, 1 ether, 0, 0, bytes(""));
+
+        plan = plan.add(Actions.SWAP_EXACT_IN_SINGLE, abi.encode(params));
+        bytes memory data = plan.finalizeSwap(currency4, permissionsAdapter0Currency, ActionConstants.MSG_SENDER);
+
+        vm.prank(alice);
+        vm.expectRevert(HookNotAllowed.selector);
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+    }
+
+    /// @notice A non-zero hook that is not on the adapter's allowlist must also be rejected. Rejecting only
+    ///         `address(0)` would let a no-op hook, or an address mined without BEFORE_SWAP_FLAG, straight through.
+    function test_swap_reverts_unapprovedNonZeroHook() public {
+        IERC20(Currency.unwrap(currency0)).transfer(alice, 2 ether);
+        IERC20(Currency.unwrap(currency1)).transfer(alice, 2 ether);
+
+        IV4Router.ExactInputSingleParams memory params =
+            IV4Router.ExactInputSingleParams(insecureKey, true, uint128(1 ether), 0, 0, bytes(""));
+
+        // insecureHooks is allow-listed in setUp, so this identical swap succeeds
+        plan = plan.add(Actions.SWAP_EXACT_IN_SINGLE, abi.encode(params));
+        bytes memory data = plan.finalizeSwap(insecureKey.currency0, insecureKey.currency1, ActionConstants.MSG_SENDER);
+        vm.prank(alice);
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+
+        // revoke the hook on one side and the same swap is now rejected
+        setAllowedHooks(permissionsAdapter0Currency, insecureHooks, false);
+
+        plan = Planner.init();
+        plan = plan.add(Actions.SWAP_EXACT_IN_SINGLE, abi.encode(params));
+        data = plan.finalizeSwap(insecureKey.currency0, insecureKey.currency1, ActionConstants.MSG_SENDER);
+        vm.prank(alice);
+        vm.expectRevert(HookNotAllowed.selector);
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+    }
+
+    /// @notice A wrapper that is not on the adapter's `allowedWrappers` list cannot obtain an adapter delta.
+    ///         This is what closes the ERC-6909 route: `PoolManager.mint` turns a delta into a freely
+    ///         transferable claim without ever entering `PermissionsAdapter._update`, so the underlying
+    ///         token's allowlist never runs and denying the delta is the only defense. Unapproved-hook
+    ///         pools are covered separately — they can never hold adapter inventory to begin with.
+    function test_unapprovedWrapper_cannotObtainAdapterDelta() public {
+        // reports alice, who holds ALL_ALLOWED, so the allowlist check on the swapper passes and the
+        // only remaining barrier is that the wrapper itself is not on `allowedWrappers`
+        MockUnapprovedWrapper unapprovedWrapper = new MockUnapprovedWrapper(manager, alice);
+        assertTrue(permissionsAdapter0.isAllowed(alice, PermissionFlags.SWAP_ALLOWED));
+        assertFalse(permissionsAdapter0.allowedWrappers(address(unapprovedWrapper)));
+
+        bool zeroForOne = key3.currency0 == currency4;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(permissionedHooks),
+                IHooks.beforeSwap.selector,
+                abi.encodeWithSelector(Unauthorized.selector),
+                abi.encodeWithSelector(HookCallFailed.selector)
+            )
+        );
+        unapprovedWrapper.swap(
+            key3,
+            SwapParams(zeroForOne, -1e15, zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1),
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            bytes("")
+        );
     }
 
     error SwappingDisabled();
@@ -229,6 +364,59 @@ contract PermissionedV4RouterTest is PermissionedRoutingTestHelpers {
 
         vm.prank(alice);
         vm.expectRevert(SwappingDisabled.selector);
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+    }
+
+    /// @dev The adapter is only on the output side, so `_pay` takes the standard path and the router's
+    ///         `_take` is the sole guard. `insecureHooks` performs no permission checks, so a revert here
+    ///         can only originate in the router. Should revert when swapping is disabled on the output adapter.
+    function test_take_revert_when_swapping_disabled_on_output_adapter() public {
+        PoolKey memory mixedInsecureKey =
+            createPoolWithLiquidity(permissionsAdapter0Currency, currency2, address(insecureHooks));
+        // minting liquidity above leaves its own actions on the shared plan
+        plan = Planner.init();
+
+        IERC20(Currency.unwrap(currency2)).transfer(alice, 2 ether);
+
+        uint256 amountIn = 100;
+        bool zeroForOne = mixedInsecureKey.currency0 == currency2;
+
+        IV4Router.ExactInputSingleParams memory params =
+            IV4Router.ExactInputSingleParams(mixedInsecureKey, zeroForOne, uint128(amountIn), 0, 0, bytes(""));
+
+        plan = plan.add(Actions.SWAP_EXACT_IN_SINGLE, abi.encode(params));
+        bytes memory data = plan.finalizeSwap(currency2, permissionsAdapter0Currency, ActionConstants.MSG_SENDER);
+
+        permissionsAdapter0.updateSwappingEnabled(false);
+
+        vm.prank(alice);
+        vm.expectRevert(SwappingDisabled.selector);
+        permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
+    }
+
+    /// @dev The adapter is only on the output side, so `_pay` takes the standard path and the router's
+    ///         `_take` is the sole guard. `insecureHooks` performs no permission checks, so a revert here
+    ///         can only originate in the router. Should revert when msg.sender is not swap-allowed.
+    function test_take_revert_when_unauthorized_on_output_adapter() public {
+        PoolKey memory mixedInsecureKey =
+            createPoolWithLiquidity(permissionsAdapter0Currency, currency2, address(insecureHooks));
+        // minting liquidity above leaves its own actions on the shared plan
+        plan = Planner.init();
+
+        IERC20(Currency.unwrap(currency2)).transfer(alice, 2 ether);
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(alice, PermissionFlags.LIQUIDITY_ALLOWED);
+
+        uint256 amountIn = 100;
+        bool zeroForOne = mixedInsecureKey.currency0 == currency2;
+
+        IV4Router.ExactInputSingleParams memory params =
+            IV4Router.ExactInputSingleParams(mixedInsecureKey, zeroForOne, uint128(amountIn), 0, 0, bytes(""));
+
+        plan = plan.add(Actions.SWAP_EXACT_IN_SINGLE, abi.encode(params));
+        bytes memory data = plan.finalizeSwap(currency2, permissionsAdapter0Currency, ActionConstants.MSG_SENDER);
+
+        vm.prank(alice);
+        vm.expectRevert(Unauthorized.selector);
         permissionedRouter.execute(COMMAND_V4_SWAP, toBytesArray(data), type(uint256).max);
     }
 

--- a/test/hooks/permissionedPools/PermissionsAdapter.t.sol
+++ b/test/hooks/permissionedPools/PermissionsAdapter.t.sol
@@ -5,6 +5,7 @@ import {
     IPermissionsAdapter,
     IAllowlistChecker
 } from "../../../src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {ERC20, IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {PermissionedPoolsBase, MockAllowlistChecker} from "./PermissionedPoolsBase.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
@@ -40,7 +41,7 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         assertEq(address(permissionsAdapter.PERMISSIONED_TOKEN()), address(permissionedToken));
     }
 
-    function testRevert_WhenNotOwner(address account) public {
+    function testRevert_WhenNotOwner(address account, IHooks hooks) public {
         vm.assume(account != owner);
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, account));
@@ -49,6 +50,8 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         permissionsAdapter.updateAllowListChecker(allowlistChecker);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, account));
         permissionsAdapter.updateSwappingEnabled(true);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, account));
+        permissionsAdapter.updateAllowedHook(hooks, true);
         vm.stopPrank();
     }
 
@@ -88,6 +91,17 @@ contract PermissionsAdapterTest is PermissionedPoolsBase {
         emit IPermissionsAdapter.AllowedWrapperUpdated(wrapper, allowed);
         permissionsAdapter.updateAllowedWrapper(wrapper, allowed);
         assertEq(permissionsAdapter.allowedWrappers(wrapper), allowed);
+    }
+
+    function test_UpdateAllowedHook(IHooks hooks, bool allowed) public {
+        vm.startPrank(owner);
+        if (permissionsAdapter.allowedHooks(hooks) != allowed) {
+            vm.expectEmit(true, true, true, true);
+            emit IPermissionsAdapter.AllowedHookUpdated(hooks, allowed);
+        }
+        permissionsAdapter.updateAllowedHook(hooks, allowed);
+        assertEq(permissionsAdapter.allowedHooks(hooks), allowed);
+        vm.stopPrank();
     }
 
     function testRevert_WhenNotSupportedInterfaceEOA(IAllowlistChecker newAllowListCheckerEOA) public {

--- a/test/hooks/permissionedPools/mocks/MockUnapprovedWrapper.sol
+++ b/test/hooks/permissionedPools/mocks/MockUnapprovedWrapper.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
+import {IMsgSender} from "../../../../src/interfaces/IMsgSender.sol";
+
+/// @notice A wrapper absent from an adapter's `allowedWrappers` list.
+/// @dev Reports a `msgSender` that holds the required flag, so a revert is attributable to the wrapper
+///      check rather than the permission check. A wrapper without `msgSender()` is rejected earlier, on
+///      the hook's staticcall, which proves nothing.
+contract MockUnapprovedWrapper is PoolSwapTest, IMsgSender {
+    address private immutable SENDER;
+
+    constructor(IPoolManager manager_, address sender_) PoolSwapTest(manager_) {
+        SENDER = sender_;
+    }
+
+    /// @inheritdoc IMsgSender
+    function msgSender() external view returns (address) {
+        return SENDER;
+    }
+}

--- a/test/hooks/permissionedPools/shared/PermissionedDeployers.sol
+++ b/test/hooks/permissionedPools/shared/PermissionedDeployers.sol
@@ -43,6 +43,7 @@ import {Deploy} from "../../../../test/shared/Deploy.sol";
 import {HookMiner} from "../../../shared/HookMiner.sol";
 import {IWETH9} from "../../../../src/interfaces/external/IWETH9.sol";
 import {PermissionFlags} from "../../../../src/hooks/permissionedPools/libraries/PermissionFlags.sol";
+import {IPermissionsAdapter} from "../../../../src/hooks/permissionedPools/interfaces/IPermissionsAdapter.sol";
 
 /// @notice A contract that provides permissioned deployment functionality for tests
 /// This moves the deployFreshManagerAndRoutersPermissioned function from v4-core to the test folder
@@ -164,6 +165,11 @@ contract PermissionedDeployers is Test {
         );
         assertEq(addr, calculatedAddr);
         deployedHooksAddr = calculatedAddr;
+    }
+
+    /// @dev `currency` must be a permissions adapter, which owns the hook allowlist
+    function setAllowedHooks(Currency currency, IHooks permissionedHooks_, bool allowed) internal {
+        IPermissionsAdapter(Currency.unwrap(currency)).updateAllowedHook(permissionedHooks_, allowed);
     }
 
     function deployPermissionedV4Router(address permit2_, address permissionsAdapterFactory_, address weth9)

--- a/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
+++ b/test/hooks/permissionedPools/shared/PermissionedRoutingTestHelpers.sol
@@ -161,23 +161,11 @@ contract PermissionedRoutingTestHelpers is PermissionedDeployers, DeployPermit2 
         permissionsAdapter0.updateAllowedWrapper(address(permissionedHooks), true);
         permissionsAdapter1.updateAllowedWrapper(address(permissionedHooks), true);
 
-        setAllowedHooks(
-            IPositionManager(positionManager), Currency.wrap(address(permissionsAdapter0)), permissionedHooks
-        );
-        setAllowedHooks(
-            IPositionManager(positionManager), Currency.wrap(address(permissionsAdapter1)), permissionedHooks
-        );
+        setAllowedHooks(Currency.wrap(address(permissionsAdapter0)), permissionedHooks, true);
+        setAllowedHooks(Currency.wrap(address(permissionsAdapter1)), permissionedHooks, true);
 
-        setAllowedHooks(IPositionManager(positionManager), Currency.wrap(address(permissionsAdapter0)), insecureHooks);
-        setAllowedHooks(IPositionManager(positionManager), Currency.wrap(address(permissionsAdapter1)), insecureHooks);
-    }
-
-    function setAllowedHooks(IPositionManager posm, Currency currency, IHooks permissionedHooks_) internal {
-        // addPermissionedHooks selector
-        bytes4 selector = 0xb5cdc484;
-        bytes memory data = abi.encodeWithSelector(selector, currency, permissionedHooks_, true);
-        (bool success,) = address(posm).call(data);
-        require(success, "Failed to set hooks");
+        setAllowedHooks(Currency.wrap(address(permissionsAdapter0)), insecureHooks, true);
+        setAllowedHooks(Currency.wrap(address(permissionsAdapter1)), insecureHooks, true);
     }
 
     function createPoolWithLiquidity(Currency currencyA, Currency currencyB, address hookAddr)


### PR DESCRIPTION
## Related Issue
N/A

## Description of changes
- Moves the per-currency hook allowlist from PermissionedPositionManager onto PermissionsAdapter (allowedHooks / updateAllowedHook), so the allowlist lives with the adapter it governs.
- PermissionedV4Router validates each pool currency's hook against the adapter's allowlist via _validatePoolKey, and checks swappingEnabled / SWAP_ALLOWED when taking or paying a verified adapter.
- Adds a _validatePoolKey extension point to V4Router (no-op by default, called once per hop) and makes DeltaResolver._take virtual.
- PermissionedPositionManager validates the same allowlist on mint and increase.
- Gas snapshots regenerated. All perm-pool, router, payments, and position-manager suites pass.