### PR TITLE
feat(router): add _mapSwapAmount hook for execution-time swap amounts

### DIFF
--- a/snapshots/PaymentsTests.json
+++ b/snapshots/PaymentsTests.json
@@ -1,6 +1,6 @@
 {
-  "Payments_swap_settleFromCaller_takeAllToMsgSender": "134021",
-  "Payments_swap_settleFromCaller_takeAllToSpecifiedAddress": "135490",
-  "Payments_swap_settleWithBalance_takeAllToMsgSender": "127972",
-  "Payments_swap_settleWithBalance_takeAllToSpecifiedAddress": "128110"
+  "Payments_swap_settleFromCaller_takeAllToMsgSender": "134043",
+  "Payments_swap_settleFromCaller_takeAllToSpecifiedAddress": "135512",
+  "Payments_swap_settleWithBalance_takeAllToMsgSender": "127994",
+  "Payments_swap_settleWithBalance_takeAllToSpecifiedAddress": "128132"
 }

--- a/snapshots/PermissionedV4RouterTest.json
+++ b/snapshots/PermissionedV4RouterTest.json
@@ -1,5 +1,5 @@
 {
   "PermissionedV4Router_ExactIn3Hops_OrdinaryTokens_DistinctAssets": "262218",
-  "PermissionedV4Router_ExactInputSingle_OrdinaryTokens": "152661",
-  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "257012"
+  "PermissionedV4Router_ExactInputSingle_OrdinaryTokens": "152683",
+  "PermissionedV4Router_ExactInputSingle_PermissionedTokens": "257034"
 }

--- a/snapshots/V4RouterTest.json
+++ b/snapshots/V4RouterTest.json
@@ -1,5 +1,5 @@
 {
-  "V4Router_Bytecode": "10785",
+  "V4Router_Bytecode": "10803",
   "V4Router_ExactIn1Hop_nativeIn": "123054",
   "V4Router_ExactIn1Hop_nativeOut": "121521",
   "V4Router_ExactIn1Hop_oneForZero": "130393",
@@ -8,9 +8,9 @@
   "V4Router_ExactIn2Hops_nativeIn": "180356",
   "V4Router_ExactIn3Hops": "251550",
   "V4Router_ExactIn3Hops_nativeIn": "237686",
-  "V4Router_ExactInputSingle": "135016",
-  "V4Router_ExactInputSingle_nativeIn": "121152",
-  "V4Router_ExactInputSingle_nativeOut": "119597",
+  "V4Router_ExactInputSingle": "135038",
+  "V4Router_ExactInputSingle_nativeIn": "121174",
+  "V4Router_ExactInputSingle_nativeOut": "119619",
   "V4Router_ExactOut1Hop_nativeIn_sweepETH": "129686",
   "V4Router_ExactOut1Hop_nativeOut": "123107",
   "V4Router_ExactOut1Hop_oneForZero": "131979",
@@ -20,8 +20,8 @@
   "V4Router_ExactOut3Hops": "250123",
   "V4Router_ExactOut3Hops_nativeIn": "243205",
   "V4Router_ExactOut3Hops_nativeOut": "227374",
-  "V4Router_ExactOutputSingle": "134596",
-  "V4Router_ExactOutputSingle_nativeIn_sweepETH": "127678",
-  "V4Router_ExactOutputSingle_nativeOut": "121112",
-  "router initcode hash (without constructor params, as uint256)": "60032899704926694655377093452966764123381444165360344337635783134256943633048"
+  "V4Router_ExactOutputSingle": "134618",
+  "V4Router_ExactOutputSingle_nativeIn_sweepETH": "127700",
+  "V4Router_ExactOutputSingle_nativeOut": "121134",
+  "router initcode hash (without constructor params, as uint256)": "114729708465987648700921406537732645444618493910742794723401238925364218137616"
 }

--- a/src/V4Router.sol
+++ b/src/V4Router.sol
@@ -81,8 +81,21 @@ abstract contract V4Router is IV4Router, BaseActionsRouter, DeltaResolver {
         revert UnsupportedAction(action);
     }
 
