### PR TITLE
fix(perm-pools): run UNSUBSCRIBE in its own unlock; add burn bounds and hookData

### DIFF
--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -76,10 +76,17 @@ contract PermissionedPositionManager is PositionManager {
 
     /// @notice Force-exit the LP from a position. Burns the NFT, unwinds liquidity, and routes each currency.
     /// @dev Either PA admin may call. Per-currency fallback is derived on-chain via `_getOwner` (see
-    ///      `_unwindWithFallback`). The 6909 fallback never reverts, so the call is atomic. Emits one
-    ///      `CurrencyUnwound` event per leg.
+    ///      `_unwindWithFallback`). The 6909 fallback never reverts, so routing cannot strand a currency.
+    ///      Emits one `CurrencyUnwound` event per leg.
     /// @param tokenId The position to unwind
-    function unwindPosition(uint256 tokenId) external isNotLocked {
+    /// @param amount0Min Minimum currency0 the burn must return; 0 disables the check
+    /// @param amount1Min Minimum currency1 the burn must return; 0 disables the check
+    /// @param hookData Forwarded to the pool's hook on removal, for hook extensions that require it
+    /// @dev Non-zero bounds revert the burn instead of executing it below them.
+    function unwindPosition(uint256 tokenId, uint128 amount0Min, uint128 amount1Min, bytes calldata hookData)
+        external
+        isNotLocked
+    {
         (PoolKey memory poolKey,) = getPoolAndPositionInfo(tokenId);
         address admin0 = _getOwner(poolKey.currency0);
         address admin1 = _getOwner(poolKey.currency1);
@@ -87,22 +94,30 @@ contract PermissionedPositionManager is PositionManager {
 
         address lp = ownerOf(tokenId);
 
-        // Pre-approve so BURN_POSITION inside the unlock passes its onlyIfApproved check.
+        // Approve so UNSUBSCRIBE below passes its own _isApprovedOrOwner check.
+        getApproved[tokenId] = msg.sender;
+
+        // Unsubscribe in a separate unlock. A hostile subscriber can overwrite getApproved during
+        // notifyUnsubscribe, but that write is discarded by the re-approval below, once this unlock
+        // has closed and no further subscriber callback can run.
+        bytes memory actions = abi.encodePacked(uint8(Actions.UNSUBSCRIBE));
+        bytes[] memory params = new bytes[](1);
+        params[0] = abi.encode(tokenId);
+        poolManager.unlock(abi.encode(actions, params));
+
+        // Re-approve so BURN_POSITION passes onlyIfApproved even if the subscriber hijacked the slot.
         // ERC-721 _burn clears getApproved as part of its teardown, so the approval is self-cleaning.
         getApproved[tokenId] = msg.sender;
 
-        bytes memory actions = abi.encodePacked(
-            uint8(Actions.UNSUBSCRIBE),
-            uint8(Actions.BURN_POSITION),
-            uint8(Actions.UNWIND_WITH_FALLBACK),
-            uint8(Actions.UNWIND_WITH_FALLBACK)
+        // Unwind
+        actions = abi.encodePacked(
+            uint8(Actions.BURN_POSITION), uint8(Actions.UNWIND_WITH_FALLBACK), uint8(Actions.UNWIND_WITH_FALLBACK)
         );
-        bytes[] memory params = new bytes[](4);
-        params[0] = abi.encode(tokenId);
-        params[1] = abi.encode(tokenId, uint128(0), uint128(0), bytes(""));
+        params = new bytes[](3);
+        params[0] = abi.encode(tokenId, amount0Min, amount1Min, hookData);
         // PoolKey is encoded into the unwind params because BURN_POSITION clears positionInfo[tokenId].
-        params[2] = abi.encode(poolKey, poolKey.currency0, lp, tokenId);
-        params[3] = abi.encode(poolKey, poolKey.currency1, lp, tokenId);
+        params[1] = abi.encode(poolKey, poolKey.currency0, lp, tokenId);
+        params[2] = abi.encode(poolKey, poolKey.currency1, lp, tokenId);
         poolManager.unlock(abi.encode(actions, params));
     }
 

--- a/src/hooks/permissionedPools/PermissionedPositionManager.sol
+++ b/src/hooks/permissionedPools/PermissionedPositionManager.sol
@@ -94,26 +94,25 @@ contract PermissionedPositionManager is PositionManager {
 
         address lp = ownerOf(tokenId);
 
-        // Approve so UNSUBSCRIBE below passes its own _isApprovedOrOwner check.
-        getApproved[tokenId] = msg.sender;
+        // Unsubscribe in its own unlock only when a subscriber is attached.
+        if (positionInfo[tokenId].hasSubscriber()) {
+            // Approve so UNSUBSCRIBE passes its own _isApprovedOrOwner check.
+            getApproved[tokenId] = msg.sender;
+            bytes memory unsubscribeAction = abi.encodePacked(uint8(Actions.UNSUBSCRIBE));
+            bytes[] memory unsubscribeParams = new bytes[](1);
+            unsubscribeParams[0] = abi.encode(tokenId);
+            poolManager.unlock(abi.encode(unsubscribeAction, unsubscribeParams));
+        }
 
-        // Unsubscribe in a separate unlock. A hostile subscriber can overwrite getApproved during
-        // notifyUnsubscribe, but that write is discarded by the re-approval below, once this unlock
-        // has closed and no further subscriber callback can run.
-        bytes memory actions = abi.encodePacked(uint8(Actions.UNSUBSCRIBE));
-        bytes[] memory params = new bytes[](1);
-        params[0] = abi.encode(tokenId);
-        poolManager.unlock(abi.encode(actions, params));
-
-        // Re-approve so BURN_POSITION passes onlyIfApproved even if the subscriber hijacked the slot.
+        // Approve so BURN_POSITION passes onlyIfApproved.
         // ERC-721 _burn clears getApproved as part of its teardown, so the approval is self-cleaning.
         getApproved[tokenId] = msg.sender;
 
         // Unwind
-        actions = abi.encodePacked(
+        bytes memory actions = abi.encodePacked(
             uint8(Actions.BURN_POSITION), uint8(Actions.UNWIND_WITH_FALLBACK), uint8(Actions.UNWIND_WITH_FALLBACK)
         );
-        params = new bytes[](3);
+        bytes[] memory params = new bytes[](3);
         params[0] = abi.encode(tokenId, amount0Min, amount1Min, hookData);
         // PoolKey is encoded into the unwind params because BURN_POSITION clears positionInfo[tokenId].
         params[1] = abi.encode(poolKey, poolKey.currency0, lp, tokenId);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -37,6 +37,10 @@ import {INotifier} from "../../../src/interfaces/INotifier.sol";
 import {MockUnsubscribeRevertingSubscriber} from "../../mocks/MockUnsubscribeRevertingSubscriber.sol";
 import {MockBurnRevertingSubscriber} from "../../mocks/MockBurnRevertingSubscriber.sol";
 import {MockReentrantSubscriber} from "../../mocks/MockReentrantSubscriber.sol";
+import {MockApprovalHijackSubscriber} from "../../mocks/MockApprovalHijackSubscriber.sol";
+import {MockRemoveLiquidityDataHook} from "./mocks/MockRemoveLiquidityDataHook.sol";
+import {HookMiner} from "../../shared/HookMiner.sol";
+import {Deploy} from "../../shared/Deploy.sol";
 import {MockSubscriber} from "../../mocks/MockSubscriber.sol";
 
 contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, LiquidityFuzzers {
@@ -1757,7 +1761,7 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
 
     /// @dev V4 rounds in favor of the pool: a mint+burn roundtrip loses up to 1 wei per side.
     uint256 private constant _ROUNDTRIP_TOLERANCE = 1;
-    bytes4 private constant _UNWIND_SELECTOR = 0x37058749;
+    bytes4 private constant _UNWIND_SELECTOR = 0xb0a281b0;
     bytes4 private constant _WITHDRAW_CLAIM_SELECTOR = 0xf77de3fc;
 
     event CurrencyUnwound(
@@ -1776,7 +1780,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
     }
 
     function _unwind(uint256 tokenId) internal {
-        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), bytes("")));
         require(ok, "unwindPosition failed");
     }
 
@@ -2030,7 +2035,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         _test_permissioned_mint_allowed_user(key2);
 
         vm.prank(notAdmin);
-        (bool ok, bytes memory data) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
+        (bool ok, bytes memory data) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), bytes("")));
         assertEq(ok, false);
         assertEq(bytes4(data), Unauthorized.selector);
     }
