### PR TITLE
docs: fix and clarify natspec inconsistencies

### DIFF
--- a/src/interfaces/INotifier.sol
+++ b/src/interfaces/INotifier.sol
@@ -37,7 +37,7 @@ interface INotifier {
     /// @param data caller-provided data that's forwarded to the subscriber contract
     /// @dev Calling subscribe when a position is already subscribed will revert
     /// @dev payable so it can be multicalled with NATIVE related actions
-    /// @dev will revert if pool manager is locked
+    /// @dev will revert if pool manager is unlocked
     function subscribe(uint256 tokenId, address newSubscriber, bytes calldata data) external payable;
 
     /// @notice Removes the subscriber from receiving notifications for a respective position
@@ -45,7 +45,7 @@ interface INotifier {
     /// @dev Callers must specify a high gas limit (remaining gas should be higher than unsubscriberGasLimit) such that the subscriber can be notified
     /// @dev payable so it can be multicalled with NATIVE related actions
     /// @dev Must always allow a user to unsubscribe. In the case of a malicious subscriber, a user can always unsubscribe safely, ensuring liquidity is always modifiable.
-    /// @dev will revert if pool manager is locked
+    /// @dev will revert if pool manager is unlocked
     function unsubscribe(uint256 tokenId) external payable;
 
     /// @notice Returns and determines the maximum allowable gas-used for notifying unsubscribe


### PR DESCRIPTION
## Related Issue
https://github.com/Uniswap/v4-periphery/issues/597

## Description of changes

| File / Location | Current NatSpec | Proposed NatSpec | Rationale |
| :--- | :--- | :--- | :--- |
| [src/interfaces/INotifier.sol#L40](https://github.com/Uniswap/v4-periphery/blob/main/src/interfaces/INotifier.sol#L40) | Will revert if pool manager is locked | Will revert if pool manager is unlocked | Function `subscribe()` has modifier onlyIfPoolManagerLocked. [Proof](https://github.com/Uniswap/v4-periphery/blob/main/src/base/Notifier.sol#L43) |
| [src/interfaces/INotifier.sol#L48](https://github.com/Uniswap/v4-periphery/blob/main/src/interfaces/INotifier.sol#L48) | Will revert if pool manager is locked | Will revert if pool manager is unlocked | Function `unsubscribe()` has modifier onlyIfPoolManagerLocked. [Proof](https://github.com/Uniswap/v4-periphery/blob/main/src/base/Notifier.sol#L63) |