+    /// @notice Maps a swap action's amount before it is used, so an inheriting router can resolve a
+    ///         route-level sentinel (e.g. a callback register populated by a prior command) into a
+    ///         concrete amount at execution time.
+    /// @dev Applied to the amount read from the swap params (`amountIn` for exact-input,
+    ///      `amountOut` for exact-output) before the `OPEN_DELTA` sentinel is interpreted, so the
+    ///      default identity mapping preserves existing behavior exactly. A value that maps to
+    ///      `OPEN_DELTA` (0) is still treated as the open-delta sentinel by the swap helpers.
+    /// @param amount The raw amount taken from the swap params
+    /// @return The amount to use for the swap
+    function _mapSwapAmount(uint128 amount) internal view virtual returns (uint128) {
+        return amount;
+    }
+
     function _swapExactInputSingle(IV4Router.ExactInputSingleParams memory params) private {
-        uint128 amountIn = params.amountIn;
+        uint128 amountIn = _mapSwapAmount(params.amountIn);
         if (amountIn == ActionConstants.OPEN_DELTA) {
             amountIn =
                 _getFullCredit(params.zeroForOne ? params.poolKey.currency0 : params.poolKey.currency1).toUint128();
@@ -105,7 +118,7 @@ abstract contract V4Router is IV4Router, BaseActionsRouter, DeltaResolver {
             uint256 pathLength = params.path.length;
             uint128 amountOut;
             Currency currencyIn = params.currencyIn;
-            uint128 amountIn = params.amountIn;
+            uint128 amountIn = _mapSwapAmount(params.amountIn);
             if (amountIn == ActionConstants.OPEN_DELTA) amountIn = _getFullCredit(currencyIn).toUint128();
             PathKey memory pathKey;
 
@@ -135,7 +148,7 @@ abstract contract V4Router is IV4Router, BaseActionsRouter, DeltaResolver {
     }
 
     function _swapExactOutputSingle(IV4Router.ExactOutputSingleParams memory params) private {
-        uint128 amountOut = params.amountOut;
+        uint128 amountOut = _mapSwapAmount(params.amountOut);
         if (amountOut == ActionConstants.OPEN_DELTA) {
             amountOut =
                 _getFullDebt(params.zeroForOne ? params.poolKey.currency1 : params.poolKey.currency0).toUint128();
@@ -163,7 +176,7 @@ abstract contract V4Router is IV4Router, BaseActionsRouter, DeltaResolver {
             // Caching for gas savings
             uint256 pathLength = params.path.length;
             uint128 amountIn;
-            uint128 amountOut = params.amountOut;
+            uint128 amountOut = _mapSwapAmount(params.amountOut);
             Currency currencyOut = params.currencyOut;
             PathKey memory pathKey;
 


### PR DESCRIPTION
## What

Adds `_mapSwapAmount(uint128) internal view virtual` to `V4Router`, applied to the amount read from each swap action's params (`amountIn` for exact-input, `amountOut` for exact-output) before the `OPEN_DELTA` sentinel is interpreted. The default is the identity mapping, so behavior is unchanged for every existing router.

## Why

The Universal Router's `RESOLVE` command (UR v2.3.0) lets a route obtain an amount from an onchain staticcall mid-plan and reference it from a later command's amount field via a sentinel. The v2 and v3 swap commands resolve that sentinel in the UR dispatcher, but v4 swap amounts are read inside `V4Router`'s private swap helpers, so the router needs one overridable seam. This is the smallest such seam: four call sites, one virtual function, no change to the public interface. The UR overrides it to swap the sentinel for the resolved amount.

Stacked on #593 so it can be bumped into the UR alongside the `abi.decode` decoder change.

## Cost

| | Before | After |
|---|---|---|
| `V4Router` bytecode | 10,785 | 10,803 (+18) |
| Gas per swap action | | +22 |

Snapshots regenerated with `FORGE_SNAPSHOT_CHECK=false forge test --isolate`; every delta is the +22 gas from the extra internal jump, plus the bytecode size and initcode hash.

## Testing

`forge test --isolate`: 787 passed. The single failure is `test_robinhoodChain_realPoolsMatchStateViewReference`, which needs a Robinhood chain RPC and is unrelated.