@@ -2308,6 +2314,96 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         assertEq(nonPermissioned.balanceOf(address(lpm)), 0);
     }
 
+    // ===== Caller-supplied burn bounds and hookData on unwindPosition =====
+
+    /// @dev Bounds the burn can satisfy do not change the outcome.
+    function test_unwindPosition_withSatisfiableMinAmounts_succeeds() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(1), uint128(1), bytes("")));
+
+        assertEq(ok, true);
+        assertEq(lpm.getPositionLiquidity(tokenId), 0);
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId);
+    }
+
+    /// @dev Bounds the burn cannot satisfy revert the whole force-exit and leave the position intact.
+    function test_unwindPosition_withUnsatisfiableMinAmounts_revertsAndPreservesPosition() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+        uint256 liquidityBefore = lpm.getPositionLiquidity(tokenId);
+
+        (bool ok, bytes memory data) = address(lpm)
+            .call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, type(uint128).max, type(uint128).max, bytes("")));
+
+        assertEq(ok, false);
+        assertEq(bytes4(data), SlippageCheck.MinimumAmountInsufficient.selector);
+        assertEq(lpm.getPositionLiquidity(tokenId), liquidityBefore, "position untouched");
+        assertEq(IERC721(address(lpm)).ownerOf(tokenId), alice);
+    }
+
+    /// @dev A custom hook extension with remove-liquidity callbacks receives the caller-supplied `hookData`.
+    function test_unwindPosition_forwardsHookDataToHook() public {
+        (MockRemoveLiquidityDataHook hook, PoolKey memory hookKey) = _setUpRemoveLiquidityDataHookPool();
+        uint256 tokenId = lpm.nextTokenId();
+        PositionConfig memory config = PositionConfig({poolKey: hookKey, tickLower: -120, tickUpper: 120});
+        vm.prank(alice);
+        mint(config, 1e18, alice, ZERO_BYTES);
+
+        bytes memory hookData = abi.encode("force-exit", tokenId);
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), hookData));
+
+        assertEq(ok, true);
+        assertEq(hook.lastHookData(), hookData, "hook received the caller-supplied hookData");
+        assertEq(lpm.getPositionLiquidity(tokenId), 0);
+    }
+
+    /// @dev Control: the same pool with empty hookData reverts in the hook, proving the test above passes
+    ///      because the data was forwarded and not because the hook is inert.
+    function test_unwindPosition_emptyHookDataRevertsInHook() public {
+        (, PoolKey memory hookKey) = _setUpRemoveLiquidityDataHookPool();
+        uint256 tokenId = lpm.nextTokenId();
+        PositionConfig memory config = PositionConfig({poolKey: hookKey, tickLower: -120, tickUpper: 120});
+        vm.prank(alice);
+        mint(config, 1e18, alice, ZERO_BYTES);
+
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), bytes("")));
+
+        assertEq(ok, false);
+        assertEq(lpm.getPositionLiquidity(tokenId), 1e18, "position untouched");
+    }
+
+    /// @dev Deploys a hook mined with BEFORE_REMOVE_LIQUIDITY_FLAG, allowlists it, and opens a pool
+    ///      pairing it with a verified adapter.
+    function _setUpRemoveLiquidityDataHookPool()
+        internal
+        returns (MockRemoveLiquidityDataHook hook, PoolKey memory hookKey)
+    {
+        uint160 flags = uint160(1 << 9); // BEFORE_REMOVE_LIQUIDITY_FLAG
+        (address expected, bytes32 salt) = HookMiner.find(
+            address(this), flags, vm.getCode("MockRemoveLiquidityDataHook.sol:MockRemoveLiquidityDataHook"), ""
+        );
+        address deployed =
+            Deploy.create2(vm.getCode("MockRemoveLiquidityDataHook.sol:MockRemoveLiquidityDataHook"), salt);
+        assertEq(deployed, expected);
+        hook = MockRemoveLiquidityDataHook(payable(deployed));
+
+        (hookKey,) = initPool(
+            Currency.wrap(address(permissionsAdapter0)),
+            Currency.wrap(address(permissionsAdapter2)),
+            IHooks(deployed),
+            3000,
+            SQRT_PRICE_1_1
+        );
+        setAllowedHooks(lpm, Currency.wrap(address(permissionsAdapter0)), IHooks(deployed));
+        setAllowedHooks(lpm, Currency.wrap(address(permissionsAdapter2)), IHooks(deployed));
+    }
+
     // ===== Subscriber DoS protection on unwindPosition =====
 
     /// @dev Admin force-exit succeeds even when the LP attached a subscriber that reverts on
