### PR TITLE
docs: trim SwapAndAdd documentation to minimal, plain-language comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Copy to .env (gitignored). Never put a raw private key here — import it once into an encrypted
+# Copy to .env (gitignored). Never put a raw private key here. Import it once into an encrypted
 # keystore instead and pass `--account <name>` to forge script / cast:
 #   cast wallet import swap-and-add-deployer --interactive
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -25,13 +25,13 @@ compilation_restrictions = [
 ]
 
 # Integration profile for the SwapAndAdd tests that need the real Universal Router (test-integration/).
-# The real UR requires via_ir, but the default profile disables it for test/**; foundry cannot mix a via_ir
-# unit with a non-via_ir unit that share forge-std. Under FOUNDRY_PROFILE=integration the whole graph compiles
-# with via_ir on (no test/** opt-out), so these tests and the nested UR build cleanly. The default profile
-# is unchanged, so the SwapAndAdd unit suite in test/ keeps running exactly as before.
-#   Run it with:  FOUNDRY_PROFILE=integration forge test
-# The integration tests live in their own `test-integration/` dir, which only this profile compiles — so a plain
-# `forge test` on the default profile never pulls in the (via_ir-only) UR and the default suite is unaffected.
+# The real router requires via_ir, but the default profile disables via_ir for test/**, and foundry
+# cannot mix a via_ir unit with a non-via_ir unit that share forge-std. Under
+# FOUNDRY_PROFILE=integration the whole graph compiles with via_ir on, so these tests and the nested
+# router build cleanly.
+#   Run it with: FOUNDRY_PROFILE=integration forge test
+# Only this profile compiles the test-integration/ directory. A plain forge test on the default
+# profile never pulls in the via_ir-only router, so the default suite is unaffected.
 [profile.integration]
 test = 'test-integration'
 via_ir = true

--- a/script/DeploySwapAndAdd.s.sol
+++ b/script/DeploySwapAndAdd.s.sol
@@ -12,18 +12,17 @@ import {SwapAndAdd} from "../src/SwapAndAdd.sol";
 import {IPositionManager} from "../src/interfaces/IPositionManager.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 
-/// @notice Deploys the patched Universal Router (feat/v4-swap-within-existing-unlock, submodule @ cf27fb66e5)
-///         and SwapAndAdd wired to it. The CANONICAL UR cannot be used: routed operations execute V4_SWAP
-///         inside SwapAndAdd's already-open PoolManager unlock, which the canonical router rejects
-///         (AlreadyUnlocked). Until that UR feature ships canonically, every SwapAndAdd deployment carries
-///         its own router instance.
+/// @notice Deploys SwapAndAdd with the patched Universal Router
+///         (feat/v4-swap-within-existing-unlock, submodule commit cf27fb66e5). The canonical router
+///         rejects V4_SWAP inside SwapAndAdd's already-open unlock (AlreadyUnlocked), so each
+///         deployment carries its own router.
 ///
-///         Run (simulate):  FOUNDRY_PROFILE=integration forge script script/DeploySwapAndAdd.s.sol \
-///                            --rpc-url sepolia
-///         Run (broadcast): add  --broadcast --private-key $DEPLOYER_KEY   (or --account <keystore>)
+///         Simulate:  FOUNDRY_PROFILE=integration forge script script/DeploySwapAndAdd.s.sol \
+///                      --rpc-url sepolia
+///         Broadcast: add --broadcast --account <keystore>
 ///