@@ -2322,7 +2418,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(sub));
 
         // address(this) is admin of both adapters (default setUp)
-        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), bytes("")));
         assertEq(ok, true);
 
         // subscriber detached, NFT burned
@@ -2356,10 +2453,69 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
         vm.prank(alice);
         IERC721(address(lpm)).setApprovalForAll(address(sub), true);
 
-        (bool ok,) = address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId));
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), bytes("")));
         assertEq(ok, true);
 
         // Subscriber fully detached — no re-attach happened, despite the reentry attempt.
+        assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(0));
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId);
+    }
+
+    /// @dev Admin force-exit succeeds even when the LP's subscriber overwrites the admin's temporary
+    ///      ERC-721 approval during `notifyUnsubscribe`. `approve` has no `onlyIfPoolManagerLocked` guard so
+    ///      the write lands, but UNSUBSCRIBE runs in its own unlock and the approval is re-applied after that
+    ///      unlock closes, so BURN_POSITION still passes `onlyIfApproved`. Here the subscriber is the
+    ///      position owner, so `approve` passes on the `msg.sender == owner` branch.
+    function test_unwindPosition_with_approvalHijackingSubscriber_succeeds() public {
+        MockApprovalHijackSubscriber sub = new MockApprovalHijackSubscriber(address(lpm), true, address(0));
+        // a contract LP needs LIQUIDITY_ALLOWED on both underlyings to hold the position
+        MockPermissionedToken(Currency.unwrap(currency0)).setAllowlist(address(sub), PermissionFlags.ALL_ALLOWED);
+        MockPermissionedToken(Currency.unwrap(currency2)).setAllowlist(address(sub), PermissionFlags.ALL_ALLOWED);
+
+        PositionConfig memory config = PositionConfig({poolKey: key2, tickLower: -120, tickUpper: 120});
+        uint256 tokenId = lpm.nextTokenId();
+        vm.prank(alice);
+        mint(config, 1e18, address(sub), ZERO_BYTES);
+        assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(sub));
+
+        sub.subscribeSelf(tokenId);
+        assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(sub));
+
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), bytes("")));
+        assertEq(ok, true);
+
+        // the hijacking write did land inside the callback, and was discarded by the re-approval
+        assertEq(sub.notifyUnsubscribeCount(), 1);
+        assertGt(sub.gasUsedByApprove(), 0);
+
+        assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(0));
+        vm.expectRevert();
+        IERC721(address(lpm)).ownerOf(tokenId);
+    }
+
+    /// @dev Same hijack through the `isApprovedForAll[owner][msg.sender]` branch instead: an EOA LP attaches a
+    ///      separate malicious subscriber and grants it operator-for-all. Operator authority outlives the
+    ///      admin's per-token approval, so this shape needs coverage of its own.
+    function test_unwindPosition_with_operatorApprovalHijackingSubscriber_succeeds() public {
+        uint256 tokenId = lpm.nextTokenId();
+        _test_permissioned_mint_allowed_user(key2);
+
+        MockApprovalHijackSubscriber sub = new MockApprovalHijackSubscriber(address(lpm), true, address(0));
+        vm.prank(alice);
+        INotifier(address(lpm)).subscribe(tokenId, address(sub), "");
+        vm.prank(alice);
+        IERC721(address(lpm)).setApprovalForAll(address(sub), true);
+
+        (bool ok,) =
+            address(lpm).call(abi.encodeWithSelector(_UNWIND_SELECTOR, tokenId, uint128(0), uint128(0), bytes("")));
+        assertEq(ok, true);
+
+        assertEq(sub.notifyUnsubscribeCount(), 1);
+        assertGt(sub.gasUsedByApprove(), 0);
+
         assertEq(address(INotifier(address(lpm)).subscriber(tokenId)), address(0));
         vm.expectRevert();
         IERC721(address(lpm)).ownerOf(tokenId);

--- a/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
+++ b/test/hooks/permissionedPools/PermissionedPositionManager.t.sol
@@ -2409,8 +2409,8 @@ contract PermissionedPositionManagerTest is Test, PermissionedPosmTestSetup, Liq
             3000,
             SQRT_PRICE_1_1
         );
-        setAllowedHooks(lpm, Currency.wrap(address(permissionsAdapter0)), IHooks(deployed));
-        setAllowedHooks(lpm, Currency.wrap(address(permissionsAdapter2)), IHooks(deployed));
+        setAllowedHooks(Currency.wrap(address(permissionsAdapter0)), IHooks(deployed), true);
+        setAllowedHooks(Currency.wrap(address(permissionsAdapter2)), IHooks(deployed), true);
     }
 
     // ===== Subscriber DoS protection on unwindPosition =====

--- a/test/hooks/permissionedPools/mocks/MockRemoveLiquidityDataHook.sol
+++ b/test/hooks/permissionedPools/mocks/MockRemoveLiquidityDataHook.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+
+/// @notice Stands in for a custom permissioned-hook extension that requires `hookData` on removal.
+/// @dev Mined with `BEFORE_REMOVE_LIQUIDITY_FLAG` only, so it is never invoked on add and cannot interfere
+///      with seeding liquidity. Reverts on empty `hookData` so callers can assert the value was forwarded.
+contract MockRemoveLiquidityDataHook {
+    error HookDataRequired();
+
+    bytes public lastHookData;
+
+    function beforeRemoveLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata hookData)
+        external
+        returns (bytes4)
+    {
+        if (hookData.length == 0) revert HookDataRequired();
+        lastHookData = hookData;
+        return IHooks.beforeRemoveLiquidity.selector;
+    }
+
+    receive() external payable {}
+}