-///         Sepolia parameters mirror the official universal-router DeploySepolia.s.sol; PoolManager, POSM and
-///         Permit2 re-verified onchain (cast code) 2026-07-13.
+///         Sepolia parameters mirror universal-router DeploySepolia.s.sol, re-verified onchain
+///         with cast code on 2026-07-13.
 contract DeploySwapAndAdd is Script {
     struct ChainParams {
         address poolManager;
@@ -40,9 +39,8 @@ contract DeploySwapAndAdd is Script {
 
     function run() external {
         ChainParams memory c = _params(block.chainid);
-        // Reuse an already-deployed patched router (built from the SAME universal-router submodule commit)
-        // by passing ROUTER=<address>; the router is the expensive half of the deployment and the zap only
-        // needs its address. Unset -> deploy a fresh router pair as before.
+        // ROUTER=<address> reuses a deployed patched router (same submodule commit). Unset
+        // deploys a fresh one.
         address existingRouter = vm.envOr("ROUTER", address(0));
 
         vm.startBroadcast();
@@ -80,7 +78,7 @@ contract DeploySwapAndAdd is Script {
     }
 
     function _params(uint256 chainid) internal pure returns (ChainParams memory) {
-        // Sepolia — source: universal-router script/deployParameters/DeploySepolia.s.sol (submodule cf27fb66e5)
+        // Sepolia. Source: universal-router script/deployParameters/DeploySepolia.s.sol (submodule cf27fb66e5)
         if (chainid == 11155111) {
             return ChainParams({
                 poolManager: 0xE03A1074c86CFeDd5C142C4F04F1a1536e203543,

--- a/script/fetch-tapi-route.sh
+++ b/script/fetch-tapi-route.sh
@@ -6,8 +6,9 @@
 #   - amountIn: raw units
 #   - chainId: default 11155111 (Sepolia)
 #
-# IMPORTANT: request the quote with swapper = the SwapAndAdd deployment — the UR executes with the zap as
-# msg.sender, so pulls/recipients must map to it. No permit data: the zap holds standing Permit2 allowances.
+# IMPORTANT: request the quote with swapper = the SwapAndAdd deployment. The router executes with
+# the zap as msg.sender, so pulls and recipients must map to it. Do not include permit data, the zap
+# holds standing Permit2 allowances.
 set -euo pipefail
 
 TOKEN_IN=${1:?tokenIn}
@@ -17,12 +18,13 @@ CHAIN_ID=${4:-11155111}
 SWAPPER=${SWAPPER:-0x6f923892d6A45f7e77DB36f48F055C045F93E979} # live Sepolia SwapAndAdd
 API=${TAPI_URL:-https://trading-api-labs.interface.gateway.uniswap.org/v1}
 KEY=${TAPI_API_KEY:?set TAPI_API_KEY (see .env)}
-# Router ABI generation to encode for (public x-universal-router-version header). Must match the ABI of the
-# router that will execute the route; the API default targets an older generation than this repo's deployment.
+# Router ABI generation to encode for (the x-universal-router-version header). It must match the
+# ABI of the router that executes the route. The API default targets an older generation than this
+# repo's deployment.
 UR_VERSION=${UR_VERSION:-2.2.0}
-# Routing preference (allowed: BEST_PRICE, FASTEST). NOTE 2026-08-19: BEST_PRICE returns the API's own
-# APIResponseValidationError on Sepolia (server-side schema bug on the testnet aggregation path); use
-# ROUTING_PREFERENCE=FASTEST there. Sepolia also currently only serves v3 legs (v4 not routed).
+# Routing preference (allowed: BEST_PRICE, FASTEST). NOTE 2026-08-19: BEST_PRICE returns the API's
+# own APIResponseValidationError on Sepolia (a server-side schema bug on the testnet aggregation
+# path), use ROUTING_PREFERENCE=FASTEST there. Sepolia also currently only serves v3 legs.
 ROUTING_PREFERENCE=${ROUTING_PREFERENCE:-BEST_PRICE}
 
 quote=$(curl -sf "$API/quote" -H "x-api-key: $KEY" -H "x-universal-router-version: $UR_VERSION" -H "content-type: application/json" -d @- <<JSON
@@ -43,13 +45,13 @@ swap=$(curl -sf "$API/swap" -H "x-api-key: $KEY" -H "x-universal-router-version:
   -d "{\"quote\": $(echo "$quote" | jq .quote), \"simulateTransaction\": false}")
 
 data=$(echo "$swap" | jq -r .swap.data)
-echo "── UR calldata (execute) ──"
+echo "== UR calldata (execute) =="
 echo "$data"
 echo
-echo "── decoded (commands, inputs, deadline) ──"
+echo "== decoded (commands, inputs, deadline) =="
 cast decode-calldata "execute(bytes,bytes[],uint256)" "$data"
 echo
 echo "Re-encode as the zap's route with:  abi.encode(commands, inputs)   (drop the deadline)"
 echo
-echo "NOTE: keep UR_VERSION in sync with the executing router's ABI generation — v4 action structs differ"
-echo "      between generations and calldata encoded for the wrong one will not decode."
+echo "NOTE: keep UR_VERSION in sync with the executing router's ABI generation. The v4 action"
+echo "      structs differ between generations, and calldata encoded for the wrong one will not decode."

--- a/src/SwapAndAdd.sol
+++ b/src/SwapAndAdd.sol
@@ -33,15 +33,12 @@ import {IUniversalRouter} from "./interfaces/external/IUniversalRouter.sol";
 
 /// @title SwapAndAdd
 /// @notice Implementation of the route-first liquidity zap for Uniswap v4.
-/// @dev Entrypoints funnel into a single PoolManager unlock callback:
-///      route -> size -> flash-take deficit -> deploy -> reconcile & trim -> floor check -> sweep dust.
-///      Rebalance first burns the old position in POSM's own unlock so the main flow starts from resolved budgets.
+/// @dev All entrypoints funnel into one PoolManager unlock:
+///      route -> size -> flash-take deficit -> deploy -> reconcile and trim -> floor check -> sweep.
+///      Rebalance burns the old position in POSM's own unlock first.
 ///
-///      Invariant: All pulled tokens, collected fees, and declared route funding are either deployed into
-///      the position or swept to the recipient within the transaction. Only direct donations or unlisted route
-///      outputs can remain at rest (which join subsequent pool budgets or can be claimed via zero-amount route
-///      funding entries). Standing Permit2 allowances to POSM and Universal Router are safe because spenders only
-///      pull during active calls initiated by this contract.
+///      Invariant: all pulled and collected funds are deployed or swept within the transaction.
+///      Only donations or undeclared route outputs can remain at rest.
 contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarder, Multicall_v4, ReentrancyLock {
     using CurrencyLibrary for Currency;
     using StateLibrary for IPoolManager;
@@ -51,8 +48,8 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
     using SafeCast for uint256;
     using Hooks for IHooks;
 
-    /// @dev Hook permissions that let a hook alter this contract's settlement deltas, breaking the
-    ///      conservation accounting the reconcile relies on. Pools carrying any of them are rejected.
+    /// @dev Permissions that let a hook alter settlement deltas, which breaks the reconcile
+    ///      accounting. Pools with any of them are rejected.
     uint160 private constant UNSUPPORTED_HOOK_FLAGS = Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG
         | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG | Hooks.AFTER_ADD_LIQUIDITY_RETURNS_DELTA_FLAG
         | Hooks.AFTER_REMOVE_LIQUIDITY_RETURNS_DELTA_FLAG;
@@ -61,8 +58,8 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
     /// @dev Universal Router command to sweep unspent native ETH.
     uint8 private constant UR_SWEEP_COMMAND = 0x04;
 
-    /// @dev Internal bundle of inputs passed to the shared unlock and execution core.
-    ///      `deployTokenId`: 0 mints a new position, non-zero increases that position in place.
+    /// @dev Inputs for the shared unlock and execution core. A `deployTokenId` of 0 mints a new
+    ///      position. A non-zero value increases that position in place.
     struct CoreParams {
         uint256 deployTokenId;
         PoolKey key;
@@ -107,8 +104,6 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         ) revert InvalidEthSender();
     }
 
-    // ───────────────────────────────────────────── external entrypoints ─────────────────────────────────────────────
-
     /// @inheritdoc ISwapAndAdd
     function add(AddParams calldata params)
         external
@@ -135,7 +130,7 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         (tokenId, liquidity, amount0, amount1) = _run(cp);
         emit Added(params.recipient, tokenId, msg.sender, liquidity, amount0, amount1);
 
-        // Position was minted to this contract so it could be trimmed; transfer it to recipient now.
+        // the position was minted to this contract so the trim step could burn from it
         ERC721(address(positionManager)).transferFrom(address(this), params.recipient, tokenId);
         _sweepFunding(params.routeFunding, params.recipient);
     }
@@ -152,7 +147,7 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         address recipient = _authAndResolveRecipient(params.tokenId, params.recipient);
         _validateRecipient(recipient);
 
-        // Pull positive additional deltas from caller; negative deltas (cash-out) pull nothing here.
+        // positive deltas are pulled, negative deltas (cash-out) pull nothing
         _pull(
             key,
             params.additional0 > 0 ? uint256(uint128(params.additional0)) : 0,
@@ -161,8 +156,7 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
             params.route
         );
 
-        // Burn the old position in POSM's own unlock, pay out any cash-out share up front,
-        // and compute net redeploy budgets before opening the main unlock.
+        // burn in POSM's own unlock and resolve the net budgets before the main unlock opens
         _burnAndWithdraw(key, params.tokenId, params.hookData);
         CoreParams memory cp = CoreParams({
             deployTokenId: 0, // Mints a new position in the new range
@@ -179,7 +173,6 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         (newTokenId, liquidity, amount0, amount1) = _run(cp);
         emit Rebalanced(recipient, params.tokenId, newTokenId, msg.sender, liquidity, amount0, amount1);
 
-        // Transfer newly minted position NFT and unconsumed route funding to recipient.
         ERC721(address(positionManager)).transferFrom(address(this), recipient, newTokenId);
         _sweepFunding(params.routeFunding, recipient);
     }
@@ -197,12 +190,11 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         CoreParams memory cp =
             _growCore(params.tokenId, params.route, params.minLiquidityAdded, recipient, params.hookData);
 
-        // Pull caller's declared budget; accrued fees are collected inside the unlock callback.
+        // accrued fees are collected inside the unlock callback
         _pull(cp.key, params.amount0In, params.amount1In, params.routeFunding, params.route);
         (, liquidityAdded, amount0, amount1) = _run(cp);
         emit Increased(recipient, params.tokenId, msg.sender, liquidityAdded, amount0, amount1);
 
-        // Position NFT stays in place; sweep unconsumed route funding to resolved recipient.
         _sweepFunding(params.routeFunding, recipient);
     }
 
@@ -216,15 +208,15 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         address recipient = _authAndResolveRecipient(params.tokenId, params.recipient);
         _validateRecipient(recipient);
 
-        // Compound is an increase with 0 pulled budget: collected fees constitute the entire budget.
+        // compound is an increase where the collected fees are the entire budget
         CoreParams memory cp =
             _growCore(params.tokenId, params.route, params.minLiquidityAdded, recipient, params.hookData);
         (, liquidityAdded, amount0, amount1) = _run(cp);
         emit Compounded(recipient, params.tokenId, msg.sender, liquidityAdded, amount0, amount1);
     }
 
-    /// @dev Shared CoreParams for grow-in-place operations (increase, compound).
-    ///      Budgets are left zero and populated in the callback after collecting accrued fees.
+    /// @dev Shared CoreParams for grow-in-place operations. Budgets are set in the callback after
+    ///      fee collection.
     function _growCore(
         uint256 tokenId,
         bytes calldata route,
@@ -256,22 +248,19 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         return abi.decode(result, (uint256, uint128, uint256, uint256));
     }
 
-    // ───────────────────────────────────────────── unlock callback ─────────────────────────────────────────────
-
-    /// @dev Unlock callback from PoolManager: collects fees for grow ops, then executes the shared core flow.
+    /// @dev Collects fees for grow operations, then executes the shared core flow.
     function _unlockCallback(bytes calldata data) internal override returns (bytes memory) {
         CoreParams memory cp = abi.decode(data, (CoreParams));
 
-        // For grow ops (increase, compound): collect accrued fees via a 0-liquidity decrease first.
-        // The held balance (collected fees + any pulled budget) becomes the redeploy budget.
+        // for grow operations, fees collected via a 0-liquidity decrease become the budget
         if (cp.deployTokenId != 0) {
-            // Skip collect for emptied positions with zero liquidity
+            // POSM reverts on a decrease of an empty position
             if (positionManager.getPositionLiquidity(cp.deployTokenId) != 0) {
                 _decrease(cp.key, cp.deployTokenId, 0, cp.hookData);
             }
             cp.budget0 = cp.key.currency0.balanceOfSelf();
             cp.budget1 = cp.key.currency1.balanceOfSelf();
-            // Revert if there are neither held fees nor a route to source tokens.
+            // a route can still source tokens, so only revert when there is also no route
             if (cp.budget0 == 0 && cp.budget1 == 0 && cp.route.length == 0) revert NoFeesToCompound();
         }
 
@@ -279,69 +268,66 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         return abi.encode(tokenId, liquidity, a0, a1);
     }
 
-    /// @dev Resolves redeploy budget from signed delta: positive deltas add to budget, negative deltas return cash-out to recipient.
+    /// @dev Resolves the redeploy budget from the signed delta. Negative deltas pay out cash-out
+    ///      to the recipient.
     function _resolveBudget(Currency currency, int128 delta, address recipient) internal returns (uint256 budget) {
         uint256 held = currency.balanceOfSelf();
-        if (delta >= 0) return held; // Withdrawn tokens + pre-pulled additional budget
+        if (delta >= 0) return held; // withdrawn tokens plus the pre-pulled additional budget
 
-        // Widen to int256 before negating to prevent overflow on type(int128).min
+        // widen to int256 before negating to prevent overflow on type(int128).min
         uint256 toReturn = uint256(-int256(delta));
         if (toReturn > held) revert ReturnExceedsWithdrawn(toReturn, held);
         currency.transfer(recipient, toReturn);
         return held - toReturn;
     }
 
-    // ───────────────────────────────────────────── core flow ─────────────────────────────────────────────
-
-    /// @dev Shared execution core: route -> size -> flash-take deficit -> deploy -> reconcile & trim -> floor check -> sweep.
+    /// @dev Shared execution core.
     function _swapAndAdd(CoreParams memory cp)
         internal
         returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)
     {
-        // Pure bitmask on the hook address; a benignly-behaving hook with the permission is still rejected —
-        // the boundary is the capability, not observed behavior.
+        // pure bitmask check, the capability is rejected regardless of observed behavior
         if (cp.key.hooks.hasPermission(UNSUPPORTED_HOOK_FLAGS)) revert UnsupportedHookPermissions(cp.key.hooks);
 
         _ensureApproved(cp.key.currency0);
         _ensureApproved(cp.key.currency1);
 
-        // 1. ROUTE FIRST: Execute off-chain route (if provided) and update held token budgets from live balances.
+        // 1. Execute the optional route and re-read the held budgets.
         if (cp.route.length != 0) {
             _executeRoute(cp);
             cp.budget0 = cp.key.currency0.balanceOfSelf();
             cp.budget1 = cp.key.currency1.balanceOfSelf();
         }
 
-        // 2. Sizing: Compute optimistic liquidity, flash-take any deficit, and deploy via POSM.
-        // Range bounds are constant for the whole operation and threaded; the live price is re-read at
-        // each use instead (the reconcile swap and hook callbacks can move it).
+        // 2. Size the liquidity, flash-take any deficit, and deploy via POSM. The bounds are
+        // constant, the price is re-read at each use because swaps and hooks move it.
         uint160 sqrtLower = TickMath.getSqrtPriceAtTick(cp.tickLower);
         uint160 sqrtUpper = TickMath.getSqrtPriceAtTick(cp.tickUpper);
         (uint128 liquidityOptimistic, uint256 amount0optimistic, uint256 amount1optimistic) =
             _planLiquidity(cp, sqrtLower, sqrtUpper);
-        // Surface contract's own floor error rather than POSM's opaque CannotUpdateEmptyPosition on 0-sized mint.
+        // revert with the floor error instead of POSM's opaque CannotUpdateEmptyPosition
         if (liquidityOptimistic == 0 && cp.deployTokenId == 0) {
             revert InsufficientLiquidity(cp.minLiquidity, 0);
         }
         _flashTakeDeficit(cp, amount0optimistic, amount1optimistic);
         tokenId = _deployLiquidity(cp, liquidityOptimistic, amount0optimistic);
 
-        // 3. Reconcile & Trim: Reconcile deficit via same-pool swap and trim newly added liquidity for any remaining debt.
+        // 3. Settle the flash-take debt, trimming the new liquidity if a debt remains.
         uint128 trimmed =
             _reconcile(cp, tokenId, liquidityOptimistic, amount0optimistic, amount1optimistic, sqrtLower, sqrtUpper);
         liquidity = liquidityOptimistic - trimmed;
 
-        // 4. Slippage Floor: Enforce minimum liquidity threshold on final post-trim position.
+        // 4. Enforce the slippage floor.
         if (liquidity < cp.minLiquidity) revert InsufficientLiquidity(cp.minLiquidity, liquidity);
 
-        // 5. Sweep: Calculate final position token amounts at live price and sweep leftover dust to recipient.
+        // 5. Compute the final position amounts and sweep dust.
         (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(cp.key.toId());
         (amount0, amount1) = SwapAndAddMath.getAmountsForLiquidity(sqrtPriceX96, sqrtLower, sqrtUpper, liquidity);
         _sweep(cp.key.currency0, cp.recipient);
         _sweep(cp.key.currency1, cp.recipient);
     }
 
-    /// @dev Computes fee-aware optimistic liquidity and required token amounts based on held budgets and pool price.
+    /// @dev Computes the fee-aware liquidity and required amounts from the budgets and pool price.
     function _planLiquidity(CoreParams memory cp, uint160 sqrtLower, uint160 sqrtUpper)
         internal
         view
@@ -355,18 +341,15 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         (amount0, amount1) = SwapAndAddMath.getAmountsForLiquidity(sqrtPriceX96, sqrtLower, sqrtUpper, liquidity);
     }
 
-    /// @dev Flash-takes deficit tokens from PoolManager so the subsequent POSM deploy is fully funded.
-    ///      `SwapAndAddMath.getAmountsForLiquidity` rounds up with the pool's own math on pool inputs, making funding wei-exact
-    ///      with no rounding buffer needed. Requires PoolManager to hold sufficient aggregate reserves of that
-    ///      token across all pools. `_reconcile` settles what the take owes afterwards.
+    /// @dev Flash-takes deficit tokens so the POSM deploy is fully funded. The rounded-up amounts
+    ///      are wei-exact against POSM's pull. `_reconcile` settles the debt.
     function _flashTakeDeficit(CoreParams memory cp, uint256 amount0, uint256 amount1) internal {
         if (amount0 > cp.budget0) _take(cp.key.currency0, address(this), amount0 - cp.budget0);
         if (amount1 > cp.budget1) _take(cp.key.currency1, address(this), amount1 - cp.budget1);
     }
 
-    /// @dev Settles flash-take debt using held tokens, same-pool swaps, and partial liquidity trimming.
-    ///      Bidirectional: handles both under-conversion (selling surplus token) and over-conversion.
-    /// @return trimmed The amount of liquidity removed by trimming (0 if budget covered deploy).
+    /// @dev Settles the flash-take debt with held tokens, a same-pool swap, then a trim.
+    /// @return trimmed The liquidity removed by the trim.
     function _reconcile(
         CoreParams memory cp,
         uint256 tokenId,
@@ -377,18 +360,18 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         uint160 sqrtUpper
     ) internal returns (uint128 trimmed) {
         bool deficitIsCurrency1;
-        if (a0opt > cp.budget0) deficitIsCurrency1 = false; // Short token0
-        else if (a1opt > cp.budget1) deficitIsCurrency1 = true; // Short token1
-        else return 0; // Holdings already covered deploy; no swap or trim needed.
+        if (a0opt > cp.budget0) deficitIsCurrency1 = false; // short token0
+        else if (a1opt > cp.budget1) deficitIsCurrency1 = true; // short token1
+        else return 0; // the budget covered the deploy, no swap or trim needed
 
         Currency deficit = deficitIsCurrency1 ? cp.key.currency1 : cp.key.currency0;
         Currency surplus = deficitIsCurrency1 ? cp.key.currency0 : cp.key.currency1;
-        bool zeroForOne = deficitIsCurrency1; // Sell surplus to buy deficit
+        bool zeroForOne = deficitIsCurrency1; // sell the surplus to buy the deficit
 
-        // 1. Settle debt using any deficit tokens already held (e.g. fee credits or sweep returns).
+        // 1. Settle with deficit tokens already held.
         _settleToward(deficit);
 
-        // 2. If debt remains, convert remaining surplus to deficit in the pool (exact-input).
+        // 2. If a debt remains, sell the surplus for the deficit token (exact input).
         int256 owed = poolManager.currencyDelta(address(this), deficit);
         if (owed < 0) {
             uint256 surplusBal = surplus.balanceOfSelf();
@@ -399,24 +382,21 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
             }
         }
 
-        // 3. If residual deficit remains (due to price impact or fees), trim the position to free tokens.
+        // 3. If price impact or fees left a residual deficit, trim the position to free tokens.
         if (owed < 0) {
             trimmed = _trim(cp, tokenId, lopt, deficitIsCurrency1, uint256(-owed), sqrtLower, sqrtUpper);
             _settleToward(deficit);
         }
 
-        // 4. Take positive delta credits into balance and close deltas.
-        // Leftovers are swept as-is (trimming in-range frees both tokens, so two-token dust is normal).
+        // 4. Take credits and defensively close both deltas.
         _takeCredit(deficit);
-        // Defensive closure: ensure both currency deltas are zero past this line (surplus debt was cleared in step 2).
         _takeCredit(surplus);
         _settleToward(surplus);
     }
 
-    /// @dev Decreases newly added liquidity to free enough deficit tokens to settle outstanding debt.
-    ///      Caps removal at `lopt` so that on increase/compound, existing position principal is never touched.
-    ///      Invariant: Price cannot be past the range's far side (reconcile swap's exact-input sell repays debt
-    ///      before or at exhausting the range because v4 fees charge input; untaxed output covers debt).
+    /// @dev Frees deficit tokens by decreasing the new liquidity, capped at `lopt` so existing
+    ///      principal is never touched. The price cannot be past the range's far side because the
+    ///      reconcile swap's untaxed output repays the debt within the range.
     function _trim(
         CoreParams memory cp,
         uint256 tokenId,
@@ -426,21 +406,18 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         uint160 sqrtLower,
         uint160 sqrtUpper
     ) internal returns (uint128 dl) {
-        // Fresh price read: the reconcile swap (or a hook) moved the price since sizing.
+        // re-read the price, the reconcile swap or a hook moved it since sizing
         (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(cp.key.toId());
         uint256 liquidityToFree =
             SwapAndAddMath.getLiquidityToFree(sqrtPriceX96, sqrtLower, sqrtUpper, deficitIsCurrency1, amountOut);
-        // Cap trim at the liquidity added in this transaction.
+        // cap the trim at the liquidity added in this transaction
         dl = liquidityToFree >= lopt ? lopt : uint128(liquidityToFree);
         _decrease(cp.key, tokenId, dl, cp.hookData);
     }
 
-    // ───────────────────────────────────────────── POSM / pool actions ─────────────────────────────────────────────
-
-    /// @dev Deploys liquidity via POSM (MINT for new position, INCREASE for existing).
-    ///      Uses CLOSE_CURRENCY on both tokens so positive deltas (e.g. fee credits from hooks or routes
-    ///      trading this pool) are credited to balance rather than reverting SETTLE_PAIR.
-    ///      POSM per-amount slippage limits are maxed because `minLiquidity` on the final post-trim position is the single slippage gate.
+    /// @dev Deploys via POSM MINT_POSITION or INCREASE_LIQUIDITY, with CLOSE_CURRENCY on both
+    ///      tokens so positive deltas credit instead of reverting SETTLE_PAIR. Per-amount slippage
+    ///      limits are maxed, `minLiquidity` is the single slippage gate.
     function _deployLiquidity(CoreParams memory cp, uint128 liquidity, uint256 amount0)
         internal
         returns (uint256 tokenId)
@@ -462,7 +439,7 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
             )
             : abi.encode(tokenId, uint256(liquidity), type(uint128).max, type(uint128).max, cp.hookData);
 
-        // Native pools carry a trailing SWEEP to return unconsumed wei of the forwarded ETH.
+        // native pools carry a trailing SWEEP to return unconsumed wei of the forwarded ETH
         Currency c0 = cp.key.currency0;
         bool isNative = c0.isAddressZero();
         bytes memory actions = isNative
@@ -480,15 +457,15 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         positionManager.modifyLiquiditiesWithoutUnlock{value: isNative ? amount0 : 0}(actions, params);
     }
 
-    /// @dev Executes the Universal Router payload and reclaims any unspent native ETH from the router.
+    /// @dev Executes the Universal Router payload and reclaims unspent native ETH from the router.
     function _executeRoute(CoreParams memory cp) internal {
         (bytes memory commands, bytes[] memory inputs) = abi.decode(cp.route, (bytes, bytes[]));
-        // Forward entire native balance (holds only this operation's native budget / funding).
+        // the contract holds only this operation's native budget
         uint256 value = address(this).balance;
 
         universalRouter.execute{value: value}(commands, inputs);
 
-        // Reclaim any unspent native ETH left in Universal Router (UR balances are permissionlessly sweepable).
+        // router balances are permissionlessly sweepable, reclaim before anyone else can
         if (address(universalRouter).balance > 0) {
             bytes[] memory sweepInputs = new bytes[](1);
             sweepInputs[0] = abi.encode(address(0), ActionConstants.MSG_SENDER, 0);
@@ -496,8 +473,8 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         }
     }
 
-    /// @dev Burns an existing position and takes both tokens to this contract.
-    ///      POSM `modifyLiquidities` is passed `type(uint256).max` deadline because staleness is already checked by entrypoint modifier.
+    /// @dev Burns a position and takes both tokens. The max POSM deadline is inert, the entrypoint
+    ///      already checked staleness.
     function _burnAndWithdraw(PoolKey memory key, uint256 tokenId, bytes calldata hookData) internal {
         bytes memory actions = abi.encodePacked(uint8(Actions.BURN_POSITION), uint8(Actions.TAKE_PAIR));
         bytes[] memory params = new bytes[](2);
@@ -506,7 +483,7 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         positionManager.modifyLiquidities(abi.encode(actions, params), type(uint256).max);
     }
 
-    /// @dev Decreases position liquidity (or collects fees when dl == 0) and takes tokens to this contract.
+    /// @dev Decreases liquidity and takes the tokens. A `dl` of 0 only collects fees.
     function _decrease(PoolKey memory key, uint256 tokenId, uint128 dl, bytes memory hookData) internal {
         bytes memory actions = abi.encodePacked(uint8(Actions.DECREASE_LIQUIDITY), uint8(Actions.TAKE_PAIR));
         bytes[] memory params = new bytes[](2);
@@ -515,8 +492,8 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         positionManager.modifyLiquiditiesWithoutUnlock(actions, params);
     }
 
-    /// @dev Executes a same-pool swap to convert surplus tokens to deficit without price limits.
-    ///      Unbounded because `minLiquidity` is the slippage gate and input amount is strictly bounded by held holdings.
+    /// @dev Swaps without a price limit. Max slippage is fine because callers enforce
+    ///      `minLiquidity` on the final position. Callers MUST check minimum amounts.
     function _swap(PoolKey memory key, bool zeroForOne, int256 amountSpecified, bytes memory hookData) internal {
         poolManager.swap(
             key,
@@ -529,9 +506,7 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         );
     }
 
-    // ───────────────────────────────────────────── delta / token helpers ─────────────────────────────────────────────
-
-    /// @dev Settles outstanding debt for a currency using held balance.
+    /// @dev Pays min(held, debt) toward the currency's outstanding debt, possibly partially.
     function _settleToward(Currency currency) internal {
         int256 d = poolManager.currencyDelta(address(this), currency);
         if (d >= 0) return;
@@ -541,13 +516,13 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         if (pay > 0) _settle(currency, address(this), pay);
     }
 
-    /// @dev Takes positive currency delta credits from PoolManager into this contract's balance.
+    /// @dev Takes any positive currency delta into this contract's balance.
     function _takeCredit(Currency currency) internal {
         int256 d = poolManager.currencyDelta(address(this), currency);
         if (d > 0) _take(currency, address(this), uint256(d));
     }
 
-    /// @dev Pulls caller budgets and route funding via Permit2/msg.value, validating single native ETH accounting.
+    /// @dev Pulls the caller's budgets and route funding via Permit2 or msg.value.
     function _pull(
         PoolKey memory key,
         uint256 amount0In,
@@ -557,7 +532,6 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
     ) internal {
         uint256 expectedValue;
 
-        // Pull route funding tokens (non-pool tokens dedicated to the off-chain route).
         if (funding.length != 0) {
             if (route.length == 0) revert RouteFundingRequiresRoute();
             for (uint256 i = 0; i < funding.length; i++) {
@@ -576,7 +550,7 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
             }
         }
 
-        // Pull pool-token budget: currency0 can be native or ERC-20; currency1 is always ERC-20.
+        // currency0 can be native or ERC-20, currency1 is always ERC-20
         Currency c0 = key.currency0;
         if (c0.isAddressZero()) {
             expectedValue += amount0In;
@@ -587,33 +561,31 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
             permit2.transferFrom(msg.sender, address(this), amount1In.toUint160(), Currency.unwrap(key.currency1));
         }
 
-        // Validate msg.value: exactly one native contribution (pool budget OR route funding) is allowed.
         if (msg.value != expectedValue) revert InvalidEthValue();
-        // In multicall batches, verify balance was not already spent by an earlier subcall.
+        // in a multicall batch, an earlier subcall may have already spent the balance
         if (address(this).balance < expectedValue) revert InvalidEthValue();
     }
 
-    /// @dev Sweeps unconsumed route funding tokens to the resolved recipient.
+    /// @dev Sweeps unconsumed route funding tokens to the recipient.
     function _sweepFunding(TokenAmount[] calldata funding, address to) internal {
         for (uint256 i = 0; i < funding.length; i++) {
             _sweep(funding[i].token, to);
         }
     }
 
-    /// @dev Grants standing max Permit2 allowances to POSM and Universal Router if not already configured.
-    ///      Safe because the contract holds no funds at rest and spenders only pull during active calls from `this`.
+    /// @dev Grants standing max Permit2 allowances to POSM and the Universal Router. Safe because
+    ///      the contract holds no funds at rest.
     function _ensureApproved(Currency currency) internal {
         if (currency.isAddressZero()) return;
 
         address token = Currency.unwrap(currency);
-        // Permit2 never decrements a uint160.max allowance, so `permitted` doubles as the init marker; the
-        // uint160.max headroom check on the token allowance heals tokens that decrement infinite approvals.
+        // Permit2 never decrements a uint160.max allowance, so `permitted` doubles as the init marker
         (uint160 permitted,,) = permit2.allowance(address(this), token, address(positionManager));
         uint256 tokenAllowance = ERC20(token).allowance(address(this), address(permit2));
         if (permitted == type(uint160).max && tokenAllowance >= type(uint160).max) return;
 
         if (tokenAllowance != type(uint256).max) {
-            // Reset to 0 first for approve-race tokens like USDT.
+            // reset to 0 first for approve-race tokens like USDT
             if (tokenAllowance != 0) SafeTransferLib.safeApprove(ERC20(token), address(permit2), 0);
             SafeTransferLib.safeApprove(ERC20(token), address(permit2), type(uint256).max);
         }
@@ -636,9 +608,8 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
         if (recipient == address(this) || recipient == address(0)) revert InvalidRecipient(recipient);
     }
 
-    /// @dev Verifies caller authorization (owner or approved operator) and resolves recipient.
-    /// @dev For approved operators, all output is forced to the position owner to prevent misdirection;
-    ///      operators remain trusted regardless (see the interface's Operator Trust Model).
+    /// @dev Verifies that the caller is the owner or an approved operator. Operator output is
+    ///      forced to the owner, though operators remain trusted (see the interface notes).
     function _authAndResolveRecipient(uint256 tokenId, address requested) internal view returns (address) {
         ERC721 posm = ERC721(address(positionManager));
         address owner = posm.ownerOf(tokenId);

--- a/src/SwapAndAdd.sol
+++ b/src/SwapAndAdd.sol
@@ -342,7 +342,8 @@ contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarde
     }
 
     /// @dev Flash-takes deficit tokens so the POSM deploy is fully funded. The rounded-up amounts
-    ///      are wei-exact against POSM's pull. `_reconcile` settles the debt.
+    ///      are wei-exact against POSM's pull. `_reconcile` settles the debt. The take requires the
+    ///      PoolManager to hold enough of the token across all pools, or it reverts.
     function _flashTakeDeficit(CoreParams memory cp, uint256 amount0, uint256 amount1) internal {
         if (amount0 > cp.budget0) _take(cp.key.currency0, address(this), amount0 - cp.budget0);
         if (amount1 > cp.budget1) _take(cp.key.currency1, address(this), amount1 - cp.budget1);

--- a/src/SwapAndAdd.sol
+++ b/src/SwapAndAdd.sol
@@ -37,8 +37,8 @@ import {IUniversalRouter} from "./interfaces/external/IUniversalRouter.sol";
 ///      route -> size -> flash-take deficit -> deploy -> reconcile and trim -> floor check -> sweep.
 ///      Rebalance burns the old position in POSM's own unlock first.
 ///
-///      Invariant: all pulled and collected funds are deployed or swept within the transaction.
-///      Only donations or undeclared route outputs can remain at rest.
+///      Invariant: pulled and collected funds are deployed or swept in the same transaction.
+///      Donations and undeclared route outputs remain and can be extracted by the next caller.
 contract SwapAndAdd is ISwapAndAdd, SafeCallback, DeltaResolver, Permit2Forwarder, Multicall_v4, ReentrancyLock {
     using CurrencyLibrary for Currency;
     using StateLibrary for IPoolManager;

--- a/src/interfaces/ISwapAndAdd.sol
+++ b/src/interfaces/ISwapAndAdd.sol
@@ -8,44 +8,26 @@ import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {IMulticall_v4} from "./IMulticall_v4.sol";
 
 /// @title ISwapAndAdd
-/// @notice Route-first liquidity zap for Uniswap v4 (add, rebalance, increase, compound).
-///         Enables callers to provide tokens in any ratio—including single-sided or arbitrary non-pool
-///         tokens—and end up with a standard PositionManager (POSM) position in a single transaction.
-/// @dev Execution Flow:
-///      1. Route First: Execute the optional Universal Router `route` to convert surplus tokens toward
-///         the deficit side, then measure actual post-route balances.
-///      2. Size & Deploy: Compute fee-aware optimistic liquidity from live holdings and pool price. Flash-take
-///         any deficit from PoolManager, then mint or increase the position through POSM.
-///      3. Reconcile & Trim: Settle deficit with held tokens or a same-pool swap. If a debt remains (due to price
-///         impact or fees), trim the newly added liquidity via a partial decrease to cover it.
-///      4. Enforce Floor & Sweep: Verify the final post-trim liquidity against `minLiquidity`, sweep all dust
-///         and unconsumed funding to `recipient`, and transfer the NFT if newly minted.
+/// @notice Turns a token budget in any ratio into a POSM position in one transaction.
+///         Operations: add, rebalance, increase, compound.
+/// @dev Flow: execute the optional Universal Router `route`, size liquidity from held balances,
+///      flash-take any deficit, deploy through POSM, settle via a same-pool swap, trim the new
+///      liquidity for any remaining debt, check `minLiquidity`, sweep dust to `recipient`.
 ///
-///      Key Integrator Notes:
-///      - Route-First Design: Passing an empty `route` turns the flow into a pure same-pool zap. When a route
-///        is provided, post-route balances are used directly so favorable swap execution improves position size.
-///      - Route Construction: Routes must specify explicit input amounts. Avoid balance-relative commands
-///        (`CONTRACT_BALANCE`, `PAY_PORTION`, bps `SWEEP`), as the zap forwards its entire native balance to the router.
-///        Any non-pool route output token (including ETH) must be declared in `routeFunding` (a zero-amount entry works) to be swept to recipient.
-///      - Slippage & Operators: `minLiquidity` / `minLiquidityAdded` is the single slippage knob checked on the final
-///        position. Constrained operator systems (e.g. keepers) must compute and enforce this floor themselves.
-///      - Position Approvals: For `rebalance`, `increase`, and `compound`, caller authorization is checked
-///        (owner or approved operator) AND this contract must be ERC-721 approved on the position via POSM
-///        (`approve` or `setApprovalForAll`), as POSM authorizes position modifications against the zap as locker.
-///      - Operator Trust Model: For operator calls, all outputs (new NFT, cash-out, dust) are forced to the position
-///        owner. This prevents accidental misdirection, though operators remain trusted since they set the `route`
-///        and `minLiquidity` (and already have full custody on POSM).
-///      - Unsupported Pools: Pools with hooks returning deltas (`BEFORE_SWAP_RETURNS_DELTA`, `AFTER_SWAP_RETURNS_DELTA`,
-///        `AFTER_REMOVE_LIQUIDITY_RETURNS_DELTA`, `AFTER_ADD_LIQUIDITY_RETURNS_DELTA`) break settlement conservation
-///        and are rejected upfront with `UnsupportedHookPermissions`. Dynamic fee, gating, and oracle hooks are supported.
-///      - Known Limits: Fee-on-transfer and rebasing tokens are unsupported (atomic reverts or larger trim, never token loss).
-///        Budgets within the pool's ~1-wei mint/burn rounding toll cannot settle and revert `InsufficientLiquidity`.
-///      - HookData Reuse: The same `hookData` payload is passed to all hook callbacks in the operation; single-use
-///        payload schemes are unsupported.
-///      - Multicall & Native ETH: Supports multicall with Permit2 forwarding (`permitBatch` + op). Because all subcalls
-///        share `msg.value`, an ETH-bearing batch supports only a single operation — adding further ops (ERC20-only
-///        included) reverts. Zero-value batches compose freely across multiple positions; batch native operations
-///        using WETH or separate transactions.
+///      Integration surface:
+///      - Routes must use explicit input amounts. Balance-relative commands are unsafe because the
+///        zap forwards its full native balance to the router.
+///      - Non-pool route outputs must appear in `routeFunding` to be swept. A zero amount is enough.
+///      - `minLiquidity` / `minLiquidityAdded` is the only slippage check, applied post-trim.
+///      - rebalance / increase / compound: the caller must be the owner or an approved operator,
+///        and this contract needs ERC-721 approval on the position in POSM. Operator calls send
+///        all output to the owner, though operators remain trusted since they set the `route` and
+///        `minLiquidity` (and already have full custody on POSM).
+///      - Hooks with returns-delta permissions are rejected. Fee-on-transfer and rebasing tokens
+///        are unsupported. The same `hookData` goes to every hook callback.
+///      - Multicall batches carry at most one native-ETH operation because all subcalls share
+///        `msg.value`; adding further operations reverts. Zero-value batches compose freely. Batch
+///        native operations using WETH or separate transactions.
 interface ISwapAndAdd is IMulticall_v4 {
     /// @notice Emitted when a new position is minted via `add`.
     event Added(
@@ -57,7 +39,7 @@ interface ISwapAndAdd is IMulticall_v4 {
         uint256 amount1
     );
 
-    /// @notice Emitted when an existing position is burned and redeployed into a new range via `rebalance`.
+    /// @notice Emitted when a position is burned and redeployed into a new range via `rebalance`.
     event Rebalanced(
         address indexed recipient,
         uint256 indexed oldTokenId,
@@ -68,7 +50,7 @@ interface ISwapAndAdd is IMulticall_v4 {
         uint256 amount1
     );
 
-    /// @notice Emitted when an existing position is topped up in place via `increase`.
+    /// @notice Emitted when a position is topped up in place via `increase`.
     event Increased(
         address indexed recipient,
         uint256 indexed tokenId,
@@ -91,59 +73,60 @@ interface ISwapAndAdd is IMulticall_v4 {
     /// @notice Thrown when a required address argument is address(0).
     error ZeroAddress();
 
-    /// @notice Thrown when the transaction is executed after the specified deadline.
+    /// @notice Thrown when the transaction executes after the deadline.
     error DeadlinePassed(uint256 deadline);
 
-    /// @notice Thrown when `msg.value` does not match the operation's expected native amount or native balance is insufficient.
+    /// @notice Thrown when `msg.value` does not match the expected native amount.
     error InvalidEthValue();
 
-    /// @notice Thrown when ETH is received from an unauthorized sender (only PoolManager, POSM, and Universal Router allowed).
+    /// @notice Thrown when ETH arrives from a sender other than PoolManager, POSM, or Universal Router.
     error InvalidEthSender();
 
-    /// @notice Thrown when the resulting position liquidity is below the caller's minimum liquidity threshold.
+    /// @notice Thrown when the final position liquidity is below the caller's minimum.
     error InsufficientLiquidity(uint256 minLiquidity, uint128 liquidity);
 
     /// @notice Thrown when the recipient is address(0) or this contract.
     error InvalidRecipient(address recipient);
 
-    /// @notice Thrown when caller is neither the position owner nor an approved operator.
+    /// @notice Thrown when the caller is neither the position owner nor an approved operator.
     error NotAuthorizedForToken(uint256 tokenId);
 
-    /// @notice Thrown when a negative delta in `rebalance` requests to withdraw more than the position's holdings.
+    /// @notice Thrown when a negative delta in `rebalance` requests more than the withdrawn amount.
     error ReturnExceedsWithdrawn(uint256 requested, uint256 withdrawn);
 
-    /// @notice Thrown when compounding or fee-only increase has no fees or budget to deploy.
+    /// @notice Thrown when a compound or fee-only increase has no fees and no budget to deploy.
     error NoFeesToCompound();
 
     /// @notice Thrown when `routeFunding` is provided without a `route`.
     error RouteFundingRequiresRoute();
 
-    /// @notice Thrown when a `routeFunding` token is one of the pool currencies (use `amount0In`/`amount1In` instead).
+    /// @notice Thrown when a `routeFunding` token is a pool currency.
     error InvalidFundingToken(Currency token);
 
-    /// @notice Thrown when the pool's hook carries a returns-delta permission (see the Unsupported Pools note).
+    /// @notice Thrown when the pool's hook carries a returns-delta permission.
     error UnsupportedHookPermissions(IHooks hooks);
 
-    /// @notice Represents a non-pool token amount pulled to fund an off-chain route.
-    /// @param token The non-pool token address (or address(0) for native ETH).
-    /// @param amount The amount to pull from caller via Permit2 (or expected msg.value for native ETH). A zero amount pulls nothing but sweeps unlisted donations of that token.
+    /// @notice A non-pool token amount pulled to fund the route.
+    /// @param token The token address, or address(0) for native ETH.
+    /// @param amount The amount to pull via Permit2, or the expected msg.value for native ETH.
+    ///               A zero amount pulls nothing but still marks the token for the sweep.
     struct TokenAmount {
         Currency token;
         uint256 amount;
     }
 
     /// @notice Parameters for `add`.
-    /// @param poolKey Target Uniswap v4 pool.
-    /// @param tickLower Lower tick of the position range.
-    /// @param tickUpper Upper tick of the position range.
-    /// @param amount0In Amount of token0 budget to pull from caller (can be 0).
-    /// @param amount1In Amount of token1 budget to pull from caller (can be 0).
-    /// @param minLiquidity Minimum liquidity required for the minted position (slippage floor).
-    /// @param recipient Address that receives the minted position NFT and leftover dust.
-    /// @param deadline Timestamp after which the transaction will revert.
-    /// @param route Encoded Universal Router commands and inputs (empty for pure same-pool zap). Must scope input amounts explicitly (never spend entire contract balance).
-    /// @param routeFunding Optional non-pool tokens pulled to fund the route. Unused amounts are swept to `recipient`.
-    /// @param hookData Arbitrary data passed to pool hooks (reused across all callbacks).
+    /// @param poolKey Target pool.
+    /// @param tickLower Lower tick of the range.
+    /// @param tickUpper Upper tick of the range.
+    /// @param amount0In Token0 to pull from the caller. Can be 0.
+    /// @param amount1In Token1 to pull from the caller. Can be 0.
+    /// @param minLiquidity Minimum liquidity of the minted position (slippage floor).
+    /// @param recipient Receives the position NFT and dust.
+    /// @param deadline Timestamp after which the transaction reverts.
+    /// @param route Encoded Universal Router commands and inputs. Empty for a same-pool zap.
+    /// @param routeFunding Non-pool tokens pulled to fund the route.
+    /// @param hookData Data passed to every hook callback.
     struct AddParams {
         PoolKey poolKey;
         int24 tickLower;
@@ -158,27 +141,27 @@ interface ISwapAndAdd is IMulticall_v4 {
         bytes hookData;
     }
 
-    /// @notice Create a new v4 position from a one- or two-sided token budget in a single transaction.
-    /// @param params The configuration parameters for the add operation.
-    /// @return tokenId The minted POSM position ID.
+    /// @notice Creates a new v4 position from a one- or two-sided token budget.
+    /// @param params The add parameters.
+    /// @return tokenId The minted position ID.
     /// @return liquidity The final liquidity of the minted position.
-    /// @return amount0 Amount of token0 deposited into the position.
-    /// @return amount1 Amount of token1 deposited into the position.
+    /// @return amount0 Token0 deposited into the position.
+    /// @return amount1 Token1 deposited into the position.
     function add(AddParams calldata params)
         external
         payable
         returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
 
     /// @notice Parameters for `increase`.
-    /// @param tokenId Existing position ID to increase.
-    /// @param amount0In Amount of token0 budget to pull from caller (can be 0). Accrued fees are collected and reinvested automatically.
-    /// @param amount1In Amount of token1 budget to pull from caller (can be 0). Accrued fees are collected and reinvested automatically.
-    /// @param minLiquidityAdded Minimum liquidity that must be added to the position (slippage floor).
-    /// @param recipient Destination for swept dust. Forced to position owner if caller is an operator.
-    /// @param deadline Timestamp after which the transaction will revert.
-    /// @param route Encoded Universal Router commands and inputs (can be empty).
-    /// @param routeFunding Optional non-pool tokens pulled to fund the route. Unused amounts are swept to `recipient`.
-    /// @param hookData Arbitrary data passed to pool hooks.
+    /// @param tokenId Position ID to increase.
+    /// @param amount0In Token0 to pull from the caller. Can be 0.
+    /// @param amount1In Token1 to pull from the caller. Can be 0.
+    /// @param minLiquidityAdded Minimum liquidity the operation must add (slippage floor).
+    /// @param recipient Receives dust. Forced to the owner if the caller is an operator.
+    /// @param deadline Timestamp after which the transaction reverts.
+    /// @param route Encoded Universal Router commands and inputs. Can be empty.
+    /// @param routeFunding Non-pool tokens pulled to fund the route.
+    /// @param hookData Data passed to every hook callback.
     struct IncreaseParams {
         uint256 tokenId;
         uint256 amount0In;
@@ -191,29 +174,31 @@ interface ISwapAndAdd is IMulticall_v4 {
         bytes hookData;
     }
 
-    /// @notice Top up an existing position with a one- or two-sided budget and reinvest accrued fees in a single transaction.
-    /// @dev Caller must be owner or approved operator, and this contract must be ERC-721 approved on POSM for `tokenId`.
-    /// @param params The configuration parameters for the increase operation.
-    /// @return liquidityAdded The liquidity added to the position.
-    /// @return amount0 Amount of token0 added to the position.
-    /// @return amount1 Amount of token1 added to the position.
+    /// @notice Tops up a position with a one- or two-sided budget and reinvests accrued fees.
+    /// @dev Requires caller authorization and ERC-721 approval on the position in POSM.
+    /// @param params The increase parameters.
+    /// @return liquidityAdded The liquidity added.
+    /// @return amount0 Token0 added to the position.
+    /// @return amount1 Token1 added to the position.
     function increase(IncreaseParams calldata params)
         external
         payable
         returns (uint128 liquidityAdded, uint256 amount0, uint256 amount1);
 
     /// @notice Parameters for `rebalance`.
-    /// @param tokenId Existing position ID to withdraw, burn, and redeploy.
-    /// @param additional0 Signed delta for token0: positive pulls additional tokens, negative returns withdrawn tokens, zero redeploys full withdrawn balance.
-    /// @param additional1 Signed delta for token1 with the same signed delta semantics.
-    /// @param newTickLower Lower tick of the new position range.
-    /// @param newTickUpper Upper tick of the new position range.
-    /// @param minLiquidity Minimum liquidity required for the newly minted position (slippage floor).
-    /// @param recipient Destination for the new position NFT, returned cash-out tokens, and dust. Forced to owner if caller is an operator.
-    /// @param deadline Timestamp after which the transaction will revert.
-    /// @param route Encoded Universal Router commands and inputs (can be empty).
-    /// @param routeFunding Optional non-pool tokens pulled to fund the route. Unused amounts are swept to `recipient`.
-    /// @param hookData Arbitrary data passed to pool hooks.
+    /// @param tokenId Position ID to burn and redeploy.
+    /// @param additional0 Signed token0 delta. Positive pulls extra tokens, negative cashes out,
+    ///                    zero redeploys the full withdrawn balance.
+    /// @param additional1 Signed token1 delta with the same semantics.
+    /// @param newTickLower Lower tick of the new range.
+    /// @param newTickUpper Upper tick of the new range.
+    /// @param minLiquidity Minimum liquidity of the new position (slippage floor).
+    /// @param recipient Receives the new NFT, cash-out, and dust. Forced to the owner if the
+    ///                  caller is an operator.
+    /// @param deadline Timestamp after which the transaction reverts.
+    /// @param route Encoded Universal Router commands and inputs. Can be empty.
+    /// @param routeFunding Non-pool tokens pulled to fund the route.
+    /// @param hookData Data passed to every hook callback.
     struct RebalanceParams {
         uint256 tokenId;
         int128 additional0;
@@ -228,25 +213,25 @@ interface ISwapAndAdd is IMulticall_v4 {
         bytes hookData;
     }
 
-    /// @notice Withdraw an existing position entirely and redeploy it into a new tick range, optionally adding or cashing out tokens.
-    /// @dev Caller must be owner or approved operator, and this contract must be ERC-721 approved on POSM for `tokenId`.
-    /// @param params The configuration parameters for the rebalance operation.
+    /// @notice Withdraws a position fully and redeploys it into a new tick range.
+    /// @dev Requires caller authorization and ERC-721 approval on the position in POSM.
+    /// @param params The rebalance parameters.
     /// @return newTokenId The minted position ID in the new range.
     /// @return liquidity The final liquidity of the new position.
-    /// @return amount0 Amount of token0 deposited into the new position.
-    /// @return amount1 Amount of token1 deposited into the new position.
+    /// @return amount0 Token0 deposited into the new position.
+    /// @return amount1 Token1 deposited into the new position.
     function rebalance(RebalanceParams calldata params)
         external
         payable
         returns (uint256 newTokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
 
     /// @notice Parameters for `compound`.
-    /// @param tokenId Existing position ID whose accrued fees will be collected and reinvested.
-    /// @param minLiquidityAdded Minimum liquidity that must be added from reinvested fees (slippage floor).
-    /// @param recipient Destination for swept dust. Forced to position owner if caller is an operator.
-    /// @param deadline Timestamp after which the transaction will revert.
-    /// @param route Encoded Universal Router commands and inputs (can be empty).
-    /// @param hookData Arbitrary data passed to pool hooks.
+    /// @param tokenId Position ID whose fees are collected and reinvested.
+    /// @param minLiquidityAdded Minimum liquidity the reinvested fees must add (slippage floor).
+    /// @param recipient Receives dust. Forced to the owner if the caller is an operator.
+    /// @param deadline Timestamp after which the transaction reverts.
+    /// @param route Encoded Universal Router commands and inputs. Can be empty.
+    /// @param hookData Data passed to every hook callback.
     struct CompoundParams {
         uint256 tokenId;
         uint256 minLiquidityAdded;
@@ -256,12 +241,12 @@ interface ISwapAndAdd is IMulticall_v4 {
         bytes hookData;
     }
 
-    /// @notice Collect accrued fees on a position and reinvest them back into the same position in a single transaction.
-    /// @dev Caller must be owner or approved operator, and this contract must be ERC-721 approved on POSM for `tokenId`.
-    /// @param params The configuration parameters for the compound operation.
-    /// @return liquidityAdded The liquidity added to the position from reinvested fees.
-    /// @return amount0 Amount of token0 reinvested into the position.
-    /// @return amount1 Amount of token1 reinvested into the position.
+    /// @notice Collects accrued fees on a position and reinvests them into the same position.
+    /// @dev Requires caller authorization and ERC-721 approval on the position in POSM.
+    /// @param params The compound parameters.
+    /// @return liquidityAdded The liquidity added from reinvested fees.
+    /// @return amount0 Token0 reinvested into the position.
+    /// @return amount1 Token1 reinvested into the position.
     function compound(CompoundParams calldata params)
         external
         returns (uint128 liquidityAdded, uint256 amount0, uint256 amount1);

--- a/src/interfaces/external/IUniversalRouter.sol
+++ b/src/interfaces/external/IUniversalRouter.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
 
-/// @notice Minimal Universal Router interface used by SwapAndAdd to delegate the bulk swap leg.
-/// @dev We intentionally depend only on this interface (not on the UR source), keeping the dependency
-///      direction clean. The route runs verbatim; the within-unlock V4_SWAP handling is internal to UR.
+/// @notice Minimal Universal Router interface used by SwapAndAdd for the route leg.
+/// @dev The route runs verbatim. The within-unlock V4_SWAP handling is internal to the router.
 interface IUniversalRouter {
     function execute(bytes calldata commands, bytes[] calldata inputs) external payable;
 }

--- a/src/libraries/SwapAndAddMath.sol
+++ b/src/libraries/SwapAndAddMath.sol
@@ -144,9 +144,11 @@ library SwapAndAddMath {
         } else {
             // token0 occupies [max(price, sqrtLower), sqrtUpper]: amount0 = L * Q96 * (hi - lo) / (hi * lo)
             uint160 clampedLower = sqrtPriceX96 > sqrtPriceLowerX96 ? sqrtPriceX96 : sqrtPriceLowerX96;
-            // below tick ~-665k this quotient rounds up from below 1 and over-trims, the caller's cap absorbs it
+            // below tick ~-665k this quotient rounds up from below 1 and over-trims by a factor of
+            // up to ~2^32 (potentially the caller's entire cap), safely absorbed without fund loss
             uint256 intermediate = FullMath.mulDivRoundingUp(clampedLower, sqrtPriceUpperX96, FixedPoint96.Q96);
-            // can overflow and revert when the price is within sqrt units of sqrtUpper with a large deficit
+            // can overflow and revert when the price is within sqrt units of sqrtUpper with a large
+            // deficit (self-inflicted and atomic, a safe known limit)
             liquidityToFree =
                 FullMath.mulDivRoundingUp(amountToCover + 1, intermediate, sqrtPriceUpperX96 - clampedLower);
         }

--- a/src/libraries/SwapAndAddMath.sol
+++ b/src/libraries/SwapAndAddMath.sol
@@ -8,20 +8,19 @@ import {SqrtPriceMath} from "@uniswap/v4-core/src/libraries/SqrtPriceMath.sol";
 import {ProtocolFeeLibrary} from "@uniswap/v4-core/src/libraries/ProtocolFeeLibrary.sol";
 
 /// @title SwapAndAddMath
-/// @notice Pure sizing and trim math for SwapAndAdd. All functions are stateless: callers supply the live
-///         sqrt price, range bounds, and fee configuration.
+/// @notice Pure sizing and trim math for SwapAndAdd. Callers supply the live sqrt price, the range
+///         bounds, and the fee configuration.
 library SwapAndAddMath {
     using SafeCast for uint256;
 
     uint256 internal constant PIPS_DENOMINATOR = 1e6;
-    /// @dev Sizing reference: maximal so the reference-scaling quantization is negligible.
+    /// @dev Reference position used to price liquidity. Maximal, so the scale-down rounding error
+    ///      is negligible.
     uint128 internal constant REFERENCE_LIQUIDITY = type(uint128).max;
 
-    /// @notice Sizes liquidity accounting for directional swap fees on the surplus token.
-    /// @dev First calculates a mid-price baseline size to find which token has a surplus, then discounts that
-    ///      surplus token's value by the combined pool fee (LP fee + directional protocol fee).
-    ///      Discounting the surplus side on both the budget and the reference position nets to charging the
-    ///      fee on exactly the swapped amount.
+    /// @notice Sizes liquidity while accounting for the swap fee on the surplus token.
+    /// @dev Sizes at the mid price to find the surplus token, then discounts that token's value by
+    ///      the combined pool fee. This nets to charging the fee on exactly the swapped amount.
     function getLiquidityFeeAware(
         uint160 sqrtPriceX96,
         uint160 sqrtPriceLowerX96,
@@ -37,7 +36,7 @@ library SwapAndAddMath {
         (uint256 mid0, uint256 mid1) =
             getAmountsForLiquidity(sqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, midLiquidity);
         if (budget0 > mid0) {
-            // Token0 surplus: reconcile swap sells token0 (zeroForOne), discount token0 value by fee.
+            // token0 surplus: the reconcile swap sells token0, so discount token0 by the zeroForOne fee
             uint256 feePips =
                 ProtocolFeeLibrary.calculateSwapFee(ProtocolFeeLibrary.getZeroForOneFee(protocolFee), lpFee);
             return getLiquidityForAmountsWeighted(
@@ -50,7 +49,7 @@ library SwapAndAddMath {
                 PIPS_DENOMINATOR
             );
         } else if (budget1 > mid1) {
-            // Token1 surplus: reconcile swap sells token1 (oneForZero), discount token1 value by fee.
+            // token1 surplus: the reconcile swap sells token1, so discount token1 by the oneForZero fee
             uint256 feePips =
                 ProtocolFeeLibrary.calculateSwapFee(ProtocolFeeLibrary.getOneForZeroFee(protocolFee), lpFee);
             return getLiquidityForAmountsWeighted(
@@ -63,13 +62,13 @@ library SwapAndAddMath {
                 PIPS_DENOMINATOR - feePips
             );
         }
-        // Holdings are already in exact proportion; no fee discount needed.
+        // the budget is already in exact proportion, no swap and therefore no fee discount
         return midLiquidity;
     }
 
-    /// @notice Computes liquidity by scaling reference liquidity against budget value in the cheaper token.
-    /// @param pipsWeight0 Value weight applied to token0, in pips of PIPS_DENOMINATOR.
-    /// @param pipsWeight1 Value weight applied to token1, in pips of PIPS_DENOMINATOR.
+    /// @notice Computes liquidity as REFERENCE_LIQUIDITY scaled by budget value over reference value.
+    /// @param pipsWeight0 Value weight applied to token0, in pips.
+    /// @param pipsWeight1 Value weight applied to token1, in pips.
     function getLiquidityForAmountsWeighted(
         uint160 sqrtPriceX96,
         uint160 sqrtPriceLowerX96,
@@ -79,9 +78,9 @@ library SwapAndAddMath {
         uint256 pipsWeight0,
         uint256 pipsWeight1
     ) internal pure returns (uint128) {
-        // Price >= 1 values both sides in token1 terms via rateX96 = sqrtPrice^2 / Q96 (token1 per token0);
-        // price < 1 values in token0 terms via rateX96 = Q96^3 / sqrtPrice^2 (split to prevent intermediate
-        // overflow). Valuing in the cheaper token keeps the rate multiplier >= Q96 across extreme ticks.
+        // Value both tokens in whichever token is cheaper or equal, so rateX96 >= Q96 and no
+        // precision is lost at extreme ticks. rateX96 is the price (sqrtPrice^2 / Q96) or its
+        // inverse, split into two mulDiv steps to avoid intermediate overflow.
         bool isToken1Cheaper = sqrtPriceX96 >= FixedPoint96.Q96;
         uint256 rateX96 = isToken1Cheaper
             ? FullMath.mulDiv(sqrtPriceX96, sqrtPriceX96, FixedPoint96.Q96)
@@ -96,16 +95,15 @@ library SwapAndAddMath {
             refValue = _weightedValue(ref0, ref1, rateX96, isToken1Cheaper, pipsWeight0, pipsWeight1);
         }
         if (refValue == 0) return 0;
-        // Scale reference liquidity: L = REFERENCE_LIQUIDITY * budgetValue / refValue.
-        // Truncating towards zero here is the safe direction (any leftover budget is swept as dust).
+        // L = budgetValue * REFERENCE_LIQUIDITY / refValue, truncation is safe (leftover is swept)
         uint256 budgetValue = _weightedValue(amount0, amount1, rateX96, isToken1Cheaper, pipsWeight0, pipsWeight1);
-        return FullMath.mulDiv(REFERENCE_LIQUIDITY, budgetValue, refValue).toUint128();
+        return FullMath.mulDiv(budgetValue, REFERENCE_LIQUIDITY, refValue).toUint128();
     }
 
-    /// @notice Calculates token amounts required for a given liquidity amount at current price/range.
-    /// @dev Rounds UP to mirror POSM's MINT_POSITION — callers funding a mint from these amounts are never
-    ///      a wei short of POSM's pull. NOT interchangeable with LiquidityAmounts (which rounds down).
-    ///      The A/B bounds follow LiquidityAmounts' convention: they may be passed in either order.
+    /// @notice Calculates the token amounts required for a liquidity amount at the given price and range.
+    /// @dev Rounds UP to mirror POSM's MINT_POSITION, so funding from these amounts is never a wei
+    ///      short. Not interchangeable with LiquidityAmounts, which rounds down. The A/B bounds may
+    ///      be passed in either order.
     function getAmountsForLiquidity(
         uint160 sqrtPriceX96,
         uint160 sqrtPriceAX96,
@@ -125,12 +123,12 @@ library SwapAndAddMath {
         }
     }
 
-    /// @notice Computes the liquidity to burn so that v4's rounded-DOWN return covers `amountToCover` of the
-    ///         deficit token.
-    /// @dev Exact ceil inverse over `amountToCover + 1`: the nested-floor bound guarantees freed >= amountToCover.
-    ///      Assumes the price is not past the range's far side for the deficit token (SwapAndAdd's reconcile
-    ///      flow guarantees this); a price outside the near side clamps to the boundary.
-    /// @return liquidityToFree The round-up liquidity to burn, uncapped — callers cap against the liquidity they added.
+    /// @notice Computes the liquidity to burn so that v4's rounded-down burn output covers
+    ///         `amountToCover` of the deficit token.
+    /// @dev Ceiling inverse over `amountToCover + 1`, so the freed amount is always sufficient.
+    ///      Assumes the price is not past the range's far side for the deficit token.
+    /// @return liquidityToFree The liquidity to burn, uncapped. Callers must cap it against the
+    ///         liquidity they added.
     function getLiquidityToFree(
         uint160 sqrtPriceX96,
         uint160 sqrtPriceLowerX96,
@@ -139,24 +137,22 @@ library SwapAndAddMath {
         uint256 amountToCover
     ) internal pure returns (uint256 liquidityToFree) {
         if (deficitIsCurrency1) {
-            // Token1 occupies [sqrtLower, min(price, sqrtUpper)]: amount1 = L * (hi - lo) / Q96.
+            // token1 occupies [sqrtLower, min(price, sqrtUpper)]: amount1 = L * (hi - lo) / Q96
             uint160 clampedUpper = sqrtPriceX96 < sqrtPriceUpperX96 ? sqrtPriceX96 : sqrtPriceUpperX96;
             liquidityToFree =
                 FullMath.mulDivRoundingUp(amountToCover + 1, FixedPoint96.Q96, clampedUpper - sqrtPriceLowerX96);
         } else {
-            // Token0 occupies [max(price, sqrtLower), sqrtUpper]: amount0 = L * Q96 * (hi - lo) / (hi * lo).
+            // token0 occupies [max(price, sqrtLower), sqrtUpper]: amount0 = L * Q96 * (hi - lo) / (hi * lo)
             uint160 clampedLower = sqrtPriceX96 > sqrtPriceLowerX96 ? sqrtPriceX96 : sqrtPriceLowerX96;
-            // Informational: Below tick ~-665k (lo * hi < Q96), rounding up this sub-1 quotient over-trims by
-            // a factor of up to ~2^32, which the caller's cap safely absorbs without fund loss.
+            // below tick ~-665k this quotient rounds up from below 1 and over-trims, the caller's cap absorbs it
             uint256 intermediate = FullMath.mulDivRoundingUp(clampedLower, sqrtPriceUpperX96, FixedPoint96.Q96);
-            // Informational: At extreme prices where post-swap price is within sqrt-units of sqrtUpper with large
-            // deficit remaining, this intermediate quotient can overflow uint256 and revert (self-inflicted, safe).
+            // can overflow and revert when the price is within sqrt units of sqrtUpper with a large deficit
             liquidityToFree =
                 FullMath.mulDivRoundingUp(amountToCover + 1, intermediate, sqrtPriceUpperX96 - clampedLower);
         }
     }
 
-    /// @dev Values a token pair in the cheaper-token numeraire, weighting each side by its pips factor.
+    /// @dev Values a token pair in the cheaper-token numeraire and weights each side by its pips factor.
     function _weightedValue(
         uint256 amount0,
         uint256 amount1,

--- a/test-integration/SwapAndAddForkMainnet.t.sol
+++ b/test-integration/SwapAndAddForkMainnet.t.sol
@@ -28,15 +28,14 @@ import {UniversalRouter} from "universal-router/contracts/UniversalRouter.sol";
 import {RouterParameters} from "universal-router/contracts/types/RouterParameters.sol";
 import {Commands} from "universal-router/contracts/libraries/Commands.sol";
 
-/// @notice Mainnet-FORK integration: deploys the REAL modified Universal Router + SwapAndAdd against the live
-///         mainnet v4 PoolManager/POSM/Permit2 and drives an add against the real deep ETH/USDC pool
-///         (id 0xdce6...78d). Backbone for the test suite and the eventual UI-on-anvil-fork.
+/// @notice Mainnet fork test. Deploys the modified Universal Router and SwapAndAdd against the live
+///         PoolManager, POSM, and Permit2, then adds to the ETH/USDC pool (id 0xdce6...78d).
 ///         Run: FOUNDRY_PROFILE=integration forge test --match-contract SwapAndAddForkMainnetTest
 contract SwapAndAddForkMainnetTest is Test {
     using StateLibrary for IPoolManager;
     using PoolIdLibrary for PoolKey;
 
-    // ── canonical mainnet addresses (from universal-router/script/deployParameters/DeployMainnet.s.sol) ──
+    // canonical mainnet addresses, from universal-router/script/deployParameters/DeployMainnet.s.sol
     address constant POOL_MANAGER = 0x000000000004444c5dc75cB358380D2e3dE08A90;
     address constant POSM = 0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e;
     address constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
@@ -59,8 +58,8 @@ contract SwapAndAddForkMainnetTest is Test {
     PoolKey key;
 
     function setUp() public {
-        // Defaults to the head because the keyless public RPC serves no archive state. For a reproducible run,
-        // set FORK_URL to an archive endpoint and pin with FORK_BLOCK (e.g. 25_495_000, 2026-07-09).
+        // The public RPC has no archive state, so default to head.
+        // For a reproducible run, set an archive FORK_URL and pin FORK_BLOCK (for example 25_495_000, 2026-07-09).
         uint256 forkBlock = vm.envOr("FORK_BLOCK", uint256(0));
         string memory forkUrl = vm.envOr("FORK_URL", string(""));
         if (bytes(forkUrl).length == 0) forkUrl = "https://ethereum-rpc.publicnode.com"; // empty env var = unset
@@ -93,7 +92,7 @@ contract SwapAndAddForkMainnetTest is Test {
         });
     }
 
-    /// @dev brute-force the PoolKey whose id == TARGET_ID, assuming no hook. Tries native-ETH/USDC then USDC/WETH.
+    /// @dev Find the hookless PoolKey whose id matches TARGET_ID.
     function _reconstructKey() internal pure returns (PoolKey memory) {
         (bool ok, PoolKey memory k) = _tryPair(Currency.wrap(address(0)), Currency.wrap(USDC));
         if (ok) return k;
@@ -147,7 +146,7 @@ contract SwapAndAddForkMainnetTest is Test {
         });
     }
 
-    // ─────────────────────────── empty-route (same-pool) against the real pool ───────────────────────────
+    // empty-route (same-pool) adds against the real pool
 
     function test_fork_add_usdcBudget_emptyRoute() public {
         (int24 lo, int24 hi) = _ticks();
@@ -177,14 +176,13 @@ contract SwapAndAddForkMainnetTest is Test {
         assertEq(IERC20(USDC).balanceOf(address(zap)), 0, "zap usdc == 0");
     }
 
-    // ─────────────────────────── real-UR route within the zap's unlock ───────────────────────────
+    // real-UR route within the zap's unlock
 
     function test_fork_add_usdcBudget_viaURRoute() public {
         (int24 lo, int24 hi) = _ticks();
         _fundUsdc(50_000e6);
 
-        // bulk: sell 4_000 USDC -> ETH on the SAME real pool via the real UR (within the zap's unlock);
-        // the same-pool reconcile + trim finish the position.
+        // Sell 4_000 USDC for ETH through the real UR inside the zap's unlock.
         bytes memory route = _v4SwapRoute(key, false, 4_000e6, key.currency1, key.currency0);
 
         (uint256 tokenId, uint128 liq,,) = zap.add(_addParams(0, 10_000e6, route, lo, hi));
@@ -195,9 +193,7 @@ contract SwapAndAddForkMainnetTest is Test {
         assertEq(IERC20(USDC).balanceOf(address(zap)), 0, "zap usdc == 0");
     }
 
-    /// @notice Route-first against the REAL UR: with a well-sized route (route does the bulk), almost the entire
-    ///         budget is deployed — the recipient gets back only tiny dust (route-first sizes from real holdings,
-    ///         so it does not return the route's execution slice the way a size-then-swap design would).
+    /// @notice With a well-sized route, the zap deploys almost the whole budget and returns only dust.
     function test_fork_add_usdcBudget_viaURRoute_lowDust() public {
         (int24 lo, int24 hi) = _ticks();
         _fundUsdc(50_000e6);
@@ -205,16 +201,14 @@ contract SwapAndAddForkMainnetTest is Test {
         uint256 usdcBefore = IERC20(USDC).balanceOf(address(this));
         uint256 ethBefore = address(this).balance;
 
-        // route ~half the budget (the bulk) USDC -> ETH on the real pool; reconcile + trim finish it.
+        // Route about half the budget USDC -> ETH.
         bytes memory route = _v4SwapRoute(key, false, 5_000e6, key.currency1, key.currency0);
         (uint256 tokenId, uint128 liq,,) = zap.add(_addParams(0, 10_000e6, route, lo, hi));
 
         uint256 usdcReturned = IERC20(USDC).balanceOf(address(this)) + 10_000e6 - usdcBefore; // budget pulled was 10_000
         assertEq(IERC721(POSM).ownerOf(tokenId), address(this), "user owns NFT");
         assertGt(liq, 0, "liquidity minted");
-        // route-first deploys nearly all of it: returned USDC is a small fraction of the 10_000 budget.
         assertLt(usdcReturned, 200e6, "returned USDC < 2% of budget");
-        // the swapped-into token (ETH) is not returned to the user beyond dust.
         assertApproxEqAbs(address(this).balance, ethBefore, 1e12, "no meaningful ETH dust to user");
         assertEq(address(zap).balance, 0, "zap eth == 0");
         assertEq(IERC20(USDC).balanceOf(address(zap)), 0, "zap usdc == 0");
@@ -240,7 +234,7 @@ contract SwapAndAddForkMainnetTest is Test {
         });
     }
 
-    // ─────────────────────────── rebalance on the real pool ───────────────────────────
+    // rebalance on the real pool
 
     function test_fork_rebalance_full() public {
         (int24 lo, int24 hi) = _ticks();
@@ -259,8 +253,7 @@ contract SwapAndAddForkMainnetTest is Test {
         assertEq(IERC20(USDC).balanceOf(address(zap)), 0, "zap usdc == 0");
     }
 
-    // Negative delta (cash-out) on the real pool: the old position is burned IN FULL, a chosen amount of USDC is
-    // returned to the recipient's wallet, and only the remainder (plus the withdrawn ETH) is redeployed.
+    // Cash-out rebalance: burn the old position, return the requested USDC, redeploy the remainder.
     function test_fork_rebalance_cashOut() public {
         (int24 lo, int24 hi) = _ticks();
         _fundUsdc(50_000e6);
@@ -275,14 +268,12 @@ contract SwapAndAddForkMainnetTest is Test {
         assertEq(IERC721(POSM).ownerOf(newTokenId), address(this), "user owns new NFT");
         assertGt(newLiq, 0, "new liquidity minted");
         assertEq(posm.getPositionLiquidity(tokenId), 0, "old position fully burned");
-        // the cashed-out USDC reaches the recipient (at least the requested 2k).
         assertGe(IERC20(USDC).balanceOf(address(this)), usdcBefore + 2_000e6, "cashed-out usdc returned");
         assertEq(address(zap).balance, 0, "zap eth == 0");
         assertEq(IERC20(USDC).balanceOf(address(zap)), 0, "zap usdc == 0");
     }
 
-    // Positive delta (rebalance + add) on the real pool: pull MORE USDC from the wallet on top of the withdrawn
-    // holdings, so the new position is larger than a plain full redeploy of the same burned position.
+    // Rebalance with extra USDC: the new position must exceed a plain full redeploy.
     function test_fork_rebalance_addMore() public {
         (int24 lo, int24 hi) = _ticks();
         _fundUsdc(50_000e6);
@@ -303,7 +294,7 @@ contract SwapAndAddForkMainnetTest is Test {
         assertEq(IERC20(USDC).balanceOf(address(zap)), 0, "zap usdc == 0");
     }
 
-    // Native positive delta on the real ETH/USDC pool: add more native ETH (via msg.value) during a rebalance.
+    // Add more native ETH (msg.value) during a rebalance.
     function test_fork_rebalance_native_addMore() public {
         (int24 lo, int24 hi) = _ticks();
         vm.deal(address(this), 100 ether);
@@ -326,7 +317,7 @@ contract SwapAndAddForkMainnetTest is Test {
         assertEq(IERC20(USDC).balanceOf(address(zap)), 0, "zap usdc == 0");
     }
 
-    // Repro: full rebalance into the SAME range as the old position (the UI's default).
+    // Full rebalance into the same range (the UI default).
     function test_fork_rebalance_sameRange_full() public {
         (int24 lo, int24 hi) = _ticks();
         _fundUsdc(50_000e6);
@@ -336,7 +327,7 @@ contract SwapAndAddForkMainnetTest is Test {
         zap.rebalance(_rebalanceParams(tokenId, 0, 0, lo, hi)); // new range == old range
     }
 
-    // Faithful repro of the in-browser flow: 0.5 ETH add, then same-range full rebalance.
+    // Browser-flow repro: 0.5 ETH add, then same-range full rebalance.
     function test_fork_rebalance_sameRange_full_halfEth() public {
         (int24 lo, int24 hi) = _ticks();
         vm.deal(address(this), 100 ether);
@@ -345,7 +336,7 @@ contract SwapAndAddForkMainnetTest is Test {
         zap.rebalance(_rebalanceParams(tokenId, 0, 0, lo, hi));
     }
 
-    // ─────────────────────────── compound on the real pool ───────────────────────────
+    // compound on the real pool
 
     function _compoundParams(uint256 tokenId, uint256 minLiquidityAdded)
         internal
@@ -362,13 +353,11 @@ contract SwapAndAddForkMainnetTest is Test {
         });
     }
 
-    /// @dev Generate fees on the real pool: balanced round-trip swaps (ETH<->USDC) so the price returns near its
-    ///      start while both sides accrue fees to the in-range position. Large notional so a position of this size
-    ///      captures a non-trivial fee share of the deep pool.
+    /// @dev Balanced round-trip swaps keep the price near its start while the position accrues fees.
     function test_fork_compound_reinvestsFees() public {
         (int24 lo, int24 hi) = _ticks();
         int24 ts = key.tickSpacing;
-        lo = lo - 40 * ts; // widen so the position stays in range across the fee-generating swaps
+        lo = lo - 40 * ts; // widen so the position stays in range
         hi = hi + 40 * ts;
 
         _fundUsdc(5_000_000e6);
@@ -380,7 +369,6 @@ contract SwapAndAddForkMainnetTest is Test {
         PoolSwapTest swapRouter = new PoolSwapTest(manager);
         IERC20(USDC).approve(address(swapRouter), type(uint256).max);
         PoolSwapTest.TestSettings memory settings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        // round-trips: sell ETH -> USDC, then sell that USDC back -> ETH, so the price returns near its start.
         for (uint256 i = 0; i < 3; i++) {
             swapRouter.swap{value: 300 ether}(
                 key,
@@ -430,15 +418,8 @@ contract SwapAndAddForkMainnetTest is Test {
         return abi.encode(commands, inputs);
     }
 
-    // ── real Trading API route fixture (mainnet) ──
-    // Fetched via /v1/quote + /v1/swap with x-universal-router-version: 2.2.0, protocols=["V4"] and
-    // swapper = TAPI_ZAP, a synthetic constant address: the zap is placed there with deployCodeTo, so the
-    // fixture (which embeds the swapper as the route's recipient) never goes stale from deployment-nonce
-    // drift. 2500e6 USDC -> native ETH as a multi-hop v4 route + native SWEEP — this is the coverage the
-    // Sepolia fixture lost when TAPI stopped serving v4 legs there: TAPI's v4-action ABI generation
-    // executing on OUR router generation, V4_SWAP running inside the zap's already-open unlock, and a
-    // native-output route. Pinned to the quote's block; refresh via script/fetch-tapi-route.sh (chainId 1,
-    // SWAPPER=TAPI_ZAP). Requires an archive FORK_URL; skipped otherwise.
+    // TAPI route fixture (mainnet): 2500e6 USDC -> native ETH, multi-hop v4 plus a native SWEEP, pinned to the quote's block.
+    // Generated by script/fetch-tapi-route.sh (chainId 1, SWAPPER=TAPI_ZAP), with the zap placed at the synthetic swapper address.
     address constant TAPI_ZAP = 0x000000000000000000000000000000005a9B7a11;
     uint256 constant TAPI_FIXTURE_BLOCK = 25789116;
     bytes constant TAPI_EXECUTE_TAIL =
@@ -446,10 +427,10 @@ contract SwapAndAddForkMainnetTest is Test {
 
     function test_fork_add_viaRealTapiRoute() public {
         string memory forkUrl = vm.envOr("FORK_URL", string(""));
-        vm.skip(bytes(forkUrl).length == 0); // pinned block needs archive state; skip on public RPC
+        vm.skip(bytes(forkUrl).length == 0); // the pinned block needs archive state, so skip on the public RPC
         vm.createSelectFork(forkUrl, TAPI_FIXTURE_BLOCK);
 
-        // fresh stack in the pinned fork; the zap sits at the fixture's swapper address
+        // fresh stack in the pinned fork, with the zap at the fixture's swapper address
         router = new UniversalRouter(_routerParams());
         deployCodeTo(
             "SwapAndAdd.sol:SwapAndAdd",

--- a/test-integration/SwapAndAddForkSepolia.t.sol
+++ b/test-integration/SwapAndAddForkSepolia.t.sol
@@ -22,20 +22,18 @@ import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol"
 
 import {Commands} from "universal-router/contracts/libraries/Commands.sol";
 
-/// @notice Sepolia-FORK integration against the LIVE deployment — nothing is deployed here except the test
-///         pool's mock tokens; the zap and its patched Universal Router are the actual onchain bytecode
-///         (broadcast @ block 11521953 (zap; router reused from block 11276910), script/DeploySwapAndAdd.s.sol). Pools are created fresh in the fork
-///         and seeded through the zap itself (first-LP on an empty pool is a supported flow), so the tests
-///         are deterministic and independent of whatever thin liquidity Sepolia happens to have.
+/// @notice Sepolia fork test against the live deployment. The zap (block 11521953) and the patched
+///         Universal Router (block 11276910) are the onchain bytecode from script/DeploySwapAndAdd.s.sol.
+///         The tests create and seed fresh pools, so they do not depend on existing Sepolia liquidity.
 ///         Run: FOUNDRY_PROFILE=integration forge test --match-contract SwapAndAddForkSepoliaTest
 contract SwapAndAddForkSepoliaTest is Test {
     using StateLibrary for IPoolManager;
     using PoolIdLibrary for PoolKey;
 
-    // ── live Sepolia deployment (chore(SwapAndAdd): deploy zap + patched UR to Sepolia) ──
+    // live Sepolia deployment (chore(SwapAndAdd): deploy zap + patched UR to Sepolia)
     address constant ZAP = 0x6f923892d6A45f7e77DB36f48F055C045F93E979;
     address constant UR = 0x44518461733Fd7f5DC5996facB405CF659108Ea2;
-    // ── canonical Sepolia protocol addresses (verified in script/DeploySwapAndAdd.s.sol) ──
+    // canonical Sepolia protocol addresses, verified in script/DeploySwapAndAdd.s.sol
     address constant POOL_MANAGER = 0xE03A1074c86CFeDd5C142C4F04F1a1536e203543;
     address constant POSM = 0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4;
     address constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
@@ -113,13 +111,13 @@ contract SwapAndAddForkSepoliaTest is Test {
         });
     }
 
-    /// @dev first LP through the live zap itself: two-sided in-ratio on the empty pool.
+    /// @dev First LP through the live zap itself: a two-sided in-ratio add on the empty pool.
     function _seed(PoolKey memory k) internal returns (uint256 tokenId, uint128 liq) {
         uint256 v = Currency.unwrap(k.currency0) == address(0) ? 50e18 : 0;
         (tokenId, liq,,) = zap.add{value: v}(_addParams(k, 50e18, 50e18, ""));
     }
 
-    // ─────────────────────────── live-bytecode behavior, no route ───────────────────────────
+    // live-bytecode behavior, no route
 
     function test_forkSepolia_add_firstLiquidity_emptyPool() public {
         (uint256 tokenId, uint128 liq) = _seed(key);
@@ -149,10 +147,9 @@ contract SwapAndAddForkSepoliaTest is Test {
         assertEq(tokenB.balanceOf(ZAP), 0, "zap token == 0");
     }
 
-    // ─────────────────────────── routed: V4_SWAP inside the zap's unlock, on the LIVE patched UR ───────────────
+    // routed: V4_SWAP inside the zap's unlock, on the live patched UR
 
-    /// @dev The single most important live assertion: the deployed UR accepts V4_SWAP within the zap's
-    ///      already-open unlock (the canonical UR reverts AlreadyUnlocked here).
+    /// @dev The deployed UR accepts V4_SWAP within the zap's open unlock (the canonical UR reverts AlreadyUnlocked).
     function test_forkSepolia_add_viaLiveURRoute() public {
         _seed(key);
         bytes memory route = _v4SwapRoute(key, false, 4e18, key.currency1, key.currency0);
@@ -163,7 +160,7 @@ contract SwapAndAddForkSepoliaTest is Test {
         assertEq(tokenB.balanceOf(ZAP), 0, "zap token1 == 0");
     }
 
-    // ─────────────────────────── rebalance + compound on live bytecode ───────────────────────────
+    // rebalance + compound on live bytecode
 
     function test_forkSepolia_rebalance_full() public {
         (uint256 tokenId,,,) = zap.add(_addParams(key, 50e18, 50e18, ""));
@@ -210,8 +207,7 @@ contract SwapAndAddForkSepoliaTest is Test {
         assertEq(tokenB.balanceOf(ZAP), 0, "zap token1 == 0");
     }
 
-    /// @dev seed, then generate real fees with a round-trip swap executed directly on the LIVE UR (standalone
-    ///      mode: it opens its own unlock) — also covers the deployed router's plain-swap path.
+    /// @dev Seed, then earn real fees with a round-trip swap directly on the live UR.
     function _seedAndEarnFees() internal returns (uint256 tokenId, uint128 liq, uint256 feesSwapped) {
         (tokenId, liq) = _seed(key);
         (bytes memory c1, bytes[] memory i1) =
@@ -249,28 +245,18 @@ contract SwapAndAddForkSepoliaTest is Test {
         return abi.encode(commands, inputs);
     }
 
-    // ── real Trading API route fixture ──
-    // Fetched via /v1/quote + /v1/swap with swapper = the LIVE zap and the public
-    // x-universal-router-version: 2.2.0 header: 50e6 USDC -> WETH. The header matters: the API encodes
-    // actions for the requested router ABI generation, and this deployment's router is built from a
-    // v2.2-line UR revision. Refreshed 2026-08-19 for the redeployed zap (the route embeds the swapper as
-    // recipient, so the fixture is address-bound): TAPI currently serves this pair through a v3 pool only
-    // (no v4 leg offered even with protocols=[V4]) and BEST_PRICE 500s on Sepolia, so this is the FASTEST
-    // route — an OFF-VENUE (v3) leg feeding a v4 deploy; the nested-V4_SWAP-in-unlock property is covered
-    // by SwapAndAddRoute.t.sol. Bytes are the verbatim /v1/swap "data" tail (selector stripped):
-    // abi.encode(commands, inputs, deadline), pinned to the quote's block so the route's own
-    // amountOutMinimum stays satisfiable forever. Refresh via script/fetch-tapi-route.sh.
+    // TAPI route fixture: 50e6 USDC -> WETH through a v3 pool, pinned to the quote's block.
+    // Fetched 2026-08-19 via script/fetch-tapi-route.sh with swapper = the live zap (the route is address-bound).
     address constant USDC = 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238;
     address constant WETH = 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14;
     uint256 constant TAPI_FIXTURE_BLOCK = 11521987;
     bytes constant TAPI_EXECUTE_TAIL =
         hex"000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000006a85a4c6000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000001400000000000000000000000006f923892d6a45f7e77db36f48f055c045f93e9790000000000000000000000000000000000000000000000000000000002faf080000000000000000000000000000000000000000000000000000778a21c40fea000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000002b1c7d4b196cb0c7b01d743fbc6116a902379c7238000064fff9976782d46cc05630d1f6ebab18b2324d6b140000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000756e69780000d7ff01b6";
 
-    /// @dev The full production flow with verbatim TAPI calldata: real route executed by the live zap on
-    ///      the live UR, deploying into the real v4 pool the route also swaps through.
+    /// @dev Full production flow: the live zap executes verbatim TAPI calldata on the live UR.
     function test_forkSepolia_add_viaRealTapiRoute() public {
         string memory forkUrl = vm.envOr("SEPOLIA_FORK_URL", string(""));
-        vm.skip(bytes(forkUrl).length == 0); // pinned block needs archive state; skip on public RPC
+        vm.skip(bytes(forkUrl).length == 0); // the pinned block needs archive state, so skip on the public RPC
         vm.createSelectFork(forkUrl, TAPI_FIXTURE_BLOCK);
 
         (bytes memory commands, bytes[] memory inputs,) = abi.decode(TAPI_EXECUTE_TAIL, (bytes, bytes[], uint256));

--- a/test-integration/SwapAndAddRoute.t.sol
+++ b/test-integration/SwapAndAddRoute.t.sol
@@ -12,8 +12,7 @@ import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.so
 import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
 import {IERC721} from "forge-std/interfaces/IERC721.sol";
 
-// Build the route bytes with THIS repo's own v4-periphery libraries. They are byte-identical to the copy UR
-// decodes against (verified: same Actions opcodes + same IV4Router.ExactInputSingleParams layout).
+// These libraries build route bytes identical to the copy the UR decodes against.
 import {Plan, Planner} from "../test/shared/Planner.sol";
 import {Actions} from "../src/libraries/Actions.sol";
 import {ActionConstants} from "../src/libraries/ActionConstants.sol";
@@ -28,10 +27,8 @@ import {UniversalRouter} from "universal-router/contracts/UniversalRouter.sol";
 import {RouterParameters} from "universal-router/contracts/types/RouterParameters.sol";
 import {Commands} from "universal-router/contracts/libraries/Commands.sol";
 
-/// @notice Integration test: SwapAndAdd's non-empty `route` path executed through the REAL modified Universal
-///         Router, with UR.execute called from inside the zap's own v4 PoolManager unlock. This is the path
-///         the UR change (`feat/v4-swap-within-existing-unlock`, V4_SWAP via _executeActionsWithoutUnlock)
-///         exists to enable — if UR lacked that branch, the nested execute would revert AlreadyUnlocked.
+/// @notice Tests the non-empty `route` path: UR.execute runs inside the zap's own PoolManager unlock.
+///         The modified UR (`feat/v4-swap-within-existing-unlock`) enables this path. The canonical UR reverts AlreadyUnlocked.
 contract SwapAndAddRouteTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -39,7 +36,7 @@ contract SwapAndAddRouteTest is PosmTestSetup {
 
     SwapAndAdd zap;
     UniversalRouter router;
-    PoolKey routeKey; // a SECOND pool, only ever touched by the UR route leg — isolates the proof.
+    PoolKey routeKey; // second pool, touched only by the UR route leg
 
     int24 constant TICK_LOWER = -600;
     int24 constant TICK_UPPER = 600;
@@ -57,7 +54,7 @@ contract SwapAndAddRouteTest is PosmTestSetup {
         (routeKey,) = initPoolAndAddLiquidity(currency0, currency1, IHooks(address(0)), 500, SQRT_PRICE_1_1);
         seedMoreLiquidity(routeKey, 1_000e18, 1_000e18);
 
-        // the REAL modified Universal Router, pointed at this test's PoolManager + Permit2 (v2/v3/migration off)
+        // the real modified Universal Router, pointed at this test's PoolManager + Permit2 (v2/v3/migration off)
         RouterParameters memory params = RouterParameters({
             permit2: address(permit2),
             weth9: address(0),
@@ -85,8 +82,7 @@ contract SwapAndAddRouteTest is PosmTestSetup {
         permit2.approve(Currency.unwrap(c), address(zap), type(uint160).max, type(uint48).max);
     }
 
-    /// @dev builds a verbatim UR route: exact-in `inCcy`->`outCcy` on `poolKey` as a single V4_SWAP, settling
-    ///      the input from the caller (the zap) via Permit2 and taking the output back to the caller (the zap).
+    /// @dev Builds a UR route: a single exact-in V4_SWAP of `inCcy` for `outCcy` on `poolKey`.
     function _v4SwapRoute(PoolKey memory poolKey, bool zeroForOne, uint128 amtIn, Currency inCcy, Currency outCcy)
         internal
         pure
@@ -114,11 +110,10 @@ contract SwapAndAddRouteTest is PosmTestSetup {
         return abi.encode(commands, inputs);
     }
 
-    /// @notice Single-token1 budget; the bulk token1->token0 swap runs through the real UR (on `routeKey`,
-    ///         within the zap's unlock of `key`), and the same-pool reconcile finishes the position.
+    /// @notice Single-token1 budget: the UR route swaps token1 -> token0 on `routeKey` inside the unlock.
     function test_add_singleToken1_viaURRoute() public {
         uint256 amount1In = 10e18;
-        uint128 routeAmountIn = 3e18; // sell 3e18 token1 -> token0 on routeKey via UR; reconcile tops up the rest
+        uint128 routeAmountIn = 3e18; // sell 3e18 token1 -> token0 on routeKey via UR, reconcile tops up the rest
         uint256 c0Before = currency0.balanceOf(address(this));
 
         bytes memory route = _v4SwapRoute(routeKey, false, routeAmountIn, currency1, currency0);
@@ -145,24 +140,19 @@ contract SwapAndAddRouteTest is PosmTestSetup {
         assertGt(liq, 0, "liquidity minted");
         assertGt(a0, 0, "token0 deployed");
         assertGt(a1, 0, "token1 deployed");
-        // no meaningful dust of the swapped-into token (token0) returned to the user
         assertApproxEqAbs(currency0.balanceOf(address(this)), c0Before, 5, "no token0 dust to user");
-        // contract strands nothing
         assertEq(currency0.balanceOf(address(zap)), 0, "zap token0 == 0");
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
 
-        // Proof the UR route executed: routeKey is touched ONLY by the route leg, so its price moving means the
-        // real UR ran a V4_SWAP within the zap's unlock. (A same-pool-only fallback would leave routeKey at 1:1.)
+        // only the route leg touches routeKey, so a price move there proves the UR route executed
         (uint160 routeSpAfter,,,) = manager.getSlot0(routeKey.toId());
         assertTrue(routeSpAfter != routeSpBefore, "UR route did not execute on the route pool");
-        // selling token1 -> token0 (oneForZero) adds token1 / removes token0, so sqrtPrice (~sqrt(token1/token0)) rises
+        // selling token1 adds token1 to the pool, so sqrtPrice rises
         assertGt(routeSpAfter, routeSpBefore, "selling token1 should raise routeKey's sqrtPrice");
     }
 
-    /// @notice Native-input route that consumes only PART of the forwarded value: the route encodes a fixed
-    ///         2-ether input while the zap forwards its whole 10-ether native balance. The unconsumed 8 ether
-    ///         must be reclaimed from UR (UR's balance is permissionlessly sweepable — anything left there is
-    ///         lost) and put back through the same-pool reconcile instead.
+    /// @notice The route spends 2 ether of the 10 ether forwarded. The zap must reclaim the unconsumed
+    ///         8 ether from the sweepable UR balance and redeploy it through the reconcile.
     function test_add_native_partialRouteValue_reclaimedFromUR() public {
         (PoolKey memory nativeKey,) = initPoolAndAddLiquidityETH(
             CurrencyLibrary.ADDRESS_ZERO, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1, 1 ether
@@ -206,9 +196,8 @@ contract SwapAndAddRouteTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "token1 stranded in zap");
     }
 
-    /// @notice Rebalance whose surplus->deficit leg runs through the real UR within the unlock. The new range is
-    ///         entirely ABOVE the current price, so the new position is single-sided token0 (deficit = token0,
-    ///         surplus = token1) -> the bulk token1->token0 swap routes via UR on routeKey, reconcile finishes.
+    /// @notice Rebalance whose surplus -> deficit swap runs through the real UR within the unlock. The new
+    ///         range sits above the current price, so the new position is single-sided token0.
     function test_rebalance_viaURRoute() public {
         // seed a position to rebalance (empty-route single-token1 add)
         ISwapAndAdd.AddParams memory ap = ISwapAndAdd.AddParams({
@@ -258,9 +247,8 @@ contract SwapAndAddRouteTest is PosmTestSetup {
         assertGt(routeSpAfter, routeSpBefore, "UR route did not raise routeKey sqrtPrice");
     }
 
-    /// @notice Compound whose fee-balancing leg runs through the real UR within the unlock: the collected fees
-    ///         are routed token1->token0 on routeKey, the same-pool reconcile finishes, and the SAME tokenId
-    ///         grows in place. Also the only existing-tokenId path exercising the nested UR execute.
+    /// @notice Compound whose fee-balancing swap runs through the real UR within the unlock. The same
+    ///         tokenId grows in place.
     function test_compound_viaURRoute() public {
         ISwapAndAdd.AddParams memory ap = ISwapAndAdd.AddParams({
             poolKey: key,
@@ -277,7 +265,7 @@ contract SwapAndAddRouteTest is PosmTestSetup {
         });
         (uint256 tokenId, uint128 liq0,,) = zap.add(ap);
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
-        // accrue fees on `key`: balanced round-trips so the price returns near 1:1 and both sides collect
+        // accrue fees on `key` with balanced round-trip swaps
         for (uint256 i = 0; i < 5; i++) {
             swap(key, true, -50e18, "");
             swap(key, false, -50e18, "");
@@ -291,7 +279,7 @@ contract SwapAndAddRouteTest is PosmTestSetup {
             hookData: "",
             deadline: block.timestamp + 1
         });
-        // dry-run (the onchain stand-in for quoting the unclaimed fees offchain) to size the route input
+        // dry-run to size the route input
         uint256 snap = vm.snapshotState();
         (,, uint256 a1Base) = zap.compound(p);
         vm.revertToState(snap);

--- a/test/SwapAndAdd.gas.t.sol
+++ b/test/SwapAndAdd.gas.t.sol
@@ -13,10 +13,7 @@ import {MockSwapRoute} from "./mocks/MockSwapRoute.sol";
 import {ISwapAndAdd} from "../src/interfaces/ISwapAndAdd.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 
-/// @notice Gas snapshots for every SwapAndAdd operation under its meaningful execution conditions. The
-///         dimensions that dominate cost: whether the reconcile swap runs (single-sided vs balanced input),
-///         whether a route executes before sizing, native vs ERC-20 currency0, and whether accrued fees are
-///         collected (grow ops). Numbers land in snapshots/SwapAndAddGasTest.json via the CI isolate run.
+/// @notice Gas snapshots for all SwapAndAdd operations. Results go to snapshots/SwapAndAddGasTest.json.
 contract SwapAndAddGasTest is PosmTestSetup {
     using CurrencyLibrary for Currency;
 
@@ -24,7 +21,7 @@ contract SwapAndAddGasTest is PosmTestSetup {
     MockSwapRoute route;
     int24 constant TICK_LOWER = -600;
     int24 constant TICK_UPPER = 600;
-    /// @dev abi.encode(bytes commands, bytes[] inputs) — a non-empty route payload the mock ignores.
+    /// @dev Non-empty route payload. The mock ignores its content.
     bytes constant ROUTE_PAYLOAD = abi.encode(bytes(""), new bytes[](0));
 
     function setUp() public {
@@ -36,7 +33,7 @@ contract SwapAndAddGasTest is PosmTestSetup {
         seedMoreLiquidity(key, 1_000e18, 1_000e18);
 
         route = new MockSwapRoute(permit2);
-        // Same artifact-based deployment as SwapAndAdd.t.sol (via_ir=true/500 production build).
+        // Deploy from the compiled artifact to measure the production via_ir build.
         zap = ISwapAndAdd(
             deployCode("SwapAndAdd.sol:SwapAndAdd", abi.encode(manager, permit2, lpm, IUniversalRouter(address(route))))
         );
@@ -99,7 +96,7 @@ contract SwapAndAddGasTest is PosmTestSetup {
         });
     }
 
-    /// @dev Balanced round-trip swaps: both sides of in-range liquidity accrue fees, price returns near 1:1.
+    /// @dev Round-trip swaps accrue fees in both tokens and return the price near 1:1.
     function _generateFees() internal {
         for (uint256 i = 0; i < 5; i++) {
             swap(key, true, -50e18, "");
@@ -107,27 +104,27 @@ contract SwapAndAddGasTest is PosmTestSetup {
         }
     }
 
-    // ───────────────────────────────────────────── add ─────────────────────────────────────────────
+    // --------------------------------------------- add ---------------------------------------------
 
-    /// @dev The full path: fee-aware sizing, flash-take, mint, reconcile swap, trim, sweep.
+    /// @dev Full path with the reconcile swap.
     function test_gas_add_singleSided() public {
         zap.add(_addParams(0, 10e18));
         vm.snapshotGasLastCall("SwapAndAdd_add_singleSided");
     }
 
-    /// @dev Proportional input at 1:1 — the reconcile swap is skipped (wei-scale residue at most).
+    /// @dev Balanced input skips the reconcile swap.
     function test_gas_add_balanced() public {
         zap.add(_addParams(10e18, 10e18));
         vm.snapshotGasLastCall("SwapAndAdd_add_balanced");
     }
 
-    /// @dev Skewed two-sided input: reconcile swap converts only the surplus share.
+    /// @dev Skewed input, so the reconcile swap converts only the surplus share.
     function test_gas_add_mixedRatio() public {
         zap.add(_addParams(3e18, 10e18));
         vm.snapshotGasLastCall("SwapAndAdd_add_mixedRatio");
     }
 
-    /// @dev Native currency0: value forwarding plus POSM's SWEEP refund leg.
+    /// @dev Native currency0 adds value forwarding and the SWEEP refund.
     function test_gas_add_native() public {
         ISwapAndAdd.AddParams memory p = _addParams(1e17, 0);
         p.poolKey = nativeKey;
@@ -135,8 +132,7 @@ contract SwapAndAddGasTest is PosmTestSetup {
         vm.snapshotGasLastCall("SwapAndAdd_add_native");
     }
 
-    /// @dev Route-first: the mock converts half the token1 input to token0 at mid before sizing, so the
-    ///      reconcile only closes the residual — measures the route plumbing on top of a near-balanced add.
+    /// @dev Measures the route plumbing on top of a near-balanced add.
     function test_gas_add_routed() public {
         route.config(Currency.unwrap(currency1), Currency.unwrap(currency0), FixedPoint96.Q96, 10000, 5e18, false);
         ISwapAndAdd.AddParams memory p = _addParams(0, 10e18);
@@ -145,16 +141,16 @@ contract SwapAndAddGasTest is PosmTestSetup {
         vm.snapshotGasLastCall("SwapAndAdd_add_routed");
     }
 
-    // ─────────────────────────────────────── increase / compound ───────────────────────────────────────
+    // --------------------------------------- increase / compound ---------------------------------------
 
-    /// @dev Warm position, no accrued fees: the fee-collect poke returns nothing.
+    /// @dev No accrued fees, so the collect step returns nothing.
     function test_gas_increase_noFees() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         zap.increase(_increaseParams(tokenId, 0, 10e18));
         vm.snapshotGasLastCall("SwapAndAdd_increase_noFees");
     }
 
-    /// @dev Accrued fees join the pulled budget: collect credits both tokens before sizing.
+    /// @dev Accrued fees join the pulled budget.
     function test_gas_increase_withAccruedFees() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         _generateFees();
@@ -162,7 +158,7 @@ contract SwapAndAddGasTest is PosmTestSetup {
         vm.snapshotGasLastCall("SwapAndAdd_increase_withAccruedFees");
     }
 
-    /// @dev Pure fee reinvestment: zero pulled budget, collected fees are the whole deploy.
+    /// @dev Collected fees fund the whole deploy.
     function test_gas_compound() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         _generateFees();
@@ -179,9 +175,9 @@ contract SwapAndAddGasTest is PosmTestSetup {
         vm.snapshotGasLastCall("SwapAndAdd_compound");
     }
 
-    // ───────────────────────────────────────────── rebalance ─────────────────────────────────────────────
+    // --------------------------------------------- rebalance ---------------------------------------------
 
-    /// @dev Burn old range, remint into a wider one: two POSM unlocks plus the full add path.
+    /// @dev Burns the old position and mints into a wider range.
     function test_gas_rebalance() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         zap.rebalance(

--- a/test/SwapAndAdd.t.sol
+++ b/test/SwapAndAdd.t.sol
@@ -32,11 +32,8 @@ import {MockDynamicFeeHook} from "./mocks/MockDynamicFeeHook.sol";
 import {ISwapAndAdd} from "../src/interfaces/ISwapAndAdd.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 
-/// @notice SwapAndAdd tests (route-first + fee-aware). The empty-route cases exercise the same-pool path
-///         (fee-aware sizing, flash-take, mint-to-contract, same-pool reconcile, trim, dust sweep, post-unlock
-///         NFT transfer); the routed cases drive a MockSwapRoute through the route-before-mint path, covering
-///         under/over-conversion (bidirectional reconcile), better-than-mid capture, and cheaper-than-pool-fee
-///         routes. End-to-end integration against the REAL Universal Router lives in test-integration/.
+/// @notice SwapAndAdd tests. Empty-route cases exercise the same-pool path, routed cases drive a
+///         MockSwapRoute. End-to-end tests against the real Universal Router live in test-integration/.
 contract SwapAndAddTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -45,7 +42,7 @@ contract SwapAndAddTest is PosmTestSetup {
     MockSwapRoute route;
     int24 constant TICK_LOWER = -600;
     int24 constant TICK_UPPER = 600;
-    /// @dev abi.encode(bytes commands, bytes[] inputs) — a non-empty route payload the mock ignores.
+    /// @dev A non-empty route payload. The mock ignores its content.
     bytes constant ROUTE_PAYLOAD = abi.encode(bytes(""), new bytes[](0));
 
     function setUp() public {
@@ -57,14 +54,11 @@ contract SwapAndAddTest is PosmTestSetup {
         seedMoreLiquidity(key, 1_000e18, 1_000e18);
 
         route = new MockSwapRoute(permit2);
-        // Deploy SwapAndAdd from its precompiled (via_ir=true/500) artifact rather than `new SwapAndAdd(...)`,
-        // so its source is never pulled into this via_ir=false test unit — mirrors how PosmTestSetup deploys
-        // PositionManager via vm.getCode. This lets SwapAndAdd be pinned to the posm profile for production
-        // (fits the 24576 size limit) without a settings conflict against the test build.
+        // Deploy from the precompiled via_ir artifact, so the via_ir=false test build never compiles the source.
         zap = ISwapAndAdd(
             deployCode("SwapAndAdd.sol:SwapAndAdd", abi.encode(manager, permit2, lpm, IUniversalRouter(address(route))))
         );
-        // fund the mock route's off-venue inventory so it can deliver the deficit token.
+        // The mock route needs off-venue inventory to deliver the deficit token.
         MockERC20(Currency.unwrap(currency0)).mint(address(route), 1_000_000e18);
         MockERC20(Currency.unwrap(currency1)).mint(address(route), 1_000_000e18);
 
@@ -72,7 +66,7 @@ contract SwapAndAddTest is PosmTestSetup {
         _approveZap(currency0);
         _approveZap(currency1);
 
-        // native pool (currency0 == native ETH) with depth for the native add test.
+        // Native pool (currency0 == native ETH) with depth for the native add tests.
         vm.deal(address(this), 1_000 ether);
         (nativeKey,) = initPoolAndAddLiquidityETH(
             CurrencyLibrary.ADDRESS_ZERO, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1, 1 ether
@@ -115,9 +109,8 @@ contract SwapAndAddTest is PosmTestSetup {
         assertGt(liq, 0, "liquidity minted");
         assertGt(a0, 0, "token0 deployed");
         assertGt(a1, 0, "token1 deployed");
-        // dust lands in the input token (token1); the swapped-into token0 returns ~nothing.
+        // Dust lands in the input token (token1). The swapped-into token0 returns almost nothing.
         assertApproxEqAbs(currency0.balanceOf(address(this)), c0Before, 5, "no token0 dust to user");
-        // contract holds nothing
         assertEq(currency0.balanceOf(address(zap)), 0, "zap token0 == 0");
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
@@ -130,7 +123,7 @@ contract SwapAndAddTest is PosmTestSetup {
 
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "user owns NFT");
         assertGt(liq, 0, "liquidity minted");
-        // dust lands in the input token (token0); the swapped-into token1 returns ~nothing.
+        // Dust lands in the input token (token0). The swapped-into token1 returns almost nothing.
         assertApproxEqAbs(currency1.balanceOf(address(this)), c1Before, 5, "no token1 dust to user");
         assertEq(currency0.balanceOf(address(zap)), 0, "zap token0 == 0");
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
@@ -144,7 +137,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev All output-producing operations reject this contract as recipient, preserving no-funds-at-rest.
+    /// @dev Every entrypoint rejects the zap itself as recipient, which keeps no funds at rest.
     function test_revertsWhenRecipientIsZap() public {
         ISwapAndAdd.AddParams memory addParams = _addParams(0, 10e18);
         addParams.recipient = address(zap);
@@ -169,9 +162,7 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.compound(compoundParams);
     }
 
-    /// @dev The zero address is rejected up front on every entrypoint: for add/rebalance the NFT hand-off
-    ///      would revert late anyway, and for increase/compound a zero recipient would silently BURN swept
-    ///      leftovers (dust, and — with routeFunding — potentially the whole unconsumed funding input).
+    /// @dev Every entrypoint rejects the zero address up front, so no sweep can silently burn leftovers.
     function test_revertsWhenRecipientIsZero() public {
         ISwapAndAdd.AddParams memory addParams = _addParams(0, 10e18);
         addParams.recipient = address(0);
@@ -196,8 +187,7 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.compound(compoundParams);
     }
 
-    /// @dev receive() accepts native only from the PoolManager, POSM and the UR; any other sender is rejected
-    ///      so stray transfers cannot be swept to the next caller.
+    /// @dev receive() accepts native only from known senders, so a stray transfer cannot join a sweep.
     function test_receive_rejectsUnknownSender() public {
         (bool ok,) = address(zap).call{value: 1 ether}("");
         assertFalse(ok, "direct native transfer must revert");
@@ -207,7 +197,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertTrue(okPm, "PoolManager may send native");
     }
 
-    // ─────────────────────────── increase (top up an existing position) ───────────────────────────
+    // increase (grow an existing position)
 
     function _increaseParams(uint256 tokenId, uint256 amount0In, uint256 amount1In)
         internal
@@ -227,8 +217,7 @@ contract SwapAndAddTest is PosmTestSetup {
         });
     }
 
-    /// @dev Increase tops up the SAME tokenId in place: liquidity grows, no new NFT, owner unchanged.
-    ///      POSM gates INCREASE_LIQUIDITY on the locker (zap) being approved, so the owner approves it first.
+    /// @dev Increase grows the same tokenId in place, no new NFT.
     function test_increase_growsSamePosition() public {
         (uint256 tokenId, uint128 liq0,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -280,8 +269,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(address(zap).balance, 0, "zap eth == 0");
     }
 
-    /// @dev Empties a position via POSM directly (decrease to 0, NFT kept) — the state a keeper uses to
-    ///      preserve the tokenId (and its subscribers) between exits.
+    /// @dev Decreases a position to 0 via POSM and keeps the NFT.
     function _emptyPosition(uint256 tokenId) internal {
         bytes memory actions = abi.encodePacked(uint8(Actions.DECREASE_LIQUIDITY), uint8(Actions.TAKE_PAIR));
         bytes[] memory params = new bytes[](2);
@@ -291,9 +279,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(lpm.getPositionLiquidity(tokenId), 0, "position emptied");
     }
 
-    /// @dev A position decreased to 0 liquidity (NFT alive) is refillable: the fee-collect poke is skipped
-    ///      (v4 rejects 0-liquidity pokes, and an emptied position holds no uncollected fees) and the
-    ///      increase recreates the position — the zap's only path back into an existing tokenId.
+    /// @dev An emptied position (0 liquidity, NFT alive) is refillable through increase.
     function test_increase_worksOnEmptiedPosition() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -305,8 +291,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(lpm.getPositionLiquidity(tokenId), added, "position liquidity equals added");
     }
 
-    /// @dev Compound on an emptied position surfaces the zap's own NoFeesToCompound instead of v4's
-    ///      opaque CannotUpdateEmptyPosition from the fee-collect poke.
+    /// @dev Compound on an emptied position surfaces NoFeesToCompound, not an opaque v4 error.
     function test_compound_emptiedPosition_revertsNoFees() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -320,7 +305,7 @@ contract SwapAndAddTest is PosmTestSetup {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
         ISwapAndAdd.IncreaseParams memory p = _increaseParams(tokenId, 0, 10e18);
-        p.minLiquidityAdded = type(uint128).max; // impossible floor on the liquidity added
+        p.minLiquidityAdded = type(uint128).max; // impossible floor
         vm.expectRevert(); // InsufficientLiquidity
         zap.increase(p);
     }
@@ -342,7 +327,7 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.increase(_increaseParams(tokenId, 0, 1e18));
     }
 
-    /// @dev Compound is an increase with a zero pulled budget — both run the same path and reinvest the fees.
+    /// @dev A zero-budget increase equals a compound.
     function test_increase_zeroBudget_equalsCompound() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -357,8 +342,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(viaIncrease, viaCompound, "increase(0,0) == compound");
     }
 
-    /// @dev The fee collect precedes the deploy: an increase consumes the position's accrued fees entirely
-    ///      (nothing left for a follow-up compound) and the position grows by exactly the returned liquidity.
+    /// @dev An increase collects and reinvests the position's accrued fees.
     function test_increase_collectsAndReinvestsFees() public {
         (uint256 tokenId, uint128 liq0,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -368,12 +352,12 @@ contract SwapAndAddTest is PosmTestSetup {
 
         assertGt(added, 0, "budget + fees deployed");
         assertEq(lpm.getPositionLiquidity(tokenId), liq0 + added, "position grew by exactly the added liquidity");
-        // the fees were consumed by the increase: an immediate compound finds nothing to reinvest
+        // The increase consumed the fees, so an immediate compound finds nothing to reinvest.
         vm.expectRevert(ISwapAndAdd.NoFeesToCompound.selector);
         zap.compound(_compoundParams(tokenId, 0));
     }
 
-    /// @dev Grow-in-place ops with nothing to deploy (no budget, no fees) revert instead of no-opping.
+    /// @dev An increase with nothing to deploy reverts instead of a silent no-op.
     function test_increase_revertsWhenNothingToDeploy() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -381,7 +365,7 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.increase(_increaseParams(tokenId, 0, 0));
     }
 
-    /// @dev Operator-called increase: all output (swept dust) is forced to the owner, like compound/rebalance.
+    /// @dev An operator-called increase forces all swept dust to the owner.
     function test_increase_operatorCannotRedirectDust() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -394,7 +378,7 @@ contract SwapAndAddTest is PosmTestSetup {
         MockERC20(Currency.unwrap(currency1)).approve(address(permit2), type(uint256).max);
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
         ISwapAndAdd.IncreaseParams memory p = _increaseParams(tokenId, 0, 5e18);
-        p.recipient = operator; // attempt to redirect the dust to itself
+        p.recipient = operator; // operator tries to redirect the dust
         zap.increase(p);
         vm.stopPrank();
 
@@ -402,9 +386,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(operator), 0, "operator got no token1 dust");
     }
 
-    /// @notice Option C deploys the *actual* max the budget supports, so returned dust is tiny (the genuine
-    ///         slippage shortfall). Dust is not re-denominated: the dominant share sits in the surplus (here:
-    ///         input) token and the deficit side returns at most a few wei of trim round-up overshoot.
+    /// @notice Returned dust is tiny, only the genuine slippage shortfall in the input token.
     function test_add_lowDust() public {
         uint256 amountIn = 10e18;
         uint256 c0Before = currency0.balanceOf(address(this));
@@ -412,18 +394,16 @@ contract SwapAndAddTest is PosmTestSetup {
 
         zap.add(_addParams(0, amountIn));
 
-        // net token1 spent = pulled budget - swept dust. dust returned should be a small fraction of the budget.
+        // net token1 spent = pulled budget - swept dust
         uint256 dust1 = currency1.balanceOf(address(this)) + amountIn - c1Before;
-        // measured ~15 bps of budget here (0.3% fee pool, ~half the budget swapped) — the genuine slippage shortfall.
+        // Measured near 15 bps of budget here, so the 2% bound has headroom.
         assertLt(dust1, amountIn / 50, "token1 dust < 2% of budget");
         assertApproxEqAbs(currency0.balanceOf(address(this)), c0Before, 5, "no token0 dust");
         assertEq(currency0.balanceOf(address(zap)), 0, "zap token0 == 0");
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev a budget too small to fund even one unit of liquidity in the requested range: a zero-sized MINT
-    ///      can never produce a position (v4 rejects empty-position updates), so the zap surfaces its own
-    ///      floor error instead of the pool's opaque CannotUpdateEmptyPosition — regardless of the floor.
+    /// @dev A budget too small for one unit of liquidity surfaces InsufficientLiquidity, not an opaque v4 error.
     function test_add_zeroSizedMint_revertsInsufficientLiquidity() public {
         ISwapAndAdd.AddParams memory p = _addParams(-887_220, 887_220, 0, 1); // 1 wei into (nearly) full range
         vm.expectRevert(abi.encodeWithSelector(ISwapAndAdd.InsufficientLiquidity.selector, 0, 0));
@@ -461,7 +441,7 @@ contract SwapAndAddTest is PosmTestSetup {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
 
-        // (0, 0) deltas -> full move: burn the whole position, redeploy everything, add/return nothing.
+        // (0, 0) deltas mean a full move, burn the whole position and redeploy everything
         (uint256 newTokenId, uint128 newLiq,,) = zap.rebalance(_rebalanceParams(tokenId, 0, 0));
 
         assertEq(IERC721(address(lpm)).ownerOf(newTokenId), address(this), "user owns new NFT");
@@ -471,8 +451,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Negative delta (cash-out): the old position is burned IN FULL, a chosen amount of token1 is returned
-    ///      to the recipient's wallet, and only the remainder is redeployed -> less liquidity than a full move.
+    /// @dev A negative delta returns token1 to the recipient and redeploys only the remainder.
     function test_rebalance_negativeDelta_cashOut() public {
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
         (uint256 idFull,,,) = zap.add(_addParams(0, 10e18));
@@ -493,8 +472,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Positive delta (rebalance + add): pull MORE token1 from the wallet on top of the withdrawn holdings,
-    ///      so the new position is LARGER than a plain full redeploy of the same burned position.
+    /// @dev A positive delta pulls more token1 from the wallet, so the new position is larger.
     function test_rebalance_positiveDelta_addsMore() public {
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
         (uint256 idFull,,,) = zap.add(_addParams(0, 10e18));
@@ -509,7 +487,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Mixed signs in one tx: pull more token0 from the wallet while returning some token1 to it.
+    /// @dev Mixed signs pull more token0 and return some token1 in one call.
     function test_rebalance_mixedSigns() public {
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
         (uint256 tokenId,,,) = zap.add(_addParams(3e18, 10e18)); // two-sided position
@@ -529,7 +507,7 @@ contract SwapAndAddTest is PosmTestSetup {
     function test_rebalance_revertsOnOverWithdrawal() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
-        // try to return far more token1 than the burned position holds -> clamp revert.
+        // request far more token1 than the burned position holds
         vm.expectPartialRevert(ISwapAndAdd.ReturnExceedsWithdrawn.selector);
         zap.rebalance(_rebalanceParams(tokenId, 0, -100e18));
     }
@@ -556,15 +534,13 @@ contract SwapAndAddTest is PosmTestSetup {
 
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "user owns NFT");
         assertGt(liq, 0, "liquidity minted");
-        // dust lands in the input token (native); the swapped-into currency1 returns ~nothing.
+        // Dust lands in the input token (native). The swapped-into currency1 returns almost nothing.
         assertApproxEqAbs(currency1.balanceOf(address(this)), c1Before, 5, "no token1 dust to user");
-        // contract strands nothing
         assertEq(address(zap).balance, 0, "zap eth == 0");
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Regression: a range entirely BELOW spot needs zero token0, so on a native pool the mint must
-    ///      forward zero value — an unheld extra wei (the former rounding buffer) reverted OutOfFunds here.
+    /// @dev Regression: a range below spot needs zero token0, so the native mint must forward zero value.
     function test_add_native_belowRange_singleToken1() public {
         ISwapAndAdd.AddParams memory p = _addParams(0, 5e18);
         p.poolKey = nativeKey;
@@ -579,9 +555,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Regression: Slot0's protocolFee packs TWO directional 12-bit fees; treating the packed value as
-    ///      plain pips made `PIPS_DENOMINATOR - feePips` underflow for any nonzero one-for-zero component,
-    ///      bricking every reconcile-needing operation on the pool. Sizing must use the direction's swap fee.
+    /// @dev Regression: Slot0's protocolFee packs two directional fees. Sizing must use the direction's swap fee.
     function test_add_directionalProtocolFeeSet() public {
         vm.prank(feeController);
         manager.setProtocolFee(key, uint24((250 << 12) | 250)); // 0.025% both directions, packed
@@ -590,14 +564,13 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "user owns NFT");
         assertGt(liq, 0, "liquidity minted with directional protocol fee");
 
-        // and the other surplus direction (token1 surplus -> one-for-zero reconcile)
+        // the other surplus direction
         (, uint128 liq1,,) = zap.add(_addParams(0, 10e18));
         assertGt(liq1, 0, "liquidity minted, token1-surplus direction");
     }
 
-    /// @dev A dynamic `beforeSwap` override is not visible in Slot0 sizing. The real fee is nevertheless applied
-    ///      during reconcile, hookData reaches the hook, trim absorbs the difference, and the final liquidity
-    ///      floor remains authoritative.
+    /// @dev A dynamic fee override is invisible to Slot0 sizing. The trim absorbs the difference and the
+    ///      final liquidity floor still holds.
     function test_add_dynamicFeeOverride_forwardsHookDataAndHonorsFinalFloor() public {
         bytes memory hookData = abi.encode("swap-and-add dynamic hook authorization");
         address hookAddress = address(uint160(Hooks.BEFORE_SWAP_FLAG));
@@ -620,7 +593,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertGt(hook.beforeSwapCalls(), 0, "reconcile forwarded hookData to beforeSwap");
         vm.revertToState(baselineSnapshot);
 
-        hook.setFee(100_000); // 10% actual fee; Slot0 remains at its stored 0 fee
+        hook.setFee(100_000); // 10% actual fee. Slot0 keeps its stored 0 fee.
         uint256 highFeeSnapshot = vm.snapshotState();
         (, uint128 highFeeLiquidity,,) = zap.add(p);
         assertLt(highFeeLiquidity, zeroFeeLiquidity, "override fee caused a larger trim");
@@ -634,9 +607,7 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.add(p);
     }
 
-    /// @dev Returns-delta hooks break settlement conservation and are rejected upfront with a typed error —
-    ///      the boundary is enforced in code, not just documented. One case per permission flag, each paired
-    ///      with the base flag v4 requires alongside it.
+    /// @dev Returns-delta hooks break settlement conservation, so the zap rejects them with a typed error.
     function test_add_returnsDeltaHook_revertsUnsupported() public {
         uint160[4] memory flagged = [
             Hooks.BEFORE_SWAP_FLAG | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG,
@@ -651,8 +622,7 @@ contract SwapAndAddTest is PosmTestSetup {
             zap.add(p);
         }
 
-        // Negative control: a hook WITHOUT returns-delta permissions passes the gate — the same call
-        // proceeds into the flow and fails deeper on the (uninitialized) pool instead.
+        // Negative control: a hook without returns-delta flags passes the gate and fails deeper.
         p.poolKey.hooks = IHooks(address(uint160(Hooks.BEFORE_SWAP_FLAG)));
         vm.expectRevert(IPoolManager.PoolNotInitialized.selector);
         zap.add(p);
@@ -660,23 +630,21 @@ contract SwapAndAddTest is PosmTestSetup {
 
     function test_rebalance_revertsIfNotAuthorized() public {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
-        // do NOT approve the zap; call from a stranger
+        // stranger, zap not approved
         vm.prank(address(0xBEEF));
         vm.expectRevert();
         zap.rebalance(_rebalanceParams(tokenId, 0, 0));
     }
 
-    /// @dev SECURITY: an approved operator may rebalance the owner's position but must NOT be able to redirect its
-    ///      value to itself. Even when the operator sets `recipient = self`, the new NFT and any cash-out are forced
-    ///      to the position owner — so a standing NFT approval can never be used to steal the position.
+    /// @dev SECURITY: an approved operator cannot redirect the new NFT or the cash-out away from the owner.
     function test_rebalance_operatorCannotRedirectToSelf() public {
         address operator = address(0xBEEF);
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
-        IERC721(address(lpm)).setApprovalForAll(address(zap), true); // zap may burn/redeploy
-        IERC721(address(lpm)).setApprovalForAll(operator, true); // owner trusts operator to MANAGE the position
+        IERC721(address(lpm)).setApprovalForAll(address(zap), true);
+        IERC721(address(lpm)).setApprovalForAll(operator, true);
 
         ISwapAndAdd.RebalanceParams memory p = _rebalanceParams(tokenId, 0, -1e18); // cash out 1 token1
-        p.recipient = operator; // operator tries to send the output to itself
+        p.recipient = operator; // operator tries to redirect the output
 
         uint256 opC1Before = currency1.balanceOf(operator);
         uint256 ownerC1Before = currency1.balanceOf(address(this));
@@ -688,7 +656,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertGe(currency1.balanceOf(address(this)) - ownerC1Before, 1e18, "owner received the cash-out");
     }
 
-    /// @dev Counterpart to the guard test: the owner themselves CAN still direct the output to any address.
+    /// @dev The owner can still direct the output to any address.
     function test_rebalance_ownerMayChooseRecipient() public {
         address dest = address(0xCAFE);
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
@@ -701,10 +669,10 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(IERC721(address(lpm)).ownerOf(newTokenId), dest, "owner may send the new NFT to a chosen recipient");
     }
 
-    // ─────────────────────────── routed (route-first) cases ───────────────────────────
+    // routed (route-first) cases
 
-    /// @dev Config the mock route for a single-token1 budget: it consumes `inputAmount` of token1 (the surplus)
-    ///      and returns token0 at `rateMultBps` vs the 1:1 mid (10000 = mid, <10000 worse, >10000 beats mid).
+    /// @dev Configure the mock route: consume `inputAmount` of token1 and return token0 at `rateMultBps`
+    ///      against the 1:1 mid (10000 = mid).
     function _configRoute(uint256 rateMultBps, uint256 inputAmount) internal {
         route.config(
             Currency.unwrap(currency1), Currency.unwrap(currency0), FixedPoint96.Q96, rateMultBps, inputAmount, false
@@ -716,18 +684,14 @@ contract SwapAndAddTest is PosmTestSetup {
         p.route = ROUTE_PAYLOAD;
     }
 
-    /// @dev The UR SWEEP reclaim triggers on ANY native balance left in the router — not only when this
-    ///      operation pushed value. A route can strand native even on a value-less operation (an ERC20-in /
-    ///      native-out route leg on a non-native pool), and UR balances are permissionlessly sweepable, so
-    ///      the reclaim must fire whenever the router holds native at all; the all-or-nothing SWEEP folds the
-    ///      whole balance (over-push and any pre-existing donation alike) into the caller's budget.
+    /// @dev UR balances are permissionlessly sweepable, so the SWEEP reclaim must fire whenever the router
+    ///      holds native. The whole balance joins the caller's budget.
     function test_add_route_reclaimsAnyUrNative() public {
-        _configRoute(10000, 0); // no-op route: consumes nothing, the mock just sits on its balance
+        _configRoute(10000, 0); // no-op route, consumes nothing
         ISwapAndAdd.AddParams memory p = _routeAdd(10e18);
         p.poolKey = nativeKey;
 
-        // 1) even with NO value pushed (token1-only budget), a native balance in the UR is reclaimed —
-        //    it joins the caller's budget (native is a pool currency here), boosting the deployed liquidity.
+        // 1) No value pushed: a native balance in the UR is still reclaimed into the budget.
         uint256 snap = vm.snapshotState();
         (, uint128 liqBaseNoPush,,) = zap.add(p); // no donation in the UR
         vm.revertToState(snap);
@@ -738,7 +702,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(address(zap).balance, 0, "zap eth == 0");
         assertGt(liqDonatedNoPush, liqBaseNoPush, "reclaimed UR native joined the caller's budget");
 
-        // 2) with native in the budget -> value pushed -> the unconsumed push AND a donation are reclaimed
+        // 2) Value pushed: the unconsumed push and the donation are both reclaimed.
         p.amount0In = 2 ether;
         snap = vm.snapshotState();
         (, uint128 liqBase,,) = zap.add{value: 2 ether}(p);
@@ -751,10 +715,9 @@ contract SwapAndAddTest is PosmTestSetup {
         assertGt(liqDonated, liqBase, "reclaimed donation joined the caller's budget");
     }
 
-    /// @notice Route under-converts (input below the ideal): the same-pool reconcile tops up the deficit in the
-    ///         normal direction (surplus token1 -> deficit token0). Position lands cleanly, contract strands nothing.
+    /// @notice The route under-converts, so the same-pool reconcile fills the remaining deficit.
     function test_add_route_underConverts() public {
-        _configRoute(9970, 3e18); // ~mid-0.3%, under the ~5e18 ideal for a 10e18 single-tok1 budget
+        _configRoute(9970, 3e18); // ~mid-0.3%, under the ~5e18 ideal for a 10e18 single-token1 budget
         (uint256 tokenId, uint128 liq,,) = zap.add(_routeAdd(10e18));
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "user owns NFT");
         assertGt(liq, 0, "liquidity minted");
@@ -762,10 +725,9 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @notice Route over-converts (input above the ideal): the reconcile runs the OTHER direction, selling the
-    ///         over-bought deficit (token0) back to the surplus (token1). Exercises the bidirectional reconcile.
+    /// @notice The route over-converts, so the reconcile sells the excess token0 back to token1.
     function test_add_route_overConverts() public {
-        _configRoute(9970, 7e18); // over the ~5e18 ideal -> ends long token0 -> reconcile sells token0->token1
+        _configRoute(9970, 7e18); // over the ~5e18 ideal, ends long token0
         (uint256 tokenId, uint128 liq,,) = zap.add(_routeAdd(10e18));
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "user owns NFT");
         assertGt(liq, 0, "liquidity minted");
@@ -773,8 +735,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @notice Better-than-mid route: route-first sizes from the (richer) post-route holdings and CAPTURES the
-    ///         upside, deploying MORE liquidity than the same-pool (empty-route) path can.
+    /// @notice A better-than-mid route deploys more liquidity than the same-pool path.
     function test_add_route_betterThanMid_capturesUpside() public {
         uint256 snap = vm.snapshotState();
         (, uint128 samePoolLiq,,) = zap.add(_addParams(0, 10e18)); // same-pool baseline
@@ -785,8 +746,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertGt(routedLiq, samePoolLiq, "better-than-mid route deploys MORE than same-pool");
     }
 
-    /// @notice Cheaper-than-pool-fee route (mid-0.05% vs the 0.30% pool): route-first deploys more and returns
-    ///         less than the same-pool path, because it sizes from the actually-cheap holdings.
+    /// @notice A route cheaper than the pool fee deploys more and returns less than the same-pool path.
     function test_add_route_cheaper_deploysMoreThanSamePool() public {
         uint256 snap = vm.snapshotState();
         uint256 c1Before = currency1.balanceOf(address(this));
@@ -805,11 +765,11 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    // ─────────────────────────── failure / edge cases ───────────────────────────
+    // failure / edge cases
 
     function test_add_revertsAfterDeadline() public {
         ISwapAndAdd.AddParams memory p = _addParams(0, 10e18);
-        vm.warp(p.deadline + 1); // now past the deadline
+        vm.warp(p.deadline + 1);
         vm.expectRevert(abi.encodeWithSelector(ISwapAndAdd.DeadlinePassed.selector, p.deadline));
         zap.add(p);
     }
@@ -837,25 +797,23 @@ contract SwapAndAddTest is PosmTestSetup {
             hookData: "",
             deadline: block.timestamp + 1
         });
-        // msg.value (1e17 - 1) != amount0In (1e17) -> InvalidEthValue
+        // msg.value != amount0In
         vm.expectRevert(ISwapAndAdd.InvalidEthValue.selector);
         zap.add{value: 1e17 - 1}(p);
     }
 
-    /// @notice Reachable-but-violated floor: set minLiquidity one wei above the realized post-trim liquidity, so
-    ///         the trim brings the final position just under the floor -> revert. (Distinct from the impossible
-    ///         type(uint128).max case; this exercises the floor at a realistic boundary.)
+    /// @notice minLiquidity one wei above the realized liquidity makes the floor check revert.
     function test_add_revertsWhenTrimUndercutsFloor() public {
         ISwapAndAdd.AddParams memory p = _addParams(0, 10e18);
         uint256 snap = vm.snapshotState();
         (, uint128 liq,,) = zap.add(p); // measure the realized liquidity
-        vm.revertToState(snap); // restore pre-add state -> the next add is identical
+        vm.revertToState(snap); // identical re-run
         p.minLiquidity = liq + 1;
         vm.expectRevert(abi.encodeWithSelector(ISwapAndAdd.InsufficientLiquidity.selector, liq + 1, liq));
         zap.add(p);
     }
 
-    // ─────────────────────────── native-ETH rebalance (signed deltas) ───────────────────────────
+    // native-ETH rebalance (signed deltas)
 
     function _nativeAdd(uint256 nativeIn) internal returns (uint256 tokenId) {
         ISwapAndAdd.AddParams memory p = _addParams(nativeIn, 0);
@@ -863,8 +821,7 @@ contract SwapAndAddTest is PosmTestSetup {
         (tokenId,,,) = zap.add{value: nativeIn}(p);
     }
 
-    /// @dev Native positive delta: add more native ETH (via msg.value) during a rebalance of a native position;
-    ///      the new position is larger than a plain full redeploy of the same burned holdings.
+    /// @dev A positive native delta adds more ETH via msg.value during a rebalance.
     function test_rebalance_native_positiveDelta_addsMore() public {
         uint256 tokenId = _nativeAdd(5e17); // 0.5 ETH position
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -885,12 +842,12 @@ contract SwapAndAddTest is PosmTestSetup {
     function test_rebalance_native_revertsOnWrongEthValue() public {
         uint256 tokenId = _nativeAdd(5e17);
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
-        // msg.value must equal the positive native delta; send one wei short -> revert.
+        // msg.value one wei short of the positive native delta
         vm.expectRevert(ISwapAndAdd.InvalidEthValue.selector);
         zap.rebalance{value: 1e17 - 1}(_rebalanceParams(tokenId, 1e17, 0));
     }
 
-    // ─────────────────────────── compound (reinvest fees) ───────────────────────────
+    // compound (reinvest fees)
 
     function _compoundParams(uint256 tokenId, uint256 minLiquidityAdded)
         internal
@@ -907,8 +864,7 @@ contract SwapAndAddTest is PosmTestSetup {
         });
     }
 
-    /// @dev Accrue fees to in-range liquidity via balanced round-trip swaps (price returns near 1:1, both sides
-    ///      collect fees).
+    /// @dev Accrue fees on both sides via balanced round-trip swaps.
     function _generateFees() internal {
         for (uint256 i = 0; i < 5; i++) {
             swap(key, true, -50e18, "");
@@ -930,8 +886,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertGt(a0 + a1, 0, "amounts reinvested");
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "NFT still owned by user");
         assertEq(lpm.getPositionLiquidity(tokenId), liq0 + added, "position grew by exactly the added liquidity");
-        // the fees were reinvested, not paid out: anything that reached the wallet is only swept dust, far less
-        // than what was compounded into the position.
+        // Only swept dust reaches the wallet, the fees were reinvested.
         assertLt(currency0.balanceOf(address(this)) - c0Before, a0 + 1, "token0 fees compounded, not paid out");
         assertLt(currency1.balanceOf(address(this)) - c1Before, a1 + 1, "token1 fees compounded, not paid out");
         assertEq(currency0.balanceOf(address(zap)), 0, "zap token0 == 0");
@@ -942,7 +897,7 @@ contract SwapAndAddTest is PosmTestSetup {
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
         _generateFees();
-        vm.expectRevert(); // impossible floor on the added liquidity
+        vm.expectRevert(); // impossible floor
         zap.compound(_compoundParams(tokenId, type(uint128).max));
     }
 
@@ -954,7 +909,7 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.compound(_compoundParams(tokenId, 0));
     }
 
-    /// @dev A position with no accrued fees can't compound. Mint directly (no swap) so it genuinely has zero fees.
+    /// @dev Mint directly with no swaps, so the position genuinely has zero fees.
     function test_compound_revertsWhenNoFees() public {
         uint256 tokenId = lpm.nextTokenId();
         PositionConfig memory cfg = PositionConfig({poolKey: key, tickLower: TICK_LOWER, tickUpper: TICK_UPPER});
@@ -964,8 +919,7 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.compound(_compoundParams(tokenId, 0));
     }
 
-    /// @dev SECURITY: an approved operator may compound the owner's fees, but the NFT never moves and any swept
-    ///      dust is forced to the owner — the operator cannot skim even rounding dust by setting recipient = self.
+    /// @dev SECURITY: an approved operator cannot redirect even the swept dust away from the owner.
     function test_compound_operatorCannotRedirectDust() public {
         address operator = address(0xBEEF);
         (uint256 tokenId,,,) = zap.add(_addParams(0, 10e18));
@@ -974,7 +928,7 @@ contract SwapAndAddTest is PosmTestSetup {
         _generateFees();
 
         ISwapAndAdd.CompoundParams memory p = _compoundParams(tokenId, 0);
-        p.recipient = operator; // operator tries to grab any dust
+        p.recipient = operator; // operator tries to grab the dust
 
         uint256 opC0Before = currency0.balanceOf(operator);
         uint256 opC1Before = currency1.balanceOf(operator);
@@ -986,9 +940,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(operator), opC1Before, "operator got no token1 dust");
     }
 
-    /// @dev Compound may route the collected fees like every other op; the reconcile absorbs whatever the
-    ///      route leaves. The route input is sized from a dry-run — the onchain stand-in for an integrator
-    ///      quoting the position's unclaimed fees offchain.
+    /// @dev Compound may route the collected fees. A dry-run sizes the route input.
     function test_compound_withRoute() public {
         (uint256 tokenId, uint128 liq0,,) = zap.add(_addParams(0, 10e18));
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
@@ -998,7 +950,7 @@ contract SwapAndAddTest is PosmTestSetup {
         (,, uint256 a1Base) = zap.compound(_compoundParams(tokenId, 0));
         vm.revertToState(snap);
 
-        _configRoute(10100, a1Base / 2); // convert half the token1 fees at mid+1%
+        _configRoute(10100, a1Base / 2); // Convert half the token1 fees at mid+1%.
         ISwapAndAdd.CompoundParams memory p = _compoundParams(tokenId, 0);
         p.route = ROUTE_PAYLOAD;
 
@@ -1012,10 +964,9 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    // ─────────────────────────── sizing / reconcile extremes ───────────────────────────
+    // sizing / reconcile extremes
 
-    /// @dev ERC-20 counterpart of the native below-range case: the position needs zero token0, the whole
-    ///      budget-side reconcile happens on token1 alone.
+    /// @dev ERC-20 counterpart of the native below-range case.
     function test_add_belowRange_singleToken1() public {
         ISwapAndAdd.AddParams memory p = _addParams(0, 5e18);
         p.tickLower = -1200;
@@ -1027,9 +978,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Range entirely BELOW spot funded with token0 only: the position is 100% token1, so the ENTIRE
-    ///      deficit is flash-taken and the reconcile sell starts from a price above the range — the trim's
-    ///      min(price, sqrtUpper) clamp is what sizes the decrease correctly there.
+    /// @dev Below-spot range funded with token0 only, so the reconcile sell starts from a price above the range.
     function test_add_belowRange_singleToken0() public {
         ISwapAndAdd.AddParams memory p = _addParams(-1200, -660, 10e18, 0);
         (uint256 tokenId, uint128 liq,,) = zap.add(p);
@@ -1039,10 +988,8 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Narrow range with a one-sided budget larger than the pool's external depth: the reconcile sell
-    ///      pushes the price BELOW the just-minted range, yet the operation still lands (the surplus input is
-    ///      valued at the pre-swap price, so it exhausts at/before the boundary and the trim can always free
-    ///      the deficit side from the just-added liquidity).
+    /// @dev A one-sided budget larger than the pool's external depth pushes the price below the new range,
+    ///      and the operation still lands.
     function test_add_narrowRange_hugeSingleSided() public {
         (uint256 tokenId, uint128 liq,,) = zap.add(_addParams(-60, 60, 1_500e18, 0));
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "user owns NFT");
@@ -1051,8 +998,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Thin pool (1e15 external liquidity vs a 500e18 one-sided budget), narrow range: the reconcile must
-    ///      traverse far more depth than exists outside the just-minted position and still settle cleanly.
+    /// @dev Thin pool, huge one-sided budget: the reconcile traverses more depth than exists outside the position.
     function test_add_thinPool_hugeSingleSided() public {
         PoolKey memory thin = _thinPool();
         ISwapAndAdd.AddParams memory p = _addParams(-60, 60, 500e18, 0);
@@ -1063,9 +1009,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Thin pool with spot exactly AT the range's upper boundary (position = 100% token1) and a token0-only
-    ///      budget: the whole budget is surplus and the whole position is flash-taken deficit — the knife-edge
-    ///      where the reconcile sell must fund the entire mint.
+    /// @dev Spot at the range's upper edge with a token0-only budget: the reconcile sell must fund the whole mint.
     function test_add_thinPool_priceAtUpperEdge_token0Only() public {
         PoolKey memory thin = _thinPool();
         ISwapAndAdd.AddParams memory p = _addParams(-600, 0, 200e18, 0); // tickUpper == current tick
@@ -1076,8 +1020,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Any two-sided budget must land: hunts the both-sides-short knife-edge where round-up makes BOTH
-    ///      optimistic amounts exceed the budget by a wei (both sides flash-taken), and every in-between ratio.
+    /// @dev Any two-sided budget must land, including the both-sides-short round-up knife-edge.
     function testFuzz_add_twoSided(uint256 a0, uint256 a1) public {
         a0 = bound(a0, 1e6, 500e18);
         a1 = bound(a1, 1e6, 500e18);
@@ -1098,7 +1041,7 @@ contract SwapAndAddTest is PosmTestSetup {
         p.tickUpper = tickUpper;
     }
 
-    /// @dev Spin up a native-ETH/token pool with depth for the weird-token `_ensureApproved` regressions.
+    /// @dev Initialize a native-ETH/token pool with depth for the weird-token `_ensureApproved` regressions.
     function _initWeirdTokenPool(address token) internal returns (PoolKey memory k) {
         (k,) = initPoolAndAddLiquidityETH(
             CurrencyLibrary.ADDRESS_ZERO, Currency.wrap(token), IHooks(address(0)), 3000, SQRT_PRICE_1_1, 1 ether
@@ -1110,8 +1053,7 @@ contract SwapAndAddTest is PosmTestSetup {
         );
     }
 
-    /// @dev Regression: `_ensureApproved` must tolerate tokens whose approve returns nothing (USDT-style) —
-    ///      a plain IERC20(returns bool) approve reverts on decode and would brick every pool of that token.
+    /// @dev Regression: `_ensureApproved` must tolerate approve() with no return data (USDT-style).
     function test_add_approveNoReturnToken() public {
         MockERC20ApproveNoReturn usdt = new MockERC20ApproveNoReturn();
         usdt.mint(address(this), 1_000e18);
@@ -1130,14 +1072,12 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(usdt.balanceOf(address(zap)), 0, "zap token == 0");
     }
 
-    /// @dev Regression: a Permit2-native token hardcodes an infinite Permit2 allowance (and reverts approve()
-    ///      toward it). `_ensureApproved` must not read that allowance as proof of its own wiring — the
-    ///      Permit2-internal grants to POSM/UR wouldn't exist — and must skip the redundant ERC20 approve,
-    ///      which here would revert and brick every pool of that token.
+    /// @dev Regression: a Permit2-native token reverts approve() toward Permit2, so `_ensureApproved` must
+    ///      skip that call and still grant the Permit2-internal allowances.
     function test_add_permit2NativeToken() public {
         MockERC20Permit2Native token = new MockERC20Permit2Native(address(permit2));
         token.mint(address(this), 1_000e18);
-        // no token.approve(permit2) — hardcoded; the user only grants the Permit2 allowance to the zap
+        // The token hardcodes the Permit2 allowance, so no token.approve(permit2) call.
         permit2.approve(address(token), address(zap), type(uint160).max, type(uint48).max);
         token.approve(address(modifyLiquidityRouter), type(uint256).max);
         PoolKey memory k = _initWeirdTokenPool(address(token));
@@ -1148,22 +1088,19 @@ contract SwapAndAddTest is PosmTestSetup {
 
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "user owns NFT");
         assertGt(liq, 0, "liquidity minted on permit2-native token pool");
-        // the wiring granted the standing Permit2 allowances despite skipping the ERC20 approve
+        // The wiring granted the Permit2 allowances without the ERC20 approve.
         (uint160 posmAmount,,) = permit2.allowance(address(zap), address(token), address(lpm));
         (uint160 urAmount,,) = permit2.allowance(address(zap), address(token), address(route));
         assertEq(posmAmount, type(uint160).max, "POSM permit2 allowance granted");
         assertEq(urAmount, type(uint160).max, "UR permit2 allowance granted");
 
-        // steady state: the wiring is detected from the Permit2 marker, never re-touching the token's approve
+        // Steady state: a second add never touches the token's approve again.
         (, liq,,) = zap.add(p);
         assertGt(liq, 0, "second add on already-wired token");
     }
 
-    /// @dev `_pullBudget` assumes currency1 is never native (native sorts to currency0; PoolManager enforces
-    ///      currency0 < currency1, so no pool with currency1 == 0 can ever be initialized). A key smuggling
-    ///      native into currency1 must revert: the Permit2 pull for "token" address(0) has no allowance
-    ///      (AllowanceExpired) — and even a caller who pre-approves address(0), turning Permit2's pull on the
-    ///      codeless address into a silent no-op, dies at the uninitialized pool, unwinding atomically.
+    /// @dev No pool with native as currency1 can exist. A key that smuggles it in must revert and
+    ///      unwind atomically.
     function test_add_revertsOnNativeAsCurrency1() public {
         ISwapAndAdd.AddParams memory p = _addParams(0, 5e18);
         p.poolKey = PoolKey({
@@ -1182,9 +1119,8 @@ contract SwapAndAddTest is PosmTestSetup {
         zap.add(p);
     }
 
-    /// @dev Regression: `_ensureApproved`'s self-heal — if the ERC20 allowance to Permit2 ever degrades below
-    ///      the uint160.max headroom threshold, the token is re-approved (zero-first, so approve-race tokens
-    ///      don't revert the heal) instead of the operation bricking on the Permit2 pull.
+    /// @dev Regression: a degraded ERC20 allowance to Permit2 is re-approved zero-first, so approve-race
+    ///      tokens do not revert the heal.
     function test_add_reapprovesDegradedAllowance() public {
         MockERC20ApproveRace token = new MockERC20ApproveRace();
         token.mint(address(this), 1_000e18);
@@ -1195,11 +1131,10 @@ contract SwapAndAddTest is PosmTestSetup {
 
         ISwapAndAdd.AddParams memory p = _addParams(0, 5e18);
         p.poolKey = k;
-        zap.add(p); // wires the token: allowance(zap -> permit2) = uint256.max
+        zap.add(p); // wires the token to the max allowance
         assertEq(token.allowance(address(zap), address(permit2)), type(uint256).max, "wired to max");
 
-        // degrade the allowance below any possible Permit2 pull — nonzero, so a heal that isn't
-        // zero-first would trip the approve race and revert
+        // Degrade to a nonzero value, so a heal that is not zero-first trips the approve race.
         token.setAllowance(address(zap), address(permit2), 1e18);
 
         (, uint128 liq,,) = zap.add(p);
@@ -1208,10 +1143,8 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(token.allowance(address(zap), address(permit2)), type(uint256).max, "allowance healed to max");
     }
 
-    /// @dev Extreme-tick sizing regressions: narrow range with the price on its lower edge -> single-sided
-    ///      token0, no swap, no fee — the minted liquidity must be the full budget's worth. Pre-fix, the 1e18
-    ///      reference position's sub-wei amounts rounded up (high ticks, ~1% deployed) and the token1-per-token0
-    ///      rate truncated to zero (ticks <~ -665455, revert / budget ignored).
+    /// @dev Extreme-tick regressions: a single-sided token0 range with no swap must deploy the full
+    ///      budget's worth of liquidity.
     function test_add_extremeHighTick_fullDeployment() public {
         _assertFullDeploymentAtTick(800000, 2e13);
     }
@@ -1220,16 +1153,15 @@ contract SwapAndAddTest is PosmTestSetup {
         _assertFullDeploymentAtTick(-700000, 1e30);
     }
 
-    /// @dev In-range two-sided add at price << 1: exercises the inverse-rate (token0 numeraire) valuation of a
-    ///      token1 budget. Deeper ticks are pinned single-sided above — below ~-665k one wei of token1 outweighs
-    ///      any realistic token0 budget, so two-sided adds there are not physically meaningful.
+    /// @dev In-range two-sided add at price << 1 exercises the inverse-rate valuation of the token1 budget.
+    ///      Below tick ~-665k one wei of token1 outweighs any realistic token0 budget.
     function test_add_lowTick_inRange_valuesToken1ViaInverseRate() public {
         int24 tick = -400000;
         PoolKey memory k = _initTickPool(tick);
         uint160 sp = TickMath.getSqrtPriceAtTick(tick);
         uint160 sl = TickMath.getSqrtPriceAtTick(tick - 600);
         uint160 su = TickMath.getSqrtPriceAtTick(tick + 600);
-        // in-ratio budgets for ~1e18 liquidity; the token1 side carries half the value through the inverse rate
+        // in-ratio budgets for ~1e18 liquidity
         uint256 b0 = SqrtPriceMath.getAmount0Delta(sp, su, 1e18, false);
         uint256 b1 = SqrtPriceMath.getAmount1Delta(sl, sp, 1e18, false);
         MockERC20(Currency.unwrap(currency0)).mint(address(this), b0);
@@ -1247,7 +1179,7 @@ contract SwapAndAddTest is PosmTestSetup {
         uint256 b0 = 10 ** bound(exp, 6, 30);
         uint160 spl = TickMath.getSqrtPriceAtTick(tick);
         uint160 spu = TickMath.getSqrtPriceAtTick(tick + 60);
-        // uint256 replica of getLiquidityForAmount0 — the lib itself would SafeCast-revert on oversized combos
+        // uint256 replica of getLiquidityForAmount0, which SafeCast-reverts on oversized combos
         uint256 expected = FullMath.mulDiv(b0, FullMath.mulDiv(spl, spu, FixedPoint96.Q96), spu - spl);
         // meaningful size, under the per-tick liquidity cap for spacing 10
         vm.assume(expected >= 1e6 && expected < 1e33);
@@ -1267,13 +1199,13 @@ contract SwapAndAddTest is PosmTestSetup {
         );
         ISwapAndAdd.AddParams memory p = _addParams(tick, tick + 60, b0, 0);
         p.poolKey = k;
-        p.minLiquidity = uint256(expected) * 999 / 1000; // contract-enforced floor: >= 99.9% of feasible
+        p.minLiquidity = uint256(expected) * 999 / 1000; // floor at 99.9% of feasible
         (, uint128 liq,,) = zap.add(p);
         assertGe(liq, uint128(p.minLiquidity), "full budget deployed at extreme tick");
     }
 
-    /// @dev Land the pool price EXACTLY on `boundaryTick`'s sqrtPrice via a limit-clamped swap, and return the
-    ///      boundary price. Going down (zeroForOne) the pool stores tick = boundary - 1; going up, tick = boundary.
+    /// @dev Land the price exactly on `boundaryTick` via a limit-clamped swap. A zeroForOne swap stores
+    ///      tick = boundary - 1, a oneForZero swap stores tick = boundary.
     function _swapToExactBoundary(int24 boundaryTick, bool zeroForOne) internal returns (uint160 boundary) {
         boundary = TickMath.getSqrtPriceAtTick(boundaryTick);
         swapRouter.swap(
@@ -1284,14 +1216,10 @@ contract SwapAndAddTest is PosmTestSetup {
         );
     }
 
-    /// @dev The pool selects its amounts branch by TICK while the zap selects by SQRTPRICE. The one state where
-    ///      they disagree: price exactly on an initialized boundary after a zeroForOne swap (pool stores
-    ///      tick = boundary - 1, price = sqrtPriceAtTick(boundary)). Minting a range whose UPPER edge is that
-    ///      boundary: the zap's price-branch computes single-sided token1 (amount0 = 0) while the pool's
-    ///      tick-branch computes in-range — the in-range amount0 must degenerate to exactly 0, else POSM pulls
-    ///      token0 the zap never funded and the unlock reverts (CurrencyNotSettled).
+    /// @dev The zap sizes by sqrtPrice while the pool branches by tick. With the price exactly on the range's
+    ///      upper boundary and the tick below it, the pool's in-range amount0 must degenerate to exactly 0.
     function test_add_priceExactlyOnUpperBoundary_tickBelow() public {
-        zap.add(_addParams(1e18, 1e18)); // initialize ticks ±600 so the swap lands ON an initialized boundary
+        zap.add(_addParams(1e18, 1e18)); // initialize ticks ±600 as swap landing boundaries
         uint160 boundary = _swapToExactBoundary(-600, true);
 
         (uint160 sp, int24 tick,,) = manager.getSlot0(key.toId());
@@ -1306,9 +1234,8 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");
     }
 
-    /// @dev Mirror case at a range's LOWER edge: price exactly on the boundary with tick == boundary (oneForZero
-    ///      landing). The zap's price-branch (<=) computes single-sided token0; the pool's tick-branch computes
-    ///      in-range — its amount1 must degenerate to exactly 0.
+    /// @dev Mirror case at the range's lower edge with tick == boundary. The pool's in-range amount1 must
+    ///      degenerate to exactly 0.
     function test_add_priceExactlyOnLowerBoundary_tickAt() public {
         zap.add(_addParams(1e18, 1e18));
         uint160 boundary = _swapToExactBoundary(600, false);
@@ -1317,8 +1244,7 @@ contract SwapAndAddTest is PosmTestSetup {
         assertEq(sp, boundary, "engineered state: price exactly on the 600 boundary");
         assertEq(tick, 600, "engineered state: tick at the boundary");
 
-        // the boundary swap bought ALL token0 out of the PoolManager (every seeded position is 100% token1 at
-        // the boundary); the sizing round-up's wei-level flash-take needs PM-wide token0 reserves to exist.
+        // The boundary swap drained the PoolManager's token0, so seed reserves for the wei-level flash-take.
         modifyLiquidityRouter.modifyLiquidity(
             key, ModifyLiquidityParams({tickLower: 600, tickUpper: 1200, liquidityDelta: 100e18, salt: 0}), ""
         );

--- a/test/SwapAndAddConstructor.t.sol
+++ b/test/SwapAndAddConstructor.t.sol
@@ -11,18 +11,14 @@ interface IZapWiring {
     function universalRouter() external view returns (address);
 }
 
-/// @notice Constructor wiring: every immutable is zero-checked (a mistyped deploy-script env var must kill the
-///         deployment with `ZeroAddress`, not produce a dead zap), and a valid deploy stores all four args.
-///         Deployed via raw `create` on the compiled artifact — `deployCode` swallows creation revert data, so
-///         the specific error could not be asserted through it (and the test profile cannot compile the
-///         contract directly: via_ir-only).
+/// @notice Constructor wiring tests. The constructor zero-checks and stores all four addresses.
 contract SwapAndAddConstructorTest is Test {
     address pm = makeAddr("poolManager");
     address p2 = makeAddr("permit2");
     address posm = makeAddr("positionManager");
     address ur = makeAddr("universalRouter");
 
-    /// @dev external so vm.expectRevert can observe the bubbled creation revert.
+    /// @dev Raw create bubbles the creation revert, which deployCode swallows. External so that vm.expectRevert observes it.
     function deployZap(address _pm, address _p2, address _posm, address _ur) external returns (address deployed) {
         bytes memory initcode =
             abi.encodePacked(vm.getCode("SwapAndAdd.sol:SwapAndAdd"), abi.encode(_pm, _p2, _posm, _ur));

--- a/test/SwapAndAddEvents.t.sol
+++ b/test/SwapAndAddEvents.t.sol
@@ -14,10 +14,7 @@ import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol"
 import {PositionConfig} from "./shared/PositionConfig.sol";
 import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
 
-/// @notice Every operation emits exactly one op-level event whose fields MIRROR its return values, with the
-///         portfolio-relevant keys indexed (recipient, tokenIds) and the caller as data — callers can always
-///         enumerate their own transactions; recipients cannot. Events are checked against the actual returns
-///         via recorded logs, so the pins hold for any pool state.
+/// @notice Each operation emits exactly one event whose fields mirror its return values.
 contract SwapAndAddEventsTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -45,7 +42,7 @@ contract SwapAndAddEventsTest is PosmTestSetup {
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
     }
 
-    // ─────────────────────────────── helpers ───────────────────────────────
+    // ------------------------------- helpers -------------------------------
 
     function _addParams(uint256 a0, uint256 a1) internal view returns (ISwapAndAdd.AddParams memory) {
         return ISwapAndAdd.AddParams({
@@ -63,7 +60,7 @@ contract SwapAndAddEventsTest is PosmTestSetup {
         });
     }
 
-    /// @dev the single log this contract emitted (all other logs come from other addresses).
+    /// @dev Returns the single log that the zap emitted.
     function _zapLog() internal returns (Vm.Log memory) {
         Vm.Log[] memory logs = vm.getRecordedLogs();
         uint256 found = type(uint256).max;
@@ -84,7 +81,7 @@ contract SwapAndAddEventsTest is PosmTestSetup {
         swap(key, false, -int256(1e20), "");
     }
 
-    // ─────────────────────────────── pins ───────────────────────────────
+    // ------------------------------- pins -------------------------------
 
     function test_add_emitsAdded_mirroringReturns() public {
         vm.recordLogs();
@@ -192,7 +189,7 @@ contract SwapAndAddEventsTest is PosmTestSetup {
         assertEq(e1, a1, "amount1 mirrors return");
     }
 
-    /// @dev an operator's event carries the RESOLVED recipient (the owner), not the operator's request.
+    /// @dev For an operator, the event carries the owner as the recipient.
     function test_increase_byOperator_eventCarriesOwnerAsRecipient() public {
         uint256 tokenId = _mintWithFees(address(this));
         address operator = makeAddr("operator");
@@ -213,7 +210,7 @@ contract SwapAndAddEventsTest is PosmTestSetup {
                 route: "",
                 routeFunding: new ISwapAndAdd.TokenAmount[](0),
                 minLiquidityAdded: 1,
-                recipient: operator, // ignored: resolved to the owner
+                recipient: operator, // ignored, resolved to the owner
                 hookData: "",
                 deadline: block.timestamp + 1
             })

--- a/test/SwapAndAddFarEdge.t.sol
+++ b/test/SwapAndAddFarEdge.t.sol
@@ -15,19 +15,9 @@ import {ISwapAndAdd} from "../src/interfaces/ISwapAndAdd.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
 
-/// @notice FAR-EDGE PROBE — referee for the claimed div-by-zero/underflow in `_trim` when the reconcile sell
-///         lands the price exactly on (or past) the range's far edge with debt still owed.
-///
-///         The counter-argument it tests: the sell's average execution price is the geometric mean of the
-///         traversed sqrt-prices — always worse than spot in the sell direction — while the fee-aware sizing
-///         hands the sell a surplus whose NET value equals the debt at SPOT. Worse-than-spot execution on a
-///         spot-sized budget can never afford the full-range extraction that reaching the far edge requires,
-///         so on hookless pools the post-sell price stays STRICTLY inside the far edge whenever a trim runs.
-///
-///         If that argument is wrong anywhere in the user-reachable input space, this suite goes red with a
-///         raw revert (FullMath's bare require or Panic 0x11) — which is then the regression for the fix.
-///         fee = 0 is included deliberately: no fee cushion, the surplus is exactly spot-sized, the tightest
-///         possible approach to the edge.
+/// @notice The reconcile sell must never land the price on or past the range's far edge with debt still
+///         owed, which raw-reverts in `_trim`. Worse-than-spot execution on a spot-sized surplus keeps
+///         the post-sell price strictly inside the far edge on hookless pools.
 contract SwapAndAddFarEdgeTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -47,9 +37,7 @@ contract SwapAndAddFarEdgeTest is PosmTestSetup {
         MockERC20(Currency.unwrap(currency0)).mint(address(this), 1e40);
         MockERC20(Currency.unwrap(currency1)).mint(address(this), 1e40);
 
-        // deep UNRELATED reserve pool: keeps the flash-take clear of the documented PoolManager-drained
-        // limit (the take needs PM-wide reserves); its fee/spacing never collide with the probe pools and it
-        // is never swapped through, so it cannot affect the probe pool's far-edge dynamics.
+        // deep unrelated reserve pool backs the flash-take. Its key never collides with the probe pools.
         (PoolKey memory rk,) = initPool(currency0, currency1, IHooks(address(0)), 500_000, int24(200), SQRT_PRICE_1_1);
         modifyLiquidityRouter.modifyLiquidity(
             rk,
@@ -58,17 +46,15 @@ contract SwapAndAddFarEdgeTest is PosmTestSetup {
         );
     }
 
-    /// @dev fresh pool at tick 0; the zap's own mint is (near-)all the liquidity — the config where the
-    ///      reconcile sell chews through the position's own range and gets closest to the far edge.
+    /// @dev fresh pool at tick 0. The zap's own mint is (near-)all the liquidity, the config that gets
+    ///      the sell closest to the far edge.
     function _pool(uint24 fee, int24 spacing, uint128 extLiquidity) internal returns (PoolKey memory k) {
         k = PoolKey({
             currency0: currency0, currency1: currency1, fee: fee, tickSpacing: spacing, hooks: IHooks(address(0))
         });
         manager.initialize(k, TickMath.getSqrtPriceAtTick(0));
         if (extLiquidity > 0) {
-            // a dust-thin external band across the whole domain: breaks the scale-invariance between the
-            // surplus and the position (so budget size genuinely varies the landing point) while adding
-            // almost no output to the sell
+            // a dust-thin full-domain band breaks the scale-invariance so budget size varies the landing point
             modifyLiquidityRouter.modifyLiquidity(
                 k,
                 ModifyLiquidityParams({
@@ -99,8 +85,7 @@ contract SwapAndAddFarEdgeTest is PosmTestSetup {
         });
     }
 
-    /// @dev run one add; only clean outcomes are allowed. On success with the price in-range at start, the
-    ///      post-op price must sit STRICTLY inside both edges (the far-edge invariant, observable form).
+    /// @dev run one add. On success the post-op price must sit strictly inside both edges.
     function _probe(PoolKey memory k, int24 tl, int24 tu, uint256 b0, uint256 b1) internal {
         try zap.add(_addP(k, tl, tu, b0, b1)) returns (uint256, uint128 liq, uint256, uint256) {
             assertGt(liq, 0);
@@ -118,10 +103,8 @@ contract SwapAndAddFarEdgeTest is PosmTestSetup {
 
     uint24 private feeNonce;
 
-    /// @dev deterministic grid over the tightest configs: (near-)zero fee = no cushion, thin spacing,
-    ///      single-sided budgets in both directions, with and without the scale-breaking external band.
-    ///      Each cell gets a unique pool via a few pips of fee nonce (immaterial to the tightness argument;
-    ///      the pool key has no salt, so identical fee+spacing would collide).
+    /// @dev grid over the tightest configs (zero fee has no fee cushion). The fee nonce keeps the pool
+    ///      keys unique.
     function test_farEdge_gridSweep_neverRawReverts() public {
         uint24[3] memory fees = [uint24(0), 500, 3000];
         int24[3] memory widths = [int24(60), 600, 6000];
@@ -137,8 +120,7 @@ contract SwapAndAddFarEdgeTest is PosmTestSetup {
             }
         }
 
-        // narrowest legal geometry — tickSpacing 1, ranges 1..5 ticks per side, near-zero fee: the quadratic
-        // impact margin is smallest here, so integer rounding is most of what separates the sell from the edge
+        // narrowest legal geometry (tickSpacing 1, 1..5 ticks per side), where the impact margin is smallest
         int24[3] memory narrow = [int24(1), 2, 5];
         for (uint256 n = 0; n < 3; n++) {
             for (uint256 e = 0; e < 2; e++) {
@@ -150,8 +132,7 @@ contract SwapAndAddFarEdgeTest is PosmTestSetup {
         }
     }
 
-    /// @dev the hunt: fuzzed budgets/widths/fees over the same config family. Any far-edge landing shows up
-    ///      as a raw revert (div-by-zero at equality, Panic 0x11 past it) and fails the outcome-class check.
+    /// @dev fuzzed budgets, widths, and fees. A far-edge landing shows up as a raw revert.
     function testFuzz_farEdge_neverRawReverts(
         uint256 b0,
         uint256 b1,

--- a/test/SwapAndAddFuzz.t.sol
+++ b/test/SwapAndAddFuzz.t.sol
@@ -21,17 +21,12 @@ import {MockSwapRoute} from "./mocks/MockSwapRoute.sol";
 import {ISwapAndAdd} from "../src/interfaces/ISwapAndAdd.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 
-/// @notice Property fuzz over the POOL CONFIGURATION as well as the inputs. The trim under-estimate (fixed
-///         at ddcfd2b) survived the whole suite because every pool sat at price 1 and the one full-domain
-///         fuzz only supplied token0-side budgets — the vulnerable configuration (low price x single-sided
-///         token1) was never generated. This suite's premise: fixed pool configs are what create false
-///         confidence, so NOTHING here is fixed — initial price, fee, tick spacing, depth, range and both
-///         budget sides are all fuzzed, across all four operations.
+/// @notice Full-domain property fuzz. Initial price, fee, tick spacing, depth, range, and both
+///         budget sides are fuzzed across all four operations.
 ///
-///         THE PROPERTY: an operation either succeeds — leaving no funds at rest — or reverts with an error
-///         the design explicitly allows (the whitelist in `_allowed`). v4's CurrencyNotSettled, panics and
-///         wrapped low-level failures are always property violations: the contract's own errors and the
-///         pool's documented limits are the only acceptable ways to fail with a non-zero minLiquidity floor.
+///         Property: an operation either succeeds and leaves no funds at rest, or reverts with an
+///         error in the `_allowed` whitelist. CurrencyNotSettled, panics, and wrapped low-level
+///         failures are always violations.
 contract SwapAndAddFuzzTest is PosmTestSetup {
     using CurrencyLibrary for Currency;
     using StateLibrary for IPoolManager;
@@ -41,10 +36,8 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
 
     bytes4 constant CURRENCY_NOT_SETTLED = 0x5212cba1;
 
-    // budget cap (uint88 ~ 3e26 raw) and price-domain cap (|tick| <= 300_000, price ~ 1e±13): together they
-    // keep the flash-take below the reserve pool's holdings, so the separate, documented PoolManager-drained limit (take
-    // exceeding the PoolManager's global balance) cannot masquerade as a property violation here. The trim
-    // bug's operational region (price ~1e-9, token1 from ~6.4e18) sits comfortably inside these bounds.
+    // budget (uint88) and price (|tick| <= 300_000) caps keep the flash-take below the reserve
+    // pool's holdings, so an out-of-scope PoolManager-drained take cannot fail the property
     int24 constant MAX_CENTRE = 300_000;
 
     function setUp() public {
@@ -66,9 +59,8 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
 
-        // deep reserve pool: keeps the flash-take clear of the PoolManager-drained limit (see above).
-        // Its fee is deliberately ABOVE the fuzzed fee range (0..100_000) so a fuzzed (fee, spacing) pair can
-        // never collide with this key and revert PoolAlreadyInitialized. It is never swapped through.
+        // deep reserve pool backs the flash-take. Its fee sits above the fuzzed fee range so a fuzzed
+        // key cannot collide with it.
         (PoolKey memory rk,) = initPool(currency0, currency1, IHooks(address(0)), 500_000, int24(200), SQRT_PRICE_1_1);
         modifyLiquidityRouter.modifyLiquidity(
             rk,
@@ -81,7 +73,7 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         MockERC20(Currency.unwrap(currency1)).mint(address(route), 1e32);
     }
 
-    // ── fuzzed pool + range construction ────────────────────────────────────────────────────────────────
+    // fuzzed pool + range construction
 
     struct Cfg {
         PoolKey key;
@@ -91,7 +83,7 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
     }
 
     /// @dev a fully fuzzed pool: initial price across ±MAX_CENTRE, fee 0..10%, spacing from the common set,
-    ///      seeded depth 1e18..1e26 — plus a fuzzed range of 1..127 spacings per side around (or off) spot.
+    ///      seeded depth 1e18..1e26, plus a fuzzed range of 1..127 spacings per side around (or off) spot.
     function _cfg(uint24 feeSeed, uint8 spacingSeed, int24 centreSeed, uint128 depthSeed, int8 loMul, int8 hiMul)
         internal
         returns (Cfg memory c)
@@ -116,27 +108,20 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         (c.tl, c.tu) = _range(c.centre, ts, loMul, hiMul);
     }
 
-    /// @dev Build an ordered range from two fuzzed multipliers by SORTING them rather than vm.assume-ing the
-    ///      ordering: a rejection-based version throws away ~half of all inputs (and both ranges together ~75%
-    ///      in the rebalance property), which exhausts the assume budget at high run counts.
+    /// @dev Sort the fuzzed multipliers into an ordered range. Rejection would exhaust the assume budget.
     function _range(int24 centre, int24 ts, int8 aMul, int8 bMul) internal pure returns (int24 lo, int24 hi) {
         (int8 lower, int8 upper) = aMul <= bMul ? (aMul, bMul) : (bMul, aMul);
         lo = centre + int24(int256(lower)) * ts;
         hi = centre + int24(int256(upper)) * ts;
-        if (lo == hi) hi += ts; // degenerate: widen by one spacing instead of rejecting the input
+        if (lo == hi) hi += ts; // widen a degenerate range by one spacing
     }
 
-    /// @dev VALUE-cap the fuzzed budgets: a budget's worth in the OTHER token bounds the flash-take, and
-    ///      the take must stay far below the reserve pool's ~1e30-per-side holdings or the run hits the
-    ///      separate, documented PoolManager-drained limit instead of the properties under test.
-    ///      Clamping (not assume-ing) keeps every run meaningful at extreme prices.
+    /// @dev Value-cap the budgets so the flash-take stays far below the reserve pool's ~1e30 holdings.
     function _capBudgets(int24 centre, uint88 b0Seed, uint88 b1Seed) internal pure returns (uint256 b0, uint256 b1) {
         return _capAt(TickMath.getSqrtPriceAtTick(centre), b0Seed, b1Seed);
     }
 
-    /// @dev The cap MUST be taken at the price that prevails when the operation runs, not at pool init: the
-    ///      flash-take is sized from the live price, so a drifted pool needs re-capping or an otherwise
-    ///      in-bounds budget implies an astronomical take (the drained-reserves noise this whole helper exists to exclude).
+    /// @dev Cap at the live price, not the init price, because the flash-take is sized from the live price.
     function _capBudgetsAtSpot(PoolKey memory k, uint88 b0Seed, uint88 b1Seed)
         internal
         view
@@ -153,8 +138,7 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         b1 = bound(b1Seed, 0, cap1 < type(uint88).max ? cap1 : type(uint88).max);
     }
 
-    /// @dev the errors an operation is DESIGNED to be able to hit on well-formed inputs; everything else —
-    ///      CurrencyNotSettled above all — is a bug.
+    /// @dev errors an operation can hit by design. Anything else, above all CurrencyNotSettled, is a bug.
     function _allowed(bytes4 sel) internal pure returns (bool) {
         return sel == ISwapAndAdd.InsufficientLiquidity.selector // the single slippage/dust gate
             || sel == ISwapAndAdd.NoFeesToCompound.selector // grow ops with nothing to deploy
@@ -192,7 +176,7 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         });
     }
 
-    // ── add: any pool config x any budgets x any range ──────────────────────────────────────────────────
+    // add: any pool config x any budgets x any range
 
     function testFuzz_add_anyPoolConfig(
         uint24 feeSeed,
@@ -218,7 +202,7 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         _noFundsAtRest(c.key);
     }
 
-    // ── add with a route leg: fuzzed off-venue conversion feeding the fuzzed pool ───────────────────────
+    // add with a route leg: fuzzed off-venue conversion feeding the fuzzed pool
 
     function testFuzz_add_routed_anyPoolConfig(
         uint24 feeSeed,
@@ -234,8 +218,8 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         Cfg memory c = _cfg(feeSeed, spacingSeed, centreSeed, depthSeed, loMul, hiMul);
         (, uint256 a1) = _capBudgets(c.centre, 0, b1);
         vm.assume(a1 > 0);
-        // an off-venue token1 -> token0 conversion at the FUZZED pool's mid, filled 50%..150% of mid, over a
-        // fuzzed slice of the budget (0 = a no-op route; > b1 clamps to the full budget in the mock)
+        // off-venue token1 -> token0 at the pool's mid, filled 50%..150% of mid, over a fuzzed slice
+        // of the budget (0 = no-op route, > b1 clamps to the full budget)
         uint256 midRateX96 = FullMath_rate(c.centre);
         route.config(
             Currency.unwrap(currency1),
@@ -257,14 +241,14 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         _noFundsAtRest(c.key);
     }
 
-    /// @dev token1-per-token0 mid rate (Q96) at a tick, for the mock's pricing; clamped away from zero.
+    /// @dev token1-per-token0 mid rate (Q96) at a tick, for the mock's pricing. Clamped away from zero.
     function FullMath_rate(int24 centre) internal pure returns (uint256 r) {
         uint160 sp = TickMath.getSqrtPriceAtTick(centre);
         r = (uint256(sp) * uint256(sp)) >> 96;
         if (r == 0) r = 1;
     }
 
-    // ── grow-in-place: mint, drift the price, then increase / compound on the fuzzed pool ───────────────
+    // grow-in-place: mint, drift the price, then increase / compound on the fuzzed pool
 
     function testFuzz_increase_afterDrift(
         uint24 feeSeed,
@@ -291,14 +275,13 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
             return; // nothing minted, nothing to grow
         }
 
-        // fuzzed price drift (either direction, bounded so the exact-input swap itself is well-formed);
-        // fee accrual on the position rides along for free.
+        // fuzzed price drift in either direction, which also accrues fees on the position
         if (drift != 0) {
             int256 d = int256(drift);
             try this.extSwap(c.key, d > 0, d > 0 ? d : -d) {} catch {}
         }
 
-        // cap the increase budgets at the POST-DRIFT price — that is what its flash-take is sized from
+        // cap the increase budgets at the post-drift price
         (uint256 c0i, uint256 c1i) = _capBudgetsAtSpot(c.key, i0, i1);
         vm.assume(c0i + c1i > 0);
 
@@ -376,8 +359,7 @@ contract SwapAndAddFuzzTest is PosmTestSetup {
         _noFundsAtRest(c.key);
     }
 
-    /// @dev external wrapper so a failing drift swap (e.g. pool drained to the bound) is skippable state,
-    ///      not a test failure — the property under test is the zap's behavior, not the drift's.
+    /// @dev external wrapper so a failed drift swap is skipped, not a test failure
     function extSwap(PoolKey memory k, bool zeroForOne, int256 amountIn) external {
         swap(k, zeroForOne, -amountIn, "");
     }

--- a/test/SwapAndAddIncreaseOutOfRange.t.sol
+++ b/test/SwapAndAddIncreaseOutOfRange.t.sol
@@ -17,12 +17,8 @@ import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol"
 import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
 import {MockSwapRoute} from "./mocks/MockSwapRoute.sol";
 
-/// @notice Regression suite for `increase` on OUT-OF-RANGE positions across a sweep of realistic-to-extreme
-///         price drifts. Before the collect-fees-first fix, POSM's accrued-fee credit made `increase` revert
-///         `DeltaNotNegative` unconditionally for any out-of-range position with fees on its empty side. The
-///         fee collect removes that; these tests additionally pin that the collected single-sided fees entering
-///         the budget are valued sanely at spot by `SwapAndAddMath.getLiquidityForAmountsWeighted` (no funds at rest, no operator
-///         redirect, stranger rejected).
+/// @notice `increase` on out-of-range positions across a sweep of price drifts. Pins that fees are
+///         collected first (no `DeltaNotNegative` revert) and that the usual invariants hold.
 contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -38,8 +34,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
         deployMintAndApprove2Currencies();
         deployAndApprovePosm(manager);
         (key,) = initPoolAndAddLiquidity(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);
-        // DEEP wide exogenous liquidity, so a push moves the price a controlled amount instead of
-        // exhausting the book and slamming into MAX_TICK.
+        // deep wide liquidity so a push moves the price a controlled amount
         modifyLiquidityRouter.modifyLiquidity(
             key,
             ModifyLiquidityParams({tickLower: -60_000, tickUpper: 60_000, liquidityDelta: int256(5e21), salt: 0}),
@@ -76,7 +71,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
                 deadline: block.timestamp + 1
             })
         );
-        // churn to accrue fees on BOTH sides
+        // churn to accrue fees on both sides
         for (uint256 i; i < 5; i++) {
             swap(key, true, -20e18, "");
             swap(key, false, -20e18, "");
@@ -99,7 +94,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
         );
     }
 
-    /// @dev Push spot ABOVE tickUpper by a given oneForZero exact-input size, then try the owner's own increase.
+    /// @dev Push spot above tickUpper, then try the owner's increase.
     function _probeAbove(uint256 pushAmount) internal returns (bool ok, int24 tick, bytes memory err) {
         uint256 snap = vm.snapshotState();
         uint256 tokenId = _mintAndAccrue();
@@ -120,7 +115,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
 
     /// @notice Sweep the out-of-range drift from mild to extreme and report where `increase` starts failing.
     function test_increase_outOfRange_driftSweep() public {
-        // sized against the 5e21 deep range: ~2e20 lands just above tickUpper, growing to a far drift
+        // against the 5e21 deep range, ~2e20 lands just above tickUpper
         uint256[7] memory pushes = [uint256(2e20), 3e20, 5e20, 1e21, 3e21, 1e22, 5e22];
         for (uint256 i; i < pushes.length; i++) {
             (bool ok, int24 tick, bytes memory err) = _probeAbove(pushes[i]);
@@ -137,7 +132,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
         }
     }
 
-    /// @notice The headline claim to verify: a MILD, entirely realistic out-of-range drift.
+    /// @notice `increase` works after a mild out-of-range drift.
     function test_increase_outOfRange_mildDrift_works() public {
         uint256 tokenId = _mintAndAccrue();
         swap(key, false, -3e20, "");
@@ -149,7 +144,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
         assertGt(added, 0, "increase must succeed on an out-of-range position after the fix");
     }
 
-    /// @notice Control: the pre-fix in-range DoS (small top-up on a fee-bearing position) is really gone.
+    /// @notice A small in-range top-up on a fee-bearing position works.
     function test_increase_inRange_smallTopUp_works() public {
         uint256 tokenId = _mintAndAccrue();
         uint128 added = _inc(tokenId, 1e12, 1e12);
@@ -157,7 +152,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
         assertGt(added, 0, "small top-up must succeed after the fix");
     }
 
-    /// @notice The zap must hold nothing afterwards (invariant 1) on the fixed increase path.
+    /// @notice The zap holds nothing after an increase.
     function test_increase_noFundsAtRest() public {
         uint256 tokenId = _mintAndAccrue();
         _inc(tokenId, 1e15, 1e15);
@@ -165,7 +160,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "token1 at rest");
     }
 
-    /// @notice An operator's dust must be forced to the owner (invariant 3 now extended to `increase`).
+    /// @notice The zap forces an operator's dust to the owner.
     function test_increase_operatorCannotRedirect() public {
         uint256 tokenId = _mintAndAccrue();
         address operator = makeAddr("operator");
@@ -188,7 +183,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
                 route: "",
                 routeFunding: new ISwapAndAdd.TokenAmount[](0),
                 minLiquidityAdded: 0,
-                recipient: operator, // requested self — must be overridden to the owner
+                recipient: operator, // requested self, must be overridden to the owner
                 hookData: "",
                 deadline: block.timestamp + 1
             })
@@ -198,7 +193,7 @@ contract SwapAndAddIncreaseOutOfRangeTest is PosmTestSetup {
         assertLt(currency0.balanceOf(operator), opBefore0, "operator must not be paid dust");
     }
 
-    /// @notice A stranger must no longer be able to touch the position at all.
+    /// @notice A stranger cannot touch the position.
     function test_increase_strangerRejected() public {
         uint256 tokenId = _mintAndAccrue();
         address stranger = makeAddr("stranger");

--- a/test/SwapAndAddMath.t.sol
+++ b/test/SwapAndAddMath.t.sol
@@ -10,17 +10,14 @@ import {ProtocolFeeLibrary} from "@uniswap/v4-core/src/libraries/ProtocolFeeLibr
 import {LiquidityAmounts} from "../src/libraries/LiquidityAmounts.sol";
 import {SwapAndAddMath} from "../src/libraries/SwapAndAddMath.sol";
 
-/// @notice Focused tests for the pure SwapAndAddMath library. Everything here runs against the library
-///         directly — no pool, no fixture — so the domains are the full sqrt-price space rather than what a
-///         test pool can reach. Behavioral proofs that need a live pool (fee-aware dust tightness, extreme-tick
-///         deployment) stay in SwapAndAddMathFuzz.t.sol; end-to-end trim behavior stays in SwapAndAddTrim.t.sol.
+/// @notice Unit tests for the pure SwapAndAddMath library over the full sqrt-price domain.
+///         Pool-dependent behavior lives in SwapAndAddMathFuzz.t.sol and SwapAndAddTrim.t.sol.
 contract SwapAndAddMathTest is Test {
     uint256 constant PIPS = 1e6;
 
-    // ─────────────────────────── getAmountsForLiquidity: round-up amounts ───────────────────────────
+    // getAmountsForLiquidity: round-up amounts
 
-    /// @dev Branch selection: below range is token0-only, above is token1-only, in-range is both,
-    ///      and unsorted bounds are normalized.
+    /// @dev Below range is token0 only, above is token1 only, in range is both, unsorted bounds normalize.
     function test_getAmountsForLiquidity_branches() public pure {
         uint160 sl = TickMath.getSqrtPriceAtTick(-600);
         uint160 su = TickMath.getSqrtPriceAtTick(600);
@@ -43,10 +40,8 @@ contract SwapAndAddMathTest is Test {
         assertEq(a1s, a1, "unsorted bounds normalized (amount1)");
     }
 
-    /// @dev The round-up amounts sit within one wei above an independent round-down oracle across the full
-    ///      domain — catches branch-boundary mistakes (<= vs <) as well as rounding-direction slips. The
-    ///      oracle is clamp-formulated (token0 spans [max(sp,sa), sb], token1 spans [sa, min(sp,sb)]) rather
-    ///      than an if/else chain, so it does not mirror the implementation's structure.
+    /// @dev The round-up amounts must sit within one wei above a clamp-formulated round-down oracle:
+    ///      token0 spans [max(sp,sa), sb], token1 spans [sa, min(sp,sb)].
     function testFuzz_getAmountsForLiquidity_withinOneWeiAboveRoundDown(
         uint160 spSeed,
         uint160 aSeed,
@@ -69,10 +64,9 @@ contract SwapAndAddMathTest is Test {
         assertLe(up1, down1 + 1, "amount1 rounding differs by more than one wei");
     }
 
-    // ──────────────────── getLiquidityForAmountsWeighted: value-weighted sizing ────────────────────
+    // getLiquidityForAmountsWeighted: value-weighted sizing
 
-    /// @dev Single-sided token1 budget with the range fully below spot: the weighted sizing must agree with
-    ///      v4's direct getLiquidityForAmount1 (the value detour through the numeraire cancels out).
+    /// @dev Range fully below spot with a token1 budget: weighted sizing must match getLiquidityForAmount1.
     function testFuzz_weighted_singleSidedToken1_matchesDirectFormula(
         int24 tlSeed,
         int24 widthSeed,
@@ -90,13 +84,12 @@ contract SwapAndAddMathTest is Test {
         vm.assume(rawFeasible >= 1e6 && rawFeasible < type(uint128).max);
         uint128 feasible = LiquidityAmounts.getLiquidityForAmount1(sl, su, b1);
 
-        // the numeraire conversion rounds down on both the reference and the budget, so the deviation from
-        // the direct formula is a few wei in either direction, relative-bounded by the reference's magnitude
+        // numeraire rounding allows a few wei of deviation in either direction
         uint128 sized = SwapAndAddMath.getLiquidityForAmountsWeighted(sp, sl, su, 0, b1, PIPS, PIPS);
         assertApproxEqAbs(sized, feasible, feasible / 1e6 + 2, "weighted deviates from direct single-sided token1");
     }
 
-    /// @dev Single-sided token0 mirror: range fully above spot vs v4's direct getLiquidityForAmount0.
+    /// @dev Token0 mirror: range fully above spot must match getLiquidityForAmount0.
     function testFuzz_weighted_singleSidedToken0_matchesDirectFormula(
         int24 tlSeed,
         int24 widthSeed,
@@ -119,9 +112,8 @@ contract SwapAndAddMathTest is Test {
         assertApproxEqAbs(sized, feasible, feasible / 1e6 + 2, "weighted deviates from direct single-sided token0");
     }
 
-    /// @dev In-range mediant property: the value-weighted size lies between the two single-token feasibility
-    ///      ratios (b0-only over [sp,su] and b1-only over [sl,sp]). Fails if either side's valuation is
-    ///      mis-weighted — the pure-level counterpart of the behavioral dust fuzz.
+    /// @dev Mediant property: the weighted size lies between the two single-token ratios
+    ///      (b0 over [sp,su], b1 over [sl,sp]).
     function testFuzz_weighted_inRange_liesBetweenSingleTokenRatios(
         int24 tickSeed,
         int24 widthSeed,
@@ -149,7 +141,7 @@ contract SwapAndAddMathTest is Test {
         assertGe(sized + minL / 1e6 + 2, minL, "weighted below the smaller single-token ratio");
     }
 
-    /// @dev Growing either budget never shrinks the sized liquidity.
+    /// @dev A larger budget never shrinks the sized liquidity.
     function testFuzz_weighted_monotonicInBudgets(
         int24 tickSeed,
         int24 widthSeed,
@@ -181,9 +173,9 @@ contract SwapAndAddMathTest is Test {
         assertEq(SwapAndAddMath.getLiquidityForAmountsWeighted(sp, sl, su, 0, 0, PIPS, PIPS), 0);
     }
 
-    // ─────────────────────────── getLiquidityFeeAware: directional discount ───────────────────────────
+    // getLiquidityFeeAware: directional discount
 
-    /// @dev With zero fees the fee-aware entry collapses to the plain weighted sizing exactly.
+    /// @dev With zero fees the fee-aware sizing equals the weighted sizing exactly.
     function testFuzz_feeAware_zeroFee_equalsWeighted(int24 tickSeed, int24 widthSeed, uint256 b0Seed, uint256 b1Seed)
         public
         pure
@@ -203,10 +195,7 @@ contract SwapAndAddMathTest is Test {
         );
     }
 
-    /// @dev The discount only ever shrinks the size: discounting the surplus side lowers the budget's value
-    ///      by a larger fraction than the reference's (the budget is surplus-heavy by definition). Fails if
-    ///      the discount lands on the deficit side instead — a percent-scale error, far above the wei-scale
-    ///      rounding tolerance. Budgets are kept above dust so value-conversion rounding cannot dominate.
+    /// @dev The fee discount never grows the size. Budgets stay above dust so rounding cannot dominate.
     function testFuzz_feeAware_neverExceedsUndiscounted(
         int24 tickSeed,
         int24 widthSeed,
@@ -232,8 +221,8 @@ contract SwapAndAddMathTest is Test {
         assertLe(feeAware, mid + mid / 1e9 + 2, "fee discount increased the sized liquidity");
     }
 
-    /// @dev The discount uses the swap fee of the direction the reconcile will actually trade: token0 surplus
-    ///      sells token0 (zeroForOne fee), token1 surplus sells token1 (oneForZero fee).
+    /// @dev The discount uses the swap fee of the reconcile direction: token0 surplus uses the zeroForOne
+    ///      fee, token1 surplus uses the oneForZero fee.
     function test_feeAware_usesDirectionalProtocolFee() public pure {
         uint160 sp = TickMath.getSqrtPriceAtTick(0);
         uint160 sl = TickMath.getSqrtPriceAtTick(-600);
@@ -259,9 +248,9 @@ contract SwapAndAddMathTest is Test {
         );
     }
 
-    // ──────────────────────────── getLiquidityToFree: the trim inverse ────────────────────────────
+    // getLiquidityToFree: the trim inverse
 
-    /// @dev what v4 actually frees for `dl` (round DOWN, the pool's favour)
+    /// @dev the token0 amount a burn of `dl` frees (v4 rounds down)
     function freed0(uint160 lo, uint160 su, uint128 dl) internal pure returns (uint256) {
         return SqrtPriceMath.getAmount0Delta(lo, su, dl, false);
     }
@@ -270,26 +259,23 @@ contract SwapAndAddMathTest is Test {
         return SqrtPriceMath.getAmount1Delta(sl, hi, dl, false);
     }
 
-    /// @dev Full-domain fuzz: burning the round-up `dl` must free >= amountOut under v4's round-DOWN burn.
-    ///      Passing sp == sl makes the price clamp pass-through so [lo, su] is fuzzed directly.
+    /// @dev A burn of the round-up `dl` must free >= amountOut. sp == sl makes the clamp a pass-through.
     function testFuzz_toFree_token0_neverUnderFrees(uint160 loSeed, uint160 suSeed, uint256 amountSeed) public pure {
         uint160 lo = uint160(bound(loSeed, TickMath.MIN_SQRT_PRICE, TickMath.MAX_SQRT_PRICE - 1));
         uint160 su = uint160(bound(suSeed, uint256(lo) + 1, TickMath.MAX_SQRT_PRICE));
-        // the debt is CORRELATED with the geometry in-contract: it can never exceed what a max-liquidity
-        // position holds in token0 over [lo, su]. (Uncorrelated hugeness makes the inverse's mulDiv overflow
-        // and revert — reachable only in an astronomically boundary-pinned state; see the library note.)
+        // the in-contract debt never exceeds what a max-liquidity position holds over [lo, su]
         uint256 maxDebt = SqrtPriceMath.getAmount0Delta(lo, su, type(uint128).max, false);
-        if (maxDebt == 0) return; // no token0 exists in this sliver of geometry — nothing to invert
+        if (maxDebt == 0) return; // no token0 exists in this geometry
         uint256 amountOut = bound(amountSeed, 1, maxDebt);
 
         uint256 dlUp = SwapAndAddMath.getLiquidityToFree(lo, lo, su, false, amountOut);
-        // the cap path (dlUp >= lopt) is the dust regime, pinned separately; here pin the inverse
+        // the dust regime (cap path) is pinned separately
         if (dlUp > type(uint128).max) return;
 
         assertGe(freed0(lo, su, uint128(dlUp)), amountOut, "round-up inverse must never under-free token0");
     }
 
-    /// @dev Token1 mirror; sp == su makes the clamp pass-through so [sl, hi] is fuzzed directly.
+    /// @dev Token1 mirror. sp == su makes the clamp a pass-through.
     function testFuzz_toFree_token1_neverUnderFrees(uint160 slSeed, uint160 hiSeed, uint128 amountSeed) public pure {
         uint160 sl = uint160(bound(slSeed, TickMath.MIN_SQRT_PRICE, TickMath.MAX_SQRT_PRICE - 1));
         uint160 hi = uint160(bound(hiSeed, uint256(sl) + 1, TickMath.MAX_SQRT_PRICE));
@@ -301,8 +287,7 @@ contract SwapAndAddMathTest is Test {
         assertGe(freed1(sl, hi, uint128(dlUp)), amountOut, "round-up inverse must never under-free token1");
     }
 
-    /// @dev A price outside the range clamps to the boundary: below the range the token0 side spans the full
-    ///      range; above it the token1 side does.
+    /// @dev A price outside the range clamps to the boundary.
     function test_toFree_priceClampsToRangeBoundary() public pure {
         uint160 sl = TickMath.getSqrtPriceAtTick(-600);
         uint160 su = TickMath.getSqrtPriceAtTick(600);
@@ -319,17 +304,14 @@ contract SwapAndAddMathTest is Test {
         );
     }
 
-    /// @dev the PREVIOUS (broken) token0 trim: floor conversion, then +1 liquidity unit. Kept as the
-    ///      historical counter-spec the shipped inverse replaced.
+    /// @dev counter-spec: floor conversion then +1 liquidity unit, which under-frees at scale
     function oldDl0(uint160 lo, uint160 su, uint256 amountOut, uint128 lopt) internal pure returns (uint128 dl) {
         dl = LiquidityAmounts.getLiquidityForAmount0(lo, su, amountOut);
         dl = dl >= lopt ? lopt : dl + 1;
     }
 
-    /// @dev Why the old formula broke at scale: exact replay of a reverting-add trace (post-swap price
-    ///      tick 4, range upper tick 60, ~4.5e26 residual token0 debt). "+1 unit of LIQUIDITY" is not
-    ///      "+1 wei of TOKEN": one liquidity unit is worth `2^96*(su-lo)/(su*lo)` wei of token0, far below
-    ///      one wei for narrow ranges, while the floored conversion's error SCALES with the amount.
+    /// @dev One liquidity unit is worth `2^96*(su-lo)/(su*lo)` wei of token0, far below one wei in a
+    ///      narrow range, so the floor-plus-one inverse under-frees at scale.
     function test_toFree_oldFormula_freesOneWeiTooLittleAtScale() public pure {
         uint160 lo = 79244399350305758162296141626;
         uint160 su = TickMath.getSqrtPriceAtTick(60);
@@ -341,7 +323,6 @@ contract SwapAndAddMathTest is Test {
         uint256 got = freed0(lo, su, dl);
         assertEq(amountOut - got, 1, "the old trim frees EXACTLY one wei less than the debt");
 
-        // one unit of liquidity is worth far less than one wei of token0 here -> "+1" was a no-op economically
         assertEq(freed0(lo, su, 1), 0, "1 unit of liquidity frees 0 wei of token0 in this range");
 
         // the shipped inverse covers it
@@ -350,19 +331,17 @@ contract SwapAndAddMathTest is Test {
         assertGe(freed0(lo, su, uint128(dlNew)), amountOut, "shipped inverse covers the debt");
     }
 
-    /// @dev The dust regime is NOT a formula error: the pool's own mint-up/burn-down rounding keeps the wei,
-    ///      so no inverse — however exact — can free it. (This is what a non-zero minLiquidity floor surfaces
-    ///      as InsufficientLiquidity; see SwapAndAddTrim.t.sol.)
+    /// @dev Dust regime: mint rounds up and burn rounds down, so no inverse can free the toll wei.
+    ///      A non-zero minLiquidity floor surfaces this as InsufficientLiquidity.
     function test_toFree_dustRegime_mintRoundsUpBurnRoundsDownToZero() public pure {
         uint160 sp = TickMath.getSqrtPriceAtTick(0);
         uint160 sl = TickMath.getSqrtPriceAtTick(-10);
         uint128 lopt = 997;
 
-        // the mint pulls 1 wei of token1 (rounded up); burning the SAME liquidity returns 0 (rounded down)
         assertEq(SqrtPriceMath.getAmount1Delta(sl, sp, lopt, true), 1, "MINT requires 1 wei of token1");
         assertEq(SqrtPriceMath.getAmount1Delta(sl, sp, lopt, false), 0, "BURN returns 0 wei of token1");
 
-        // even the exact round-up inverse asks for more liquidity than exists -> the lopt cap must bite
+        // the exact inverse needs more liquidity than exists, so the lopt cap bites
         assertGt(SwapAndAddMath.getLiquidityToFree(sp, sl, sp, true, 1), lopt, "toll wei needs more than was added");
 
         // the same asymmetry on token0: 259 in, 258 out
@@ -370,9 +349,7 @@ contract SwapAndAddMathTest is Test {
         assertEq(SqrtPriceMath.getAmount0Delta(sp, TickMath.getSqrtPriceAtTick(6000), lopt, false), 258);
     }
 
-    /// @dev The shipped inverse never under-frees: widths x amounts x price levels, including the low-price
-    ///      levels where the old formula's error exploded and non-boundary prices where the intermediate
-    ///      truncates. (Price level tick 0 is the blind spot; kept for coverage.)
+    /// @dev Grid sweep: the inverse never under-frees across widths, amounts, and price levels.
     function test_toFree_shippedInverse_neverUnderFrees() public pure {
         int24[5] memory bases = [int24(0), int24(-100_000), int24(-207_240), int24(-400_000), int24(200_000)];
         int24[5] memory widths = [int24(1), int24(2), int24(60), int24(600), int24(6000)];
@@ -383,7 +360,7 @@ contract SwapAndAddMathTest is Test {
                 uint160 lo = TickMath.getSqrtPriceAtTick(bases[b]);
                 uint160 su = TickMath.getSqrtPriceAtTick(bases[b] + widths[w]);
                 uint160 sl = TickMath.getSqrtPriceAtTick(bases[b] - widths[w]);
-                // a non-boundary price inside the range: truncation is maximal off the exact tick prices
+                // a non-boundary price inside the range, where the intermediate truncates
                 uint160 mid = lo + uint160(uint256(keccak256(abi.encode(b, w))) % uint256(su - lo));
                 if (mid <= lo) mid = lo + 1;
 
@@ -414,9 +391,8 @@ contract SwapAndAddMathTest is Test {
         assertGe(freed1(sl, hi, uint128(dl)), a, "token1 inverse under-freed");
     }
 
-    /// @dev Pin for the documented informational limit: with the price within sqrt-units of sqrtUpper and an
-    ///      enormous token0 debt outstanding, the inverse's final mulDiv result exceeds uint256 and reverts —
-    ///      self-inflicted, atomic, transient. Unreachable through the contract without a returns-delta hook.
+    /// @dev Documented limit: a price within sqrt-units of sqrtUpper plus an enormous token0 debt
+    ///      overflows the inverse's final mulDiv and reverts.
     function test_toFree_revertsAtDocumentedFarEdge() public {
         uint160 su = TickMath.MAX_SQRT_PRICE;
         uint160 lo = su - 1;

--- a/test/SwapAndAddMathFuzz.t.sol
+++ b/test/SwapAndAddMathFuzz.t.sol
@@ -15,22 +15,13 @@ import {ISwapAndAdd} from "../src/interfaces/ISwapAndAdd.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
 
-/// @notice Behavioral fuzzed pins for SwapAndAdd math that need a live pool (the pure-math surface is
-///         covered directly in SwapAndAddMath.t.sol against the extracted library):
-///
-///         1. Fee-aware sizing accuracy: the dust returned by an add must stay price-impact-small across
-///            fee tiers and budget splits. This is the one test that FAILS if the fee discount in
-///            getLiquidityFeeAware is broken or removed — every other suite tolerates the resulting
-///            over-mint because the trim claws it back and conservation still holds; only the dust (fee *
-///            swapped amount, clawed back to the recipient) betrays the regression. Verified discriminating
-///            by neutering the discount in src and watching this fail.
-///
-///         2. Extreme-tick full deployment: single-sided budgets must deploy >= 99.9% of feasible liquidity
-///            end-to-end at any tick, exercising both numeraire branches of the sizing through the contract.
+/// @notice Behavioral fuzz pins that need a live pool (pure-math coverage is in SwapAndAddMath.t.sol):
+///         fee-aware sizing keeps the add dust price-impact-small, and single-sided budgets deploy
+///         >= 99.9% of feasible liquidity at any tick.
 contract SwapAndAddMathFuzzTest is PosmTestSetup {
     using CurrencyLibrary for Currency;
 
-    // ─────────────────────── 1. fee-aware sizing accuracy: dust-tightness fuzz ───────────────────────
+    // fee-aware sizing: dust-tightness fuzz
 
     ISwapAndAdd zap;
     address dustRecipient = makeAddr("dustRecipient");
@@ -46,10 +37,8 @@ contract SwapAndAddMathFuzzTest is PosmTestSetup {
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
     }
 
-    /// @dev With the fee discount exact, add's dust is only the reconcile swap's price impact plus rounding —
-    ///      bounded well below 10bps for budgets <= 3e20 against 1e24 pool liquidity. With the discount broken
-    ///      the over-mint is trimmed back and the fee on the swapped amount (up to 10% of ~half the budget)
-    ///      lands in the dust instead, blowing through the bound from ~0.25bps of regression upward.
+    /// @dev With an exact fee discount the dust stays below 10bps for budgets <= 3e20 against 1e24 pool
+    ///      liquidity. A broken discount pushes the swap fee into the dust and breaks the bound.
     function testFuzz_add_feeAware_dustStaysImpactSmall(uint24 feeSeed, uint256 b0Seed, uint256 b1Seed) public {
         uint24 fee = uint24(bound(feeSeed, 5000, 100_000)); // 0.5% .. 10%
         uint256 b0 = bound(b0Seed, 0, 3e20);
@@ -80,23 +69,22 @@ contract SwapAndAddMathFuzzTest is PosmTestSetup {
         );
         assertGt(liq, 0, "position minted");
 
-        // dust = everything the fresh recipient received; valued at the (still ~1) pool price
+        // dust = everything the recipient received, valued at the ~1 pool price
         uint256 dustValue = currency0.balanceOf(dustRecipient) + currency1.balanceOf(dustRecipient);
         uint256 budgetValue = b0 + b1;
         assertLe(dustValue * 10_000, budgetValue * 10, "dust exceeded 10bps: fee-aware sizing is inaccurate");
     }
 
-    // ─────────────────── 2. extreme-tick sizing: token1 mirror of the token0 fuzz ───────────────────
+    // extreme-tick sizing: token1 mirror of the token0 fuzz
 
-    /// @dev single-sided token1 (range fully below spot) must deploy >= 99.9% of the feasible liquidity at any
-    ///      tick — the mirror of testFuzz_add_extremeTick_fullDeployment, exercising the price<1 numeraire
-    ///      branch of getLiquidityForAmountsWeighted with token1 budgets.
+    /// @dev Single-sided token1 (range fully below spot) must deploy >= 99.9% of feasible liquidity at
+    ///      any tick, through the price<1 numeraire branch.
     function testFuzz_add_extremeTick_token1_fullDeployment(int24 tick, uint256 exp) public {
         tick = int24((bound(int256(tick), -799990, 800000) / 10) * 10);
         uint256 b1 = 10 ** bound(exp, 6, 30);
         uint160 spl = TickMath.getSqrtPriceAtTick(tick - 60);
         uint160 spu = TickMath.getSqrtPriceAtTick(tick);
-        // uint256 replica of getLiquidityForAmount1 to pre-filter oversized/degenerate combos
+        // replica of getLiquidityForAmount1 to pre-filter degenerate combos
         uint256 expected = FullMath.mulDiv(b1, FixedPoint96.Q96, spu - spl);
         vm.assume(expected >= 1e6 && expected < 1e33);
 

--- a/test/SwapAndAddMulticall.t.sol
+++ b/test/SwapAndAddMulticall.t.sol
@@ -19,12 +19,8 @@ import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol"
 import {PositionConfig} from "./shared/PositionConfig.sol";
 import {PosmTestSetup} from "./shared/PosmTestSetup.sol";
 
-/// @notice Multicall on the zap (POSM-style `Multicall_v4`): the flagship flow is `[permitBatch, op]` — wire
-///         the caller's Permit2 allowances from a signature and run the op in ONE transaction. The signer
-///         deliberately holds NO standing Permit2 allowance toward the zap in these tests; only the one-time
-///         token->Permit2 approval. Also pins the msg.value discipline under batching: the ops' exact
-///         `msg.value == expected` checks plus balance-funded native spending make the classic multicall
-///         double-spend impossible — a second native op reverts the whole batch.
+/// @notice Multicall on the zap. Covers the `[permitBatch, op]` flow, which sets Permit2 allowances
+///         from a signature and runs the op in one transaction, and msg.value discipline under batching.
 contract SwapAndAddMulticallTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -60,8 +56,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
             deployCode("SwapAndAdd.sol:SwapAndAdd", abi.encode(manager, permit2, lpm, IUniversalRouter(makeAddr("ur"))))
         );
 
-        // the signer holds tokens and the one-time token->Permit2 approvals, but NO Permit2 allowance
-        // naming the zap — the batched permit must supply that from the signature.
+        // the signer has the token->Permit2 approvals but no Permit2 allowance for the zap
         (signer, signerPk) = makeAddrAndKey("signer");
         vm.deal(signer, 10 ether);
         MockERC20(Currency.unwrap(currency0)).mint(signer, 1e30);
@@ -72,11 +67,11 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
         vm.stopPrank();
 
-        // the test contract keeps full allowances for POSM-side setup (minting positions to the signer)
+        // the test contract keeps full allowances for POSM-side setup
         IERC721(address(lpm)).setApprovalForAll(address(zap), true);
     }
 
-    // ─────────────────────────────── helpers ───────────────────────────────
+    // helpers
 
     function _addParams(PoolKey memory k, uint256 a0, uint256 a1) internal view returns (ISwapAndAdd.AddParams memory) {
         return ISwapAndAdd.AddParams({
@@ -94,7 +89,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         });
     }
 
-    /// @dev PermitBatch naming the zap as spender over the given tokens, nonces read live from Permit2.
+    /// @dev PermitBatch naming the zap as spender over the given tokens. Nonces are read live from Permit2.
     function _batch(address[] memory tokens) internal view returns (IAllowanceTransfer.PermitBatch memory b) {
         IAllowanceTransfer.PermitDetails[] memory details = new IAllowanceTransfer.PermitDetails[](tokens.length);
         for (uint256 i = 0; i < tokens.length; i++) {
@@ -132,7 +127,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         return bytes.concat(r, s, bytes1(v));
     }
 
-    /// @dev `[permitBatch(tokens), <opCall>]` — the flagship single-tx approve-and-operate batch.
+    /// @dev Builds the `[permitBatch(tokens), <opCall>]` batch.
     function _permitThen(address[] memory tokens, bytes memory opCall) internal view returns (bytes[] memory calls) {
         IAllowanceTransfer.PermitBatch memory b = _batch(tokens);
         calls = new bytes[](2);
@@ -140,13 +135,13 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         calls[1] = opCall;
     }
 
-    /// @dev Mint a plain POSM position owned by the signer (setup runs as the test contract).
+    /// @dev Mints a plain POSM position owned by the signer.
     function _mintToSigner(PoolKey memory k, uint256 liquidity) internal returns (uint256 tokenId) {
         tokenId = lpm.nextTokenId();
         mint(PositionConfig({poolKey: k, tickLower: -600, tickUpper: 600}), liquidity, signer, "");
     }
 
-    // ─────────────────────────────── happy paths ───────────────────────────────
+    // happy paths
 
     function test_multicall_permitThenAdd_withoutPriorAllowance() public {
         ISwapAndAdd.AddParams memory p = _addParams(key, 1e18, 2e18);
@@ -194,7 +189,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
 
         ISwapAndAdd.RebalanceParams memory p = ISwapAndAdd.RebalanceParams({
             tokenId: tokenId,
-            additional0: int128(1e18), // pulled via the batched permit — the part that needs the allowance
+            additional0: int128(1e18), // pulled via the batched permit
             additional1: 0,
             newTickLower: -1200,
             newTickUpper: 1200,
@@ -219,7 +214,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
 
     function test_multicall_permitThenAddNative_valueBatch() public {
         ISwapAndAdd.AddParams memory p = _addParams(nativeKey, 1e17, 1e17);
-        // only currency1 needs a Permit2 allowance: currency0 is native and arrives as the batch's msg.value
+        // currency0 is native and arrives as msg.value, so only currency1 needs an allowance
         bytes[] memory calls = _permitThen(_oneToken(currency1), abi.encodeCall(ISwapAndAdd.add, (p)));
         uint256 expectedId = lpm.nextTokenId();
 
@@ -232,8 +227,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertEq(address(zap).balance, 0, "no native at rest");
     }
 
-    /// @dev The operator-friendly composition: a zero-value batch of ERC20 ops over multiple positions. Every
-    ///      op asserts msg.value == 0, so all-ERC20 batches compose freely; each op sweeps before returning.
+    /// @dev A zero-value batch of ERC20 ops over multiple positions composes freely.
     function test_multicall_zeroValueBatch_composesOps() public {
         uint256 id1 = _mintToSigner(key, 1e21);
         uint256 id2 = _mintToSigner(key, 1e21);
@@ -281,14 +275,12 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "no token1 at rest after the batch");
     }
 
-    // ─────────────────────────────── msg.value discipline ───────────────────────────────
+    // msg.value discipline
 
-    /// @dev THE classic multicall danger, pinned impossible: two native ops each asserting the same msg.value.
-    ///      Both equality checks pass (delegatecall preserves msg.value), but native spending is BALANCE-
-    ///      funded — the first op consumes and sweeps the value, the second finds an empty balance and the
-    ///      whole batch reverts atomically. No double-spend, no partial execution.
+    /// @dev Two native ops see the same msg.value, but native spending is balance-funded. The first
+    ///      op consumes and sweeps the value, so the second reverts the whole batch. No double-spend.
     function test_multicall_secondNativeOp_cannotDoubleSpend() public {
-        // signer has standing allowances here to isolate the value mechanics from the permit flow
+        // standing allowances isolate the value mechanics from the permit flow
         vm.startPrank(signer);
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
 
@@ -297,14 +289,13 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         calls[0] = abi.encodeCall(ISwapAndAdd.add, (p));
         calls[1] = abi.encodeCall(ISwapAndAdd.add, (p));
 
-        // the second op must fail CLEARLY (the balance guard in _pullBudget), not deep in the deploy
+        // the second op must fail on the balance guard in _pullBudget
         vm.expectRevert(ISwapAndAdd.InvalidEthValue.selector);
         zap.multicall{value: 1e17}(calls);
         vm.stopPrank();
     }
 
-    /// @dev An ERC20-only op asserts msg.value == 0, so it cannot ride in a value-bearing batch at all:
-    ///      msg.value keeps exactly one meaning per batch.
+    /// @dev An ERC20-only op asserts msg.value == 0, so it cannot run in a value-bearing batch.
     function test_multicall_erc20OpInValueBatch_reverts() public {
         vm.startPrank(signer);
         permit2.approve(Currency.unwrap(currency0), address(zap), type(uint160).max, type(uint48).max);
@@ -319,10 +310,10 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         vm.stopPrank();
     }
 
-    // ─────────────────────────────── failure & adversarial paths ───────────────────────────────
+    // failure and adversarial paths
 
-    /// @dev The permit signature is public in the mempool: anyone can submit it first (burning the nonce but
-    ///      SETTING the allowance). The batched permit swallows that inner revert and the op completes.
+    /// @dev A front-run permit burns the nonce but still sets the allowance. The batched permit
+    ///      swallows the inner revert and the op completes.
     function test_multicall_frontRunPermit_stillSucceeds() public {
         ISwapAndAdd.AddParams memory p = _addParams(key, 1e18, 2e18);
         IAllowanceTransfer.PermitBatch memory b = _batch(_bothTokens());
@@ -341,8 +332,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertGt(liquidity, 0, "op completes although the permit nonce was already burned");
     }
 
-    /// @dev A garbage signature is swallowed by the forwarder; with no standing allowance the op's own Permit2
-    ///      pull then reverts (fresh allowance slot -> expiration 0 -> AllowanceExpired), bubbled by multicall.
+    /// @dev The forwarder swallows a garbage signature, so the op's own Permit2 pull reverts AllowanceExpired.
     function test_multicall_invalidSignature_revertsOnPull() public {
         ISwapAndAdd.AddParams memory p = _addParams(key, 1e18, 2e18);
         IAllowanceTransfer.PermitBatch memory b = _batch(_bothTokens());
@@ -357,11 +347,9 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         zap.multicall(calls);
     }
 
-    // ─────────────────────────────── equivalence ───────────────────────────────
+    // equivalence
 
-    /// @dev A batched `[permit, add]` must be observationally identical to granting the allowance and calling
-    ///      `add` directly — same tokenId, same liquidity, same reported amounts (delegatecall preserves
-    ///      msg.sender, so the pull and auth context are the caller's own either way).
+    /// @dev A batched `[permit, add]` must match a direct `add` exactly: same tokenId, liquidity, and amounts.
     function testFuzz_multicall_permitThenAdd_matchesDirectCall(uint256 a0, uint256 a1) public {
         a0 = bound(a0, 0, 1e22);
         a1 = bound(a1, 0, 1e22);
@@ -370,7 +358,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         ISwapAndAdd.AddParams memory p = _addParams(key, a0, a1);
         bytes[] memory calls = _permitThen(_bothTokens(), abi.encodeCall(ISwapAndAdd.add, (p)));
 
-        // direct path: standing allowances + plain entrypoint
+        // direct path
         uint256 snapshot = vm.snapshotState();
         vm.startPrank(signer);
         permit2.approve(Currency.unwrap(currency0), address(zap), type(uint160).max, type(uint48).max);
@@ -379,7 +367,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         vm.stopPrank();
         vm.revertToState(snapshot);
 
-        // batched path: same params through [permitBatch, add]
+        // batched path with the same params
         vm.prank(signer);
         bytes[] memory results = zap.multicall(calls);
         (uint256 wId, uint128 wLiq, uint256 wA0, uint256 wA1) =
@@ -391,7 +379,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertEq(wA1, dA1, "same amount1");
     }
 
-    // ─────────────────────────────── adversarial mixing & matching ───────────────────────────────
+    // adversarial mixing and matching
 
     function _incParams(uint256 tokenId, uint256 a0, uint256 a1)
         internal
@@ -422,26 +410,21 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         });
     }
 
-    /// @dev THE mixing-and-matching theorem, fuzzed: a batch of N calls must be observationally identical to
-    ///      the same N calls as separate transactions — the batch succeeds iff every sequential call succeeds,
-    ///      per-call returndata is byte-identical, and the final state (wallet balances, position liquidity,
-    ///      next tokenId, empty zap) matches. Any state leaking between subcalls, any msg.sender/value
-    ///      confusion, any partial execution would break one of these equalities. Op kinds, order and budgets
-    ///      are all fuzzed; reverting sequences are part of the domain (batch must then revert too).
+    /// @dev A batch of N calls must match the same N calls as separate transactions: same success or
+    ///      revert, byte-identical returndata, and the same final state. Ops and budgets are fuzzed.
     function testFuzz_multicall_batchEquivalentToSequential(
         uint8[3] memory opSeeds,
         uint88[3] memory b0s,
         uint88[3] memory b1s
     ) public {
-        // standing allowances: this fuzz isolates BATCHING mechanics from the permit flow
+        // standing allowances isolate batching mechanics from the permit flow
         vm.startPrank(signer);
         permit2.approve(Currency.unwrap(currency0), address(zap), type(uint160).max, type(uint48).max);
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
         vm.stopPrank();
         uint256 posId = _mintToSigner(key, 1e21);
-        // accrue fees so a first compound/zero-budget-increase has something to deploy; a SECOND one in the
-        // same sequence finds the fees gone and reverts NoFeesToCompound — deliberately in-domain: the batch
-        // must reproduce exactly that failure.
+        // accrue fees so a compound has something to deploy. A second compound in the same
+        // sequence reverts NoFeesToCompound, which is deliberately in-domain.
         swap(key, true, -int256(1e20), "");
         swap(key, false, -int256(1e20), "");
 
@@ -457,7 +440,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
 
         uint256 snapshot = vm.snapshotState();
 
-        // PATH A: the same calldata as three separate transactions
+        // path A: the same calldata as three separate transactions
         bool seqAllOk = true;
         bytes[] memory seqResults = new bytes[](3);
         for (uint256 i = 0; i < 3; i++) {
@@ -481,7 +464,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         }
         vm.revertToState(snapshot);
 
-        // PATH B: the same calldata as one batch
+        // path B: the same calldata as one batch
         vm.prank(signer);
         try zap.multicall(calls) returns (bytes[] memory results) {
             assertTrue(seqAllOk, "batch succeeded although a sequential call failed");
@@ -499,14 +482,13 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         }
     }
 
-    /// @dev Atomicity: a failing later subcall rolls back everything an earlier one did — no minted position,
-    ///      no consumed funds, no partial state.
+    /// @dev A failing later subcall rolls back everything an earlier one did.
     function test_multicall_laterFailureRollsBackEarlierOps() public {
         vm.startPrank(signer);
         permit2.approve(Currency.unwrap(currency0), address(zap), type(uint160).max, type(uint48).max);
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
         vm.stopPrank();
-        // a position the signer is NOT authorized for
+        // a position the signer is not authorized for
         uint256 foreignId = lpm.nextTokenId();
         mint(PositionConfig({poolKey: key, tickLower: -600, tickUpper: 600}), 1e21, makeAddr("someoneElse"), "");
 
@@ -525,10 +507,8 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertEq(lpm.nextTokenId(), nextBefore, "add's mint was not rolled back");
     }
 
-    /// @dev Mixing OTHER PEOPLE's permits into a batch grants nothing: a victim's (mempool-public) permit
-    ///      signature sets the VICTIM's allowance, while every pull in the batch draws from msg.sender — the
-    ///      attacker. With no allowance of their own the attacker's op reverts; with their own allowance it
-    ///      spends only their own funds. Either way the victim's balances are untouchable through the batch.
+    /// @dev A victim's permit mixed into a batch grants nothing: every pull draws from msg.sender,
+    ///      so the funds of the victim stay untouched.
     function test_multicall_victimPermitInBatch_cannotTouchVictimFunds() public {
         IAllowanceTransfer.PermitBatch memory victimPermit = _batch(_bothTokens());
         bytes memory victimSig = _sign(victimPermit, signerPk); // signer plays the victim
@@ -550,12 +530,12 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         calls[0] = abi.encodeCall(IPermit2Forwarder.permitBatch, (signer, victimPermit, victimSig));
         calls[1] = abi.encodeCall(ISwapAndAdd.add, (p));
 
-        // attacker has no allowance of their own: the victim's permit does not stand in for it
+        // the attacker has no allowance of their own
         vm.prank(attacker);
         vm.expectRevert(abi.encodeWithSelector(IAllowanceTransfer.AllowanceExpired.selector, 0));
         zap.multicall(calls);
 
-        // with their own allowance the batch runs — on the attacker's OWN funds exclusively
+        // with their own allowance the batch runs, funded from the attacker's own wallet
         vm.startPrank(attacker);
         permit2.approve(Currency.unwrap(currency0), address(zap), type(uint160).max, type(uint48).max);
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
@@ -568,12 +548,11 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertLt(currency0.balanceOf(attacker), attC0, "the add was funded by the attacker");
     }
 
-    /// @dev An approved operator batching over the owner's position gains nothing from the batch: the
-    ///      grow op's output is forced to the OWNER (recipient resolution), and the operator's own op in the
-    ///      same batch is funded solely from the operator's wallet. The operator's balances can only go down.
+    /// @dev An operator gains nothing from batching over the owner's position: grow output resolves
+    ///      to the owner, and the operator's own op is funded from the operator's wallet.
     function test_multicall_operatorBatch_cannotRedirectOwnerValue() public {
         uint256 ownerPos = _mintToSigner(key, 1e21);
-        // accrue owner fees — the value an operator might try to redirect
+        // accrue owner fees
         swap(key, true, -int256(1e20), "");
         swap(key, false, -int256(1e20), "");
 
@@ -589,7 +568,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         vm.prank(signer);
         IERC721(address(lpm)).setApprovalForAll(operator, true);
 
-        // the operator asks for itself as recipient everywhere it can
+        // the operator asks for itself as recipient
         ISwapAndAdd.CompoundParams memory comp = _compParams(ownerPos);
         comp.recipient = operator; // ignored: resolved to the owner for an operator caller
         ISwapAndAdd.AddParams memory ownAdd = _addParams(key, 1e18, 1e18);
@@ -613,8 +592,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "token1 at rest");
     }
 
-    /// @dev An operator batching ERC-20 operations for multiple owners produces the exact same outcomes
-    ///      as executing them sequentially. (Native ETH batches can only fund one operation).
+    /// @dev An operator batch of ERC-20 ops for two owners matches sequential execution exactly.
     function test_multicall_operatorBatch_twoOwners_attributionMatchesSequential() public {
         address alice = makeAddr("alice");
         address bob = makeAddr("bob");
@@ -622,7 +600,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         mint(PositionConfig({poolKey: key, tickLower: -600, tickUpper: 600}), 1e21, alice, "");
         uint256 posB = lpm.nextTokenId();
         mint(PositionConfig({poolKey: key, tickLower: -600, tickUpper: 600}), 1e21, bob, "");
-        // accrue fees to both positions so the compound has substance
+        // accrue fees to both positions
         swap(key, true, -int256(1e20), "");
         swap(key, false, -int256(1e20), "");
 
@@ -659,7 +637,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         }
     }
 
-    /// @dev Owner-attribution snapshot: both owners' token balances and position liquidities.
+    /// @dev Snapshot of the token balances and position liquidities of both owners.
     function _ownerState(address alice, address bob, uint256 posA, uint256 posB)
         internal
         view
@@ -691,7 +669,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         vm.stopPrank();
     }
 
-    /// @dev Nested multicall composes with the same semantics — no context is gained or lost one level down.
+    /// @dev Nested multicall composes with the same semantics.
     function test_multicall_nestedBatch_behavesLikeFlat() public {
         ISwapAndAdd.AddParams memory p = _addParams(key, 1e18, 2e18);
         bytes[] memory inner = _permitThen(_bothTokens(), abi.encodeCall(ISwapAndAdd.add, (p)));
@@ -704,8 +682,7 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         assertEq(IERC721(address(lpm)).ownerOf(expectedId), signer, "nested batch minted to the signer");
     }
 
-    /// @dev compound is non-payable: it cannot ride in a value-bearing batch at all (delegatecall preserves
-    ///      msg.value, the non-payable dispatch guard sees it and reverts).
+    /// @dev compound is non-payable, so it cannot run in a value-bearing batch.
     function test_multicall_compoundInValueBatch_reverts() public {
         uint256 tokenId = _mintToSigner(key, 1e21);
         bytes[] memory calls = new bytes[](1);
@@ -716,9 +693,8 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         zap.multicall{value: 1}(calls);
     }
 
-    /// @dev Value attached to a batch no op consumes strands as an unsolicited donation (documented in the
-    ///      MULTICALL/ETH NOTES) and becomes part of the next native operation's sweep — never a third party's
-    ///      claim through allowances.
+    /// @dev Batch value that no op consumes strands in the contract as a donation. The sweep of the
+    ///      next native op hands it to the recipient of that op.
     function test_multicall_permitsOnlyValueBatch_strandsAsDonation() public {
         IAllowanceTransfer.PermitBatch memory b = _batch(_oneToken(currency1));
         bytes[] memory calls = new bytes[](1);
@@ -729,7 +705,6 @@ contract SwapAndAddMulticallTest is PosmTestSetup {
         zap.multicall{value: donation}(calls);
         assertEq(address(zap).balance, donation, "unconsumed batch value rests in the contract");
 
-        // the next native op's sweep hands it to that op's recipient (donation doctrine)
         uint256 balBefore = signer.balance;
         ISwapAndAdd.AddParams memory p = _addParams(nativeKey, 1e17, 1e17);
         vm.prank(signer);

--- a/test/SwapAndAddRouteFunding.t.sol
+++ b/test/SwapAndAddRouteFunding.t.sol
@@ -15,10 +15,8 @@ import {MockSwapRoute} from "./mocks/MockSwapRoute.sol";
 import {ISwapAndAdd} from "../src/interfaces/ISwapAndAdd.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 
-/// @notice `routeFunding` — zap-in from arbitrary (non-pool) tokens. The entries are pulled up front, exist
-///         solely as route input, and whatever the route leaves unconsumed is swept to the RESOLVED recipient
-///         (operator leftovers forced to the owner). The core (sizing, reconcile, trim) never sees the funding
-///         token: only the post-route pool-token balances.
+/// @notice `routeFunding`: zap-in from arbitrary non-pool tokens. Entries feed the route, unconsumed
+///         amounts sweep to the resolved recipient, and the core only sees pool-token balances.
 contract SwapAndAddRouteFundingTest is PosmTestSetup {
     using CurrencyLibrary for Currency;
 
@@ -27,7 +25,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
     MockERC20 tokenX;
     address recipient;
 
-    /// @dev abi.encode(bytes commands, bytes[] inputs) — a non-empty route payload the mock ignores.
+    /// @dev abi.encode(bytes commands, bytes[] inputs), a non-empty route payload the mock ignores.
     bytes ROUTE_PAYLOAD = abi.encode(bytes(""), new bytes[](0));
 
     function setUp() public {
@@ -47,17 +45,17 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         permit2.approve(Currency.unwrap(currency0), address(zap), type(uint160).max, type(uint48).max);
         permit2.approve(Currency.unwrap(currency1), address(zap), type(uint160).max, type(uint48).max);
 
-        // the arbitrary input token: not a currency of any pool involved
+        // arbitrary input token, not a pool currency
         tokenX = new MockERC20("Arbitrary", "X", 18);
         tokenX.mint(address(this), 1e30);
         tokenX.approve(address(permit2), type(uint256).max);
         permit2.approve(address(tokenX), address(zap), type(uint160).max, type(uint48).max);
 
-        // route inventory: the mock pays out pool tokens for whatever input it consumes
+        // route inventory: the mock pays out pool tokens for consumed input
         MockERC20(Currency.unwrap(currency0)).mint(address(route), 1e24);
         MockERC20(Currency.unwrap(currency1)).mint(address(route), 1e24);
 
-        // deep reserve pool so the flash-take never hits the (unrelated) PoolManager-drained revert
+        // deep reserve pool backs the flash-take
         (PoolKey memory rk,) = initPool(currency0, currency1, IHooks(address(0)), 10000, int24(200), SQRT_PRICE_1_1);
         modifyLiquidityRouter.modifyLiquidity(
             rk,
@@ -68,7 +66,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         recipient = makeAddr("recipient");
     }
 
-    // ── helpers ─────────────────────────────────────────────────────────────────────────────────────────
+    // helpers
 
     function _funding(address token, uint256 amount) internal pure returns (ISwapAndAdd.TokenAmount[] memory f) {
         f = new ISwapAndAdd.TokenAmount[](1);
@@ -100,7 +98,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         route.config(address(tokenX), Currency.unwrap(currency1), 1 << 96, 10000, inputAmount, true);
     }
 
-    // ── add: the zap-in-from-X happy paths ──────────────────────────────────────────────────────────────
+    // add: the zap-in-from-X happy paths
 
     function test_add_funding_xOnly_mintsPosition() public {
         _configXRoute(5e18);
@@ -137,7 +135,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         assertEq(tokenX.balanceOf(address(zap)), 0, "no X at rest");
     }
 
-    /// @dev a zero-amount entry pulls nothing but wires + sweeps the token: the donation-claim path.
+    /// @dev a zero-amount entry pulls nothing but wires and sweeps the token (donation claim)
     function test_add_funding_zeroAmountEntry_claimsDonation() public {
         tokenX.transfer(address(zap), 5e18); // donation / stuck tokens
         _configXRoute(2e18); // the route consumes part of the donated balance
@@ -147,7 +145,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         assertEq(tokenX.balanceOf(address(zap)), 0, "no X at rest");
     }
 
-    // ── add: native funding on a non-native pool ────────────────────────────────────────────────────────
+    // add: native funding on a non-native pool
 
     function test_add_funding_native() public {
         // route: consume 0.6 ETH of the pushed value, pay out currency1 1:1
@@ -168,7 +166,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         zap.add{value: 0.5 ether}(p);
     }
 
-    // ── guards ──────────────────────────────────────────────────────────────────────────────────────────
+    // guards
 
     function test_add_funding_revertsWithoutRoute() public {
         ISwapAndAdd.AddParams memory p = _addP(0, 1e18, "", _funding(address(tokenX), 1e18));
@@ -186,8 +184,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         zap.add(p);
     }
 
-    /// @dev on a native pool address(0) IS currency0 -> rejected as a pool currency, so msg.value can never
-    ///      mean two things at once.
+    /// @dev on a native pool address(0) is currency0 and is rejected as a pool currency
     function test_add_funding_rejectsNativeEntryOnNativePool() public {
         ISwapAndAdd.AddParams memory p = _addP(0, 1e18, ROUTE_PAYLOAD, _funding(address(0), 1 ether));
         p.poolKey = PoolKey({
@@ -201,7 +198,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         zap.add{value: 1 ether}(p);
     }
 
-    // ── increase: funding must satisfy the nothing-to-deploy gate via the route ─────────────────────────
+    // increase: funding must satisfy the nothing-to-deploy gate via the route
 
     function _mintViaZap() internal returns (uint256 tokenId) {
         _configXRoute(0); // no-op
@@ -231,8 +228,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         assertEq(tokenX.balanceOf(address(zap)), 0, "no X at rest");
     }
 
-    /// @dev an operator's unconsumed funding is forced to the OWNER — a route can also produce a funding
-    ///      token from position value, so funding leftovers are output like any other.
+    /// @dev an operator's unconsumed funding is forced to the owner, like any other output
     function test_increase_funding_operatorLeftoverForcedToOwner() public {
         uint256 tokenId = _mintViaZap();
         address operator = makeAddr("operator");
@@ -265,7 +261,7 @@ contract SwapAndAddRouteFundingTest is PosmTestSetup {
         assertEq(tokenX.balanceOf(address(zap)), 0, "no X at rest");
     }
 
-    // ── rebalance with funding ──────────────────────────────────────────────────────────────────────────
+    // rebalance with funding
 
     function test_rebalance_funding_topsUpViaRoute() public {
         uint256 tokenId = _mintViaZap();

--- a/test/SwapAndAddSamePoolRoute.t.sol
+++ b/test/SwapAndAddSamePoolRoute.t.sol
@@ -23,9 +23,7 @@ interface IERC20Min {
     function transfer(address to, uint256 amt) external returns (bool);
 }
 
-/// @notice A route that swaps in the TARGET pool (exactly what a real Universal Router v4 leg does when the
-///         off-chain router picks the same pool). Pulls its declared input from the caller via Permit2, swaps,
-///         settles its own input debt and takes its own output straight to the caller.
+/// @notice A route that swaps in the target pool, like a Universal Router v4 leg through the same pool.
 contract MockSamePoolRoute {
     using CurrencyLibrary for Currency;
 
@@ -71,19 +69,9 @@ contract MockSamePoolRoute {
     }
 }
 
-/// @notice Regression: `increase`/`compound` with a route leg through the SAME pool accrues LP fees to the
-///         position between the callback's collect prologue and `_deployLiquidity`'s liquidity action. POSM applies
-///         `liquidityDelta + feesAccrued` to its own delta, so a fee credit exceeding that side's principal
-///         makes the delta POSITIVE — the previous `SETTLE_PAIR` asserted a debt and reverted
-///         `DeltaNotNegative`, bricking a route shape the contract advertises as supported. `_deployLiquidity` now
-///         closes each currency with `CLOSE_CURRENCY`, which settles a debt or takes a credit.
-///
-///         Where the credited fees END UP: taken into this contract's balance AFTER sizing, so they cannot
-///         grow the position beyond the already-fixed optimistic size. The reconcile spends them on the flash
-///         debt first (avoiding a trim), and the remainder is swept to the resolved recipient. So fees accrued
-///         DURING an operation are refunded, not compounded — measured below. Fees accrued BEFORE the
-///         operation are unaffected: the prologue collect puts them in the budget ahead of sizing, so they
-///         are still fully reinvested, which is what `compound` promises.
+/// @notice A route leg through the target pool accrues LP fees to the position mid-operation, which can
+///         turn a POSM delta positive. `_deployLiquidity` closes each currency with `CLOSE_CURRENCY`, so
+///         the credit is taken and refunded after sizing. Fees accrued before the operation still compound.
 contract SwapAndAddSamePoolRouteTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -107,12 +95,12 @@ contract SwapAndAddSamePoolRouteTest is PosmTestSetup {
         MockERC20(Currency.unwrap(currency0)).approve(address(permit2), type(uint256).max);
         MockERC20(Currency.unwrap(currency1)).approve(address(permit2), type(uint256).max);
 
-        // target pool: 10% LP fee, spot ABOVE the position's range (tick 1200 > TU), no other liquidity
+        // target pool: 10% LP fee, spot above the position's range (tick 1200 > TU), no other liquidity
         (targetKey,) = initPool(
             currency0, currency1, IHooks(address(0)), 100_000, int24(60), TickMath.getSqrtPriceAtTick(int24(1200))
         );
 
-        // deep reserve pool in an UNRELATED pool so the flash-take always finds PoolManager-wide reserves
+        // deep reserves in an unrelated pool so the flash-take always finds PoolManager-wide liquidity
         (PoolKey memory rk,) = initPool(currency0, currency1, IHooks(address(0)), 500, int24(10), SQRT_PRICE_1_1);
         modifyLiquidityRouter.modifyLiquidity(
             rk,
@@ -135,26 +123,22 @@ contract SwapAndAddSamePoolRouteTest is PosmTestSetup {
         return abi.encode(bytes(hex"00"), inputs);
     }
 
-    /// @dev A route leg that trades the target pool and drives spot into the position's own range accrues LP
-    ///      fees far exceeding the increase's principal on the deficit side (here 13x). Before the fix this
-    ///      reverted DeltaNotNegative(currency0). Now the deploy takes the credit, the reconcile spends what
-    ///      it needs on the flash debt, and the rest is refunded to the recipient.
+    /// @dev A same-pool route leg drives spot into the range of the position and accrues fees ~13x the
+    ///      deficit-side principal. The deploy takes the credit and the surplus is refunded.
     function test_increase_samePoolRouteLeg_completesAndRefundsFeeCredit() public {
-        // 1. the position, minted straight through POSM (spot is above TU: pure token1)
+        // the position, minted straight through POSM (spot above TU: pure token1)
         PositionConfig memory cfg = PositionConfig({poolKey: targetKey, tickLower: TL, tickUpper: TU});
         uint256 tokenId = lpm.nextTokenId();
         mint(cfg, L_POS, address(this), "");
 
-        // 2. the caller's route: sell token0 into the same pool. Spot free-falls from tick 1200 to TU=600
-        //    (no liquidity in between), then eats ~10 ticks into the position's own range: every wei of LP fee
-        //    on that leg accrues to THIS position — ~13x the increase's token0 principal pull.
+        // the route sells token0 into the same pool. Spot falls from tick 1200 into the range of the
+        // position, so every LP fee on the leg accrues to this position.
         uint256 routeIn = 5.4e20;
         route.config(targetKey, true, routeIn);
 
         uint256 c0Before = currency0.balanceOf(address(this));
         uint256 c1Before = currency1.balanceOf(address(this));
 
-        // same budget, same pool, swap leg runs through the target pool: the pre-fix DeltaNotNegative case.
         (uint128 added,,) = zap.increase(
             ISwapAndAdd.IncreaseParams({
                 tokenId: tokenId,
@@ -174,9 +158,7 @@ contract SwapAndAddSamePoolRouteTest is PosmTestSetup {
         uint256 refunded = routeIn - (c0Before - currency0.balanceOf(address(this)));
 
         assertGt(added, 0, "increase must complete with a same-pool route leg");
-        // the fee credit is refunded to the recipient — not stranded, not burned. It arrives AFTER sizing;
-        // step 1 spends what the flash debt needs (~1/13 here) and the remainder comes straight back — the
-        // reconcile swap is SKIPPED (credit retired the debt), so no swap output pads the refund any more.
+        // the fee credit funds the flash debt first (~1/13 here) and the remainder is refunded, not compounded
         assertLt(refunded, accruedFee, "part of the credit funded the flash debt");
         assertGt(refunded, (accruedFee * 85) / 100, "the bulk of the credit is refunded");
         // no funds at rest, and the position NFT never moved
@@ -186,10 +168,8 @@ contract SwapAndAddSamePoolRouteTest is PosmTestSetup {
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "owner keeps the NFT");
     }
 
-    /// @dev When the route-accrued fee credit alone retires the flash debt in reconcile step 1, step 2's
-    ///      sell-all buys nothing the operation needs: it pays the pool fee converting the token1 surplus into
-    ///      token0 that is immediately refunded, and re-denominates the refund (contradicting the sweep
-    ///      doctrine). With the guard, the swap is skipped and the surplus comes back in its OWN token.
+    /// @dev When the fee credit alone retires the flash debt, the reconcile swap is skipped and the
+    ///      token1 surplus comes back in its own denomination.
     function test_increase_creditRetiresDebt_skipsGratuitousSwap() public {
         PositionConfig memory cfg = PositionConfig({poolKey: targetKey, tickLower: TL, tickUpper: TU});
         uint256 tokenId = lpm.nextTokenId();
@@ -214,8 +194,7 @@ contract SwapAndAddSamePoolRouteTest is PosmTestSetup {
         );
         assertGt(added, 0, "increase completes");
 
-        // the credit (13x the deficit) fully retires the flash debt in step 1, so no reconcile swap may run:
-        // the token1 surplus must be refunded AS token1, not converted through the pool at a 10% fee
+        // the credit retires the flash debt, so no reconcile swap runs and the surplus comes back as token1
         assertGt(currency1.balanceOf(address(this)), c1Before, "surplus refunded in its own denomination");
         assertEq(currency0.balanceOf(address(zap)), 0, "zap token0 == 0");
         assertEq(currency1.balanceOf(address(zap)), 0, "zap token1 == 0");

--- a/test/SwapAndAddSubscriber.t.sol
+++ b/test/SwapAndAddSubscriber.t.sol
@@ -28,9 +28,8 @@ interface IERC20Min {
     function transfer(address to, uint256 amt) external returns (bool);
 }
 
-/// @notice A subscriber that trades the position's own pool from inside a notification — the strongest thing
-///         subscriber code can do to a SwapAndAdd operation. It fires on the FIRST notifyModifyLiquidity (the
-///         grow ops' fee collect), i.e. between the collect and the sizing read, and settles its own deltas.
+/// @notice A subscriber that trades the pool of the position from inside the first
+///         notifyModifyLiquidity, between the fee collect and the sizing read.
 contract MockSwappingSubscriber is ISubscriber {
     using CurrencyLibrary for Currency;
 
@@ -73,12 +72,9 @@ contract MockSwappingSubscriber is ISubscriber {
     }
 }
 
-/// @notice POSM SUBSCRIBERS are the one owner-chosen external-call surface inside SwapAndAdd's unlock that is
-///         not a hook: `notifyModifyLiquidity` fires (full gas, revert bubbling) on the grow ops' fee collect,
-///         the INCREASE, and any trim; `notifyBurn` fires on the rebalance burn. This suite pins the doctrine:
-///         a well-behaved subscriber is transparent; a reverting subscriber can only DoS its OWN position's
-///         operations (atomic revert, funds safe); a subscriber that trades the pool mid-operation is gated by
-///         the `minLiquidity` floor exactly like a hook or the caller's own route.
+/// @notice Subscriber notifications fire inside the unlock of SwapAndAdd. A well-behaved subscriber is
+///         transparent, a reverting one only blocks its own position, and a pool-trading one is gated
+///         by the `minLiquidity` floor.
 contract SwapAndAddSubscriberTest is PosmTestSetup {
     using StateLibrary for IPoolManager;
     using CurrencyLibrary for Currency;
@@ -108,13 +104,13 @@ contract SwapAndAddSubscriberTest is PosmTestSetup {
         sub = new MockSubscriber(lpm);
     }
 
-    // ─────────────────────────────── helpers ───────────────────────────────
+    // helpers
 
     /// @dev Position owned by this contract with accrued fees, subscribed to `subscriber`.
     function _subscribedPosition(address subscriber) internal returns (uint256 tokenId) {
         tokenId = lpm.nextTokenId();
         mint(PositionConfig({poolKey: key, tickLower: -600, tickUpper: 600}), 1e21, address(this), "");
-        // accrue fees so the grow ops have position value to work with
+        // accrue fees for the grow ops
         swap(key, true, -int256(1e20), "");
         swap(key, false, -int256(1e20), "");
         lpm.subscribe(tokenId, subscriber, "");
@@ -138,7 +134,7 @@ contract SwapAndAddSubscriberTest is PosmTestSetup {
         });
     }
 
-    // ─────────────────────────────── well-behaved subscriber: transparent ───────────────────────────────
+    // well-behaved subscriber: transparent
 
     function test_increase_subscribedPosition_notifiesAndSucceeds() public {
         uint256 tokenId = _subscribedPosition(address(sub));
@@ -148,7 +144,7 @@ contract SwapAndAddSubscriberTest is PosmTestSetup {
 
         assertGt(added, 0, "increase completed on a subscribed position");
         assertEq(lpm.getPositionLiquidity(tokenId), before + added, "position grew");
-        // fee collect + INCREASE both notified (a trim, if any, adds a third)
+        // the fee collect and the increase both notify (a trim, if any, adds a third)
         assertGe(sub.notifyModifyLiquidityCount(), 2, "collect and increase must both notify");
         assertEq(currency0.balanceOf(address(zap)), 0, "no token0 at rest");
         assertEq(currency1.balanceOf(address(zap)), 0, "no token1 at rest");
@@ -199,17 +195,17 @@ contract SwapAndAddSubscriberTest is PosmTestSetup {
         assertEq(IERC721(address(lpm)).ownerOf(newTokenId), address(this), "owner receives the new NFT");
     }
 
-    // ─────────────────────────────── reverting subscriber: self-DoS only, atomic ───────────────────────────────
+    // reverting subscriber: self-DoS only, atomic
 
     function test_increase_revertingSubscriber_revertsAtomically() public {
         MockRevertSubscriber rev = new MockRevertSubscriber(lpm);
-        rev.setRevert(false); // let notifySubscribe pass; notifyModifyLiquidity always reverts
+        rev.setRevert(false); // let notifySubscribe pass, notifyModifyLiquidity always reverts
         uint256 tokenId = _subscribedPosition(address(rev));
 
         uint128 liqBefore = lpm.getPositionLiquidity(tokenId);
         uint256 c0Before = currency0.balanceOf(address(this));
 
-        // the revert is bubbled (wrapped) by the Notifier at the very first notification — the fee collect
+        // the Notifier bubbles the revert at the first notification, the fee collect
         vm.expectRevert();
         zap.increase(_incParams(tokenId, 1e18, 1e18, 1));
 
@@ -244,11 +240,11 @@ contract SwapAndAddSubscriberTest is PosmTestSetup {
         assertEq(IERC721(address(lpm)).ownerOf(tokenId), address(this), "NFT untouched");
     }
 
-    // ─────────────────────────── price-manipulating subscriber: gated by the floor ───────────────────────────
+    // price-manipulating subscriber: gated by the floor
 
     function _swappingSetup() internal returns (uint256 tokenId, MockSwappingSubscriber swapper) {
         swapper = new MockSwappingSubscriber(lpm, manager);
-        // fund the swapper so it can settle its own mid-operation trade
+        // fund the swapper so it can settle its own trade
         MockERC20(Currency.unwrap(currency0)).mint(address(swapper), 1e22);
         tokenId = _subscribedPosition(address(swapper));
         swapper.config(key, 1e21); // fires on the fee collect, before the zap sizes from the live price
@@ -257,8 +253,7 @@ contract SwapAndAddSubscriberTest is PosmTestSetup {
     function test_increase_swappingSubscriber_floorReverts() public {
         (uint256 tokenId,) = _swappingSetup();
 
-        // an honest floor quoted against the pre-manipulation price: the subscriber's swap makes the
-        // operation miss it, and the whole thing reverts atomically — exactly the hook/route doctrine
+        // the swap of the subscriber makes the operation miss a floor quoted at the pre-manipulation price
         vm.expectPartialRevert(ISwapAndAdd.InsufficientLiquidity.selector);
         zap.increase(_incParams(tokenId, 1e18, 1e18, type(uint128).max));
     }

--- a/test/SwapAndAddTrim.t.sol
+++ b/test/SwapAndAddTrim.t.sol
@@ -15,21 +15,9 @@ import {MockSwapRoute} from "./mocks/MockSwapRoute.sol";
 import {ISwapAndAdd} from "../src/interfaces/ISwapAndAdd.sol";
 import {IUniversalRouter} from "../src/interfaces/external/IUniversalRouter.sol";
 
-/// @notice Regression suite for `_trim`'s token->liquidity inverse. The pre-fix code computed the trim with
-///         floor-rounding library math plus "+1 liquidity unit": the token0 inverse floors an intermediate
-///         value whose truncation is scaled by the amount, so the under-trim error is unbounded in the amount
-///         and single-sided token1 budgets reverted CurrencyNotSettled at real sizes (from ~6.4 tokens on a
-///         price-1e-9 pool; pinned here at 4.4e30 on a price-1 pool). The fixed inverse rounds UP on every
-///         division over `amountOut + 1`, so an uncapped trim always frees the debt.
-///
-///         The only remaining failure is the pool's own mint/burn rounding toll (~1 wei/side kept on any
-///         mint->decrease round trip): budgets within a few wei of that toll cannot settle no matter how much
-///         is trimmed. There the trim caps at the full just-added liquidity, the added liquidity is 0, and any
-///         non-zero `minLiquidity` floor surfaces it as InsufficientLiquidity; only a zero floor (the explicit
-///         opt-out) still sees v4's CurrencyNotSettled. Both pinned below.
-///
-///         NOTE the mechanism-hiding price: at price exactly 1 the floored intermediate has zero truncation,
-///         so price-1 tests alone can never catch a trim under-estimate — hence the low-price pins.
+/// @notice Regression suite for the token->liquidity inverse of `_trim`. The inverse must round up so
+///         an uncapped trim always frees the flash debt. At price 1 the floored intermediate has zero
+///         truncation, so the low-price pins are the load-bearing cases.
 contract SwapAndAddTrimTest is PosmTestSetup {
     using CurrencyLibrary for Currency;
 
@@ -111,7 +99,7 @@ contract SwapAndAddTrimTest is PosmTestSetup {
         }
     }
 
-    // ── the SCALE regime: single-sided token1 at real size — the pre-fix High ───────────────────────────
+    // scale regime: single-sided token1 at real size
 
     function test_trim_largeSingleSidedToken1_succeeds() public {
         PoolKey memory k = _pool(100, 60, SQRT_PRICE_1_1, 1e34);
@@ -122,15 +110,13 @@ contract SwapAndAddTrimTest is PosmTestSetup {
         assertEq(currency1.balanceOf(address(zap)), 0, "no funds at rest (1)");
     }
 
-    /// @dev the operational case from the finding: a price-1e-9 pool (high-supply token vs WETH shape) broke
-    ///      single-sided token1 adds from ~6.4 tokens. Price 1 hides the bug (zero intermediate truncation),
-    ///      so this low-price sweep is the load-bearing regression.
+    /// @dev single-sided token1 adds on a price ~1e-9 pool, where intermediate truncation is largest
     function test_trim_lowPricePool_singleSidedSweep() public {
         int24 centre = -207_240; // price ~1e-9, multiple of the spacing
         PoolKey memory k = _pool(3000, 30, TickMath.getSqrtPriceAtTick(centre), 1e27);
 
-        // top tier bounded by the PM's own reserves: at price 1e-9 the token0 flash-take is ~1e9x the token1
-        // budget, and taking more than the PM holds across all pools is the separate, documented PoolManager-drained limit.
+        // the top tier stays under the reserves of the PoolManager: at this price the token0
+        // flash-take is ~1e9x the token1 budget
         uint256[5] memory amounts = [uint256(1e18), 6.4e18, 20e18, 1_000e18, 5_000e18];
         for (uint256 i = 0; i < amounts.length; i++) {
             uint256 snap = vm.snapshotState();
@@ -143,10 +129,9 @@ contract SwapAndAddTrimTest is PosmTestSetup {
         }
     }
 
-    // ── the DUST regime: budgets within the pool's ~1-wei mint/burn rounding toll ───────────────────────
+    // dust regime: budgets within the pool's ~1-wei mint/burn rounding toll
 
-    /// @dev with any non-zero minLiquidity the capped trim (added liquidity fully removed) hits the floor and
-    ///      surfaces as the contract's own InsufficientLiquidity — never v4's CurrencyNotSettled.
+    /// @dev in the dust regime a non-zero floor surfaces the contract's own InsufficientLiquidity
     function test_trim_dustRegime_floorSurfacesInsufficientLiquidity() public {
         PoolKey memory k = _pool(500, 1, SQRT_PRICE_1_1, 1e24);
         (bool r, bytes4 sel,) = _try(k, -10, 6000, 259, 0, 1);
@@ -154,8 +139,7 @@ contract SwapAndAddTrimTest is PosmTestSetup {
         assertEq(sel, ISwapAndAdd.InsufficientLiquidity.selector, "non-zero floor must surface InsufficientLiquidity");
     }
 
-    /// @dev a zero floor is the documented opt-out: the unsettled rounding toll then surfaces as v4's
-    ///      CurrencyNotSettled at the end of the unlock. Pinned so a behavior change is noticed.
+    /// @dev a zero floor is the documented opt-out: the rounding toll surfaces as v4's CurrencyNotSettled
     function test_trim_dustRegime_zeroFloorSurfacesCurrencyNotSettled() public {
         PoolKey memory k = _pool(500, 1, SQRT_PRICE_1_1, 1e24);
         (bool r, bytes4 sel,) = _try(k, -10, 6000, 259, 0, 0);
@@ -163,7 +147,7 @@ contract SwapAndAddTrimTest is PosmTestSetup {
         assertEq(sel, CURRENCY_NOT_SETTLED, "zero floor lets CurrencyNotSettled surface");
     }
 
-    // ── happy-path sweep: the fix must not regress anything that already worked ─────────────────────────
+    // happy-path sweep across ranges and budgets
 
     function test_trim_happyPathSweep() public {
         PoolKey memory k = _pool(500, 10, SQRT_PRICE_1_1, 1e24);
@@ -191,7 +175,7 @@ contract SwapAndAddTrimTest is PosmTestSetup {
         }
     }
 
-    // ── fuzz: with a non-zero floor, CurrencyNotSettled is unreachable from the rounding domain ─────────────
+    // fuzz: with a non-zero floor, CurrencyNotSettled is unreachable from the rounding domain
 
     PoolKey fuzzKeyMid;
     PoolKey fuzzKeyLow;
@@ -213,8 +197,7 @@ contract SwapAndAddTrimTest is PosmTestSetup {
         uint256 x1 = uint256(b1);
         if (x0 == 0 && x1 == 0) return;
         (bool r,,) = _try(k, tl, tu, x0, x1, 1);
-        // the zap may legitimately revert for other reasons (dust floor, sizing overflow, ...) but with a
-        // non-zero floor never with CurrencyNotSettled.
+        // other reverts (dust floor, sizing overflow, and so on) are legitimate, CurrencyNotSettled is not
         if (r) {
             (, bytes4 sel,) = _try(k, tl, tu, x0, x1, 1);
             assertTrue(sel != CURRENCY_NOT_SETTLED, "left a currency unsettled despite floor");

--- a/test/mocks/MockERC20ApproveNoReturn.sol
+++ b/test/mocks/MockERC20ApproveNoReturn.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
 
-/// @notice ERC-20 whose approve returns NOTHING (USDT-style): decoding a declared bool return reverts, so
-///         integrations must use a return-tolerant approve. transfer/transferFrom stay standard so the test
-///         plumbing (liquidity routers, settle paths) is unaffected — SwapAndAdd only calls approve directly.
+/// @notice ERC-20 whose approve returns nothing, which simulates USDT.
 contract MockERC20ApproveNoReturn {
     string public constant name = "ApproveNoReturn";
     string public constant symbol = "ANR";

--- a/test/mocks/MockERC20ApproveRace.sol
+++ b/test/mocks/MockERC20ApproveRace.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
 
-/// @notice USDT-style approve-race ERC-20: a nonzero allowance cannot be changed to another nonzero value
-///         (it must be zeroed first). Includes a test hook to force an allowance value, simulating a token
-///         whose allowance degrades over time — a re-approve that isn't zero-first reverts here.
+/// @notice ERC-20 that requires a zero allowance before a nonzero approve, which simulates USDT.
 contract MockERC20ApproveRace {
     string public constant name = "ApproveRace";
     string public constant symbol = "RACE";
@@ -23,7 +21,7 @@ contract MockERC20ApproveRace {
         return true;
     }
 
-    /// @dev test hook: force-set an allowance to simulate degradation without moving 2^256 tokens.
+    /// @dev Test hook that force-sets an allowance.
     function setAllowance(address owner, address spender, uint256 amount) external {
         allowance[owner][spender] = amount;
     }

--- a/test/mocks/MockERC20Permit2Native.sol
+++ b/test/mocks/MockERC20Permit2Native.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
 
-/// @notice ERC-20 that hardcodes an infinite allowance for the canonical Permit2 ("Permit2-native" token
-///         pattern) and reverts approve() toward it — such approvals are pointless and strict implementations
-///         disallow them. Integrations must therefore neither trust the token's ERC20 allowance as proof of
-///         their own wiring (their Permit2-internal grants may not exist yet) nor issue the redundant approve.
+/// @notice ERC-20 that hardcodes an infinite Permit2 allowance and reverts approve toward Permit2,
+///         which simulates Permit2-native tokens.
 contract MockERC20Permit2Native {
     string public constant name = "Permit2Native";
     string public constant symbol = "P2N";

--- a/test/mocks/MockSwapRoute.sol
+++ b/test/mocks/MockSwapRoute.sol
@@ -10,11 +10,8 @@ interface IERC20Min {
     function balanceOf(address) external view returns (uint256);
 }
 
-/// @notice Test stand-in for an off-venue Universal Router route (ERC20 only). Implements the
-///         `IUniversalRouter.execute(bytes,bytes[])` shape SwapAndAdd calls. Consumes a FIXED `inputAmount`
-///         of the surplus token (pulled via Permit2, exactly as a real route does) and returns the deficit at
-///         an effective rate = mid * rateMultBps / 10000 (10000 = mid, <10000 worse, >10000 beats mid). It does
-///         NOT touch the target pool, mimicking off-venue execution. Pre-fund it with inventory of both tokens.
+/// @notice Test stand-in for a Universal Router route. Pulls a fixed `inputAmount` of the surplus token
+///         via Permit2 and returns the deficit token at mid * rateMultBps / 10000. Pre-fund it with both tokens.
 contract MockSwapRoute {
     IAllowanceTransfer public immutable permit2;
 
@@ -46,7 +43,7 @@ contract MockSwapRoute {
     }
 
     function execute(bytes calldata commands, bytes[] calldata inputs) external payable {
-        // Universal Router SWEEP (0x04) — SwapAndAdd reclaims native left in the router after a route.
+        // Universal Router SWEEP (0x04) returns leftover native to the caller.
         if (commands.length == 1 && uint8(commands[0]) == 0x04) {
             (address token,,) = abi.decode(inputs[0], (address, address, uint256));
             require(token == address(0), "mock: only native sweep");
@@ -54,8 +51,7 @@ contract MockSwapRoute {
             require(ok, "mock: sweep failed");
             return;
         }
-        // native surplus: consume from the forwarded msg.value (a real route spends the pushed value at its
-        // venue); the consumed part leaves to a sink, the remainder stays here for the caller's SWEEP reclaim.
+        // A native surplus consumes from msg.value. The rest stays here for the SWEEP reclaim.
         if (surplus == address(0)) {
             uint256 nativePull = inputAmount > msg.value ? msg.value : inputAmount;
             if (nativePull == 0) return;


### PR DESCRIPTION
## Summary

Documentation-only cleanup of everything the swap-and-add diff introduced. The NatSpec and inline comments read AI-generated (long doctrine paragraphs, historical bug narratives, em dashes, shouty emphasis). This PR rewrites them to carry the minimal developer/integrator-facing information:

- **src**: NatSpec states what each function does plus its limitations and integration surface, nothing else. The `ISwapAndAdd` header is condensed to a short flow description and a compact "integration surface" list. Internal `@dev` comments are down to one or two lines.
- **tests**: comments state what happens and the intended effect. Bug-history stories, premise essays, and restated mechanics are deleted. Irrecoverable provenance (fork blocks, TAPI route generation, deploy blocks) is kept as one-liners.
- **script / config**: same treatment for `DeploySwapAndAdd.s.sol`, `fetch-tapi-route.sh`, `foundry.toml`, and `.env.example` comments.

No code changes, with one reviewer-requested readability exception: `SwapAndAddMath.getLiquidityForAmountsWeighted` now computes `mulDiv(budgetValue, REFERENCE_LIQUIDITY, refValue)` instead of `mulDiv(REFERENCE_LIQUIDITY, budgetValue, refValue)` (mulDiv is commutative in its first two arguments, so behavior and gas are identical).

Addresses these review comments on #591:
- `SwapAndAddMath.sol:17` — REFERENCE_LIQUIDITY comment rewritten in plain terms
- `SwapAndAddMath.sol:84-85` — cheaper-token numeraire comment rewritten, "cheaper or equal" fixed
- `SwapAndAddMath.sol:99` — scaling reads as budget times reference over reference value
- `SwapAndAdd.sol:519` — `_swap` NatSpec states max slippage is safe because callers enforce `minLiquidity`, and that callers MUST check minimum amounts
- `SwapAndAddFuzz.t.sol` — the "trim bug" narrative and the opaque budget-cap comment are gone

## Verification

- `forge build --skip script`: compiles clean (plain `forge build` fails on the universal-router node_modules on the base branch too, unrelated)
- All 21 touched test files verified byte-identical to HEAD after stripping comments
- `forge test --match-path "test/SwapAndAdd*"`: passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