--- a/test/mocks/MockApprovalHijackSubscriber.sol
+++ b/test/mocks/MockApprovalHijackSubscriber.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC721} from "forge-std/interfaces/IERC721.sol";
+import {ISubscriber} from "../../src/interfaces/ISubscriber.sol";
+import {INotifier} from "../../src/interfaces/INotifier.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {PositionInfo} from "../../src/libraries/PositionInfoLibrary.sol";
+
+/// @notice Subscriber that overwrites `getApproved[tokenId]` during `notifyUnsubscribe`.
+/// @dev `approve` carries no `onlyIfPoolManagerLocked` guard, so the write lands even from inside an
+///      active unlock callback. Two attacker shapes both satisfy `ERC721Permit_v4.approve`'s auth check:
+///      the subscriber IS the owner (a contract LP subscribing itself), or it holds `setApprovalForAll`.
+///      Must return cleanly — `_unsubscribe` wraps the callback in try/catch, so reverting would roll the
+///      hijacking SSTORE back. Set `approveTarget` to the admin to write the same value back, isolating the
+///      written value rather than the act of reentering, and `approveDuringCallback = false` for a
+///      behaviourally benign control.
+contract MockApprovalHijackSubscriber is ISubscriber {
+    IERC721 public immutable posm;
+    bool public immutable approveDuringCallback;
+    /// @dev `address(0)` is a sentinel meaning "approve myself".
+    address public immutable approveTarget;
+
+    uint256 public notifyUnsubscribeCount;
+    uint256 public gasUsedByApprove;
+
+    constructor(address _posm, bool _approveDuringCallback, address _approveTarget) {
+        posm = IERC721(_posm);
+        approveDuringCallback = _approveDuringCallback;
+        approveTarget = _approveTarget;
+    }
+
+    /// @notice Used by the contract-LP shape, where the subscriber is itself the position owner.
+    function subscribeSelf(uint256 tokenId) external {
+        INotifier(address(posm)).subscribe(tokenId, address(this), "");
+    }
+
+    function notifySubscribe(uint256, bytes memory) external {}
+
+    function notifyUnsubscribe(uint256 tokenId) external {
+        if (approveDuringCallback) {
+            uint256 gasBefore = gasleft();
+            posm.approve(approveTarget == address(0) ? address(this) : approveTarget, tokenId);
+            gasUsedByApprove = gasBefore - gasleft();
+        }
+        notifyUnsubscribeCount++;
+    }
+
+    function notifyModifyLiquidity(uint256, int256, BalanceDelta) external {}
+
+    function notifyBurn(uint256, address, PositionInfo, uint256, BalanceDelta) external {}
+}


### PR DESCRIPTION
## Related Issue
N/A

## Description of changes
- unwindPosition performs UNSUBSCRIBE in a separate unlock, then re-applies the caller's approval immediately before BURN_POSITION, so the approval the burn depends on is set right before it runs.
- Adds amount0Min / amount1Min / hookData parameters, forwarded to BURN_POSITION (bounds → validateMinOut, hookData → the pool hook on removal). Zero bounds and empty hookData preserve current behavior.
- Adds coverage for both approval-lifecycle paths and for the new parameters.